### PR TITLE
feat: refresh ultralytics_yolo evaluator docs and scripts for rdk_s

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ The `run.sh` script automatically downloads the model, installs dependencies, an
 
 | Category | Model Name | Model Path | Supported Platforms | Details |
 | :--- | :--- | :--- | :--- | :---: |
-| Vision Multi-task | Ultralytics YOLO (YOLOv5u / YOLOv8 / YOLOv10 / YOLO11 / YOLO12) | `samples/vision/ultralytics_yolo` | S100 / S100P | [Details](./samples/vision/ultralytics_yolo) |
+| Vision Multi-task | Ultralytics YOLO (YOLOv5u / YOLOv8 / YOLOv9 / YOLOv10 / YOLO11 / YOLO12) | `samples/vision/ultralytics_yolo` | S100 / S100P / S600 | [Details](./samples/vision/ultralytics_yolo) |
 | Vision Multi-task | YOLO26 | `samples/vision/ultralytics_yolo26` | S100 / S100P / S600 | [Details](./samples/vision/ultralytics_yolo26) |
 | Object Detection | YOLOv5x | `samples/vision/yolov5` | S100 / S600 | [Details](./samples/vision/yolov5) |
 | Object Detection | YOLO11 | `samples/vision/yolo11` | S100 / S600 | [Details](./samples/vision/yolo11) |
@@ -149,7 +149,7 @@ The `run.sh` script automatically downloads the model, installs dependencies, an
 | Text Recognition | PaddleOCR | `samples/vision/paddle_ocr` | S100 | [Details](./samples/vision/paddle_ocr) |
 | Speech Recognition | ASR (Wav2Vec2) | `samples/speech/asr` | S100 / S600 | [Details](./samples/speech/asr) |
 | Keyword Spotting | KWS (MDTC) | `samples/speech/kws` | S100 | [Details](./samples/speech/kws) |
-| Embodied AI / Robot Policy | ACT (Action Chunking Transformer) | `samples/vla/act` | S100 | [Details](./samples/vla/act) |
+| Embodied AI / Robot Policy | ACT (Action Chunking Transformer) | `samples/vla/act` | S100 / S600 | [Details](https://github.com/D-Robotics/rdk_LeRobot_tools) |
 
 ---
 

--- a/README_cn.md
+++ b/README_cn.md
@@ -122,7 +122,7 @@ bash run.sh
 
 | 类别 | 模型名称 | 模型路径 | 支持平台 | 详情 |
 | :--- | :--- | :--- | :--- | :---: |
-| 视觉多任务 | Ultralytics YOLO（YOLOv5u / YOLOv8 / YOLOv10 / YOLO11 / YOLO12） | `samples/vision/ultralytics_yolo` | S100 / S100P | [详情](./samples/vision/ultralytics_yolo) |
+| 视觉多任务 | Ultralytics YOLO（YOLOv5u / YOLOv8 / YOLOv9 / YOLOv10 / YOLO11 / YOLO12） | `samples/vision/ultralytics_yolo` | S100 / S100P / S600 | [详情](./samples/vision/ultralytics_yolo) |
 | 视觉多任务 | YOLO26 | `samples/vision/ultralytics_yolo26` | S100 / S100P / S600 | [详情](./samples/vision/ultralytics_yolo26) |
 | 目标检测 | YOLOv5x | `samples/vision/yolov5` | S100 / S600 | [详情](./samples/vision/yolov5) |
 | 目标检测 | YOLO11 | `samples/vision/yolo11` | S100 / S600 | [详情](./samples/vision/yolo11) |
@@ -149,7 +149,7 @@ bash run.sh
 | 文字识别 | PaddleOCR | `samples/vision/paddle_ocr` | S100 | [详情](./samples/vision/paddle_ocr) |
 | 语音识别 | ASR（Wav2Vec2） | `samples/speech/asr` | S100 / S600 | [详情](./samples/speech/asr) |
 | 关键词唤醒 | KWS（MDTC） | `samples/speech/kws` | S100 | [详情](./samples/speech/kws) |
-| 具身智能 / 机器人策略 | ACT（Action Chunking Transformer） | `samples/vla/act` | S100 | [详情](./samples/vla/act) |
+| 具身智能 / 机器人策略 | ACT（Action Chunking Transformer） | `samples/vla/act` | S100 / S600 | [详情](https://github.com/D-Robotics/rdk_LeRobot_tools) |
 
 ---
 

--- a/samples/vision/ultralytics_yolo/README.md
+++ b/samples/vision/ultralytics_yolo/README.md
@@ -10,11 +10,11 @@ This directory provides the complete usage guide for the Ultralytics YOLO sample
 
 Ultralytics YOLO is a real-time vision model family covering object detection,
 instance segmentation, pose estimation, and image classification. This sample
-provides RDK S100/S100P deployment examples for the following public model
-families:
+provides RDK S100/S100P/S600 deployment examples for the following public
+model families:
 
 - Detection:
-  `YOLOv5u / YOLOv8 / YOLOv10 / YOLO11 / YOLO12`
+  `YOLOv5u / YOLOv8 / YOLOv9 / YOLOv10 / YOLO11 / YOLO12`
 - Instance Segmentation:
   `YOLOv8 / YOLO11`
 - Pose Estimation:
@@ -41,7 +41,7 @@ YOLOv5u detect covers the public `yolov5nu/su/mu/lu/xu` model family.
 
 ### Platform Notes
 
-- Target platforms: `RDK S100` / `RDK S100P`
+- Target platforms: `RDK S100` / `RDK S100P` / `RDK S600`
 - Runtime backend: `hbm_runtime`
 - Inference model format: `.hbm`
 - Input format: `NV12` (Y + UV as two separate tensors)
@@ -95,7 +95,7 @@ For detailed arguments and task examples, refer to
 
 ## Model Conversion
 
-This sample provides pre-converted `.hbm` models for RDK S100/S100P.
+This sample provides pre-converted `.hbm` models for RDK S100/S100P/S600.
 
 - If you only want to run inference, download models from [model/README.md](./model/README.md) and skip conversion.
 - If you need to export ONNX, prepare calibration data, or compile the model,
@@ -130,10 +130,10 @@ Refer to [evaluator/README.md](./evaluator/README.md) for details.
 ## Inference Result
 
 The Python runtime provides `run.sh` coverage for the following documented
-models on `RDK S100` / `RDK S100P`:
+models on `RDK S100` / `RDK S100P` / `RDK S600`:
 
 - Detect:
-  `YOLOv5u / YOLOv8 / YOLOv10 / YOLO11 / YOLO12`
+  `YOLOv5u / YOLOv8 / YOLOv9 / YOLOv10 / YOLO11 / YOLO12`
 - Seg:
   `YOLOv8 / YOLO11`
 - Pose:

--- a/samples/vision/ultralytics_yolo/README_cn.md
+++ b/samples/vision/ultralytics_yolo/README_cn.md
@@ -8,10 +8,10 @@
 
 ## 算法介绍
 
-Ultralytics YOLO 是一个实时视觉模型家族，涵盖目标检测、实例分割、姿态估计和图像分类。本示例提供了在 RDK S100/S100P 平台上的公开模型部署示例，支持以下模型系列：
+Ultralytics YOLO 是一个实时视觉模型家族，涵盖目标检测、实例分割、姿态估计和图像分类。本示例提供了在 RDK S100/S100P/S600 平台上的公开模型部署示例，支持以下模型系列。
 
 - 目标检测：
-  `YOLOv5u / YOLOv8 / YOLOv10 / YOLO11 / YOLO12`
+  `YOLOv5u / YOLOv8 / YOLOv9 / YOLOv10 / YOLO11 / YOLO12`
 - 实例分割：
   `YOLOv8 / YOLO11`
 - 姿态估计：
@@ -38,7 +38,7 @@ YOLOv5u detect 覆盖公开的 `yolov5nu/su/mu/lu/xu` 模型族。
 
 ### 平台说明
 
-- 目标平台：`RDK S100` / `RDK S100P`
+- 目标平台：`RDK S100` / `RDK S100P` / `RDK S600`
 - 运行时后端：`hbm_runtime`
 - 推理模型格式：`.hbm`
 - 输入格式：`NV12`（Y + UV 两个独立输入张量）
@@ -90,7 +90,7 @@ bash run.sh detect
 
 ## 模型转换
 
-本示例已提供 RDK S100/S100P 的预编译 `.hbm` 模型文件。
+本示例已提供 RDK S100/S100P/S600 的预编译 `.hbm` 模型文件。
 
 - 如仅需推理，可从 [model/README.md](./model/README.md) 下载模型，跳过转换步骤。
 - 如需导出 ONNX、准备校准数据或编译模型，请参考 [conversion/README.md](./conversion/README.md)。
@@ -121,10 +121,10 @@ bash run.sh detect
 
 ## 推理结果
 
-Python runtime 的 `run.sh` 覆盖以下 `RDK S100` / `RDK S100P` 文档化模型：
+Python runtime 的 `run.sh` 覆盖以下 `RDK S100` / `RDK S100P` / `RDK S600` 文档化模型：
 
 - 检测：
-  `YOLOv5u / YOLOv8 / YOLOv10 / YOLO11 / YOLO12`
+  `YOLOv5u / YOLOv8 / YOLOv9 / YOLOv10 / YOLO11 / YOLO12`
 - 分割：
   `YOLOv8 / YOLO11`
 - 姿态：

--- a/samples/vision/ultralytics_yolo/conversion/README.md
+++ b/samples/vision/ultralytics_yolo/conversion/README.md
@@ -2,7 +2,7 @@ English | [简体中文](./README_cn.md)
 
 # Ultralytics YOLO Model Conversion and Compilation Guide
 
-This directory provides the scripts, resources, and instructions for exporting Ultralytics YOLO models, running quantized compilation, and checking HBM artifacts for RDK S100/S100P BPU deployment.
+This directory provides the scripts, resources, and instructions for exporting Ultralytics YOLO models, running quantized compilation, and checking HBM artifacts for RDK S100/S100P/S600 BPU deployment.
 
 ## Directory Structure
 
@@ -17,7 +17,7 @@ This directory provides the scripts, resources, and instructions for exporting U
 
 ## Compilation Environment
 
-Run model compilation on an x86 Linux host with the RDK S100 OpenExplore Docker environment. Installing the compiler toolchain on the board is not recommended.
+Run model compilation on an x86 Linux host with the corresponding RDK S OpenExplore Docker environment. Installing the compiler toolchain on the board is not recommended.
 
 Toolchain entry points:
 
@@ -35,7 +35,10 @@ sudo docker run --rm hello-world
 
 ### 2. Download and Load the Offline Image
 
-Visit the [D-Robotics developer documentation](https://developer.d-robotics.cc/rdk_doc/rdk_s/Advanced_development/toolchain_development/overview#docker-%E9%95%9C%E5%83%8F) and download the CPU Docker image for the RDK S100 series.
+Visit the D-Robotics developer documentation and download the matching OE Docker image:
+
+- RDK S100 / S100P: <https://developer.d-robotics.cc/rdk_s_doc/Advanced_development/toolchain_development/algorithm_toolchain/overview?v=4.0.5&p=RDK+S100>
+- RDK S600: <https://developer.d-robotics.cc/rdk_s_doc/Advanced_development/toolchain_development/algorithm_toolchain/overview?v=5.1.0&p=RDK+S600>
 
 ```bash
 sudo docker load -i ai_toolchain_ubuntu_22_s100_xxx.tar
@@ -186,7 +189,7 @@ python3 export_monkey_patch.py --pt yolo11n.pt
 
 ### 3. Model Compilation
 
-Run model compilation in the RDK S100/S100P OpenExplore toolchain environment. The OE Docker offline image is recommended. Do not install or run the compiler toolchain on the board.
+Run model compilation in the matching RDK S OpenExplore toolchain environment. The OE Docker offline image is recommended. Do not install or run the compiler toolchain on the board.
 
 Toolchain entry points:
 
@@ -203,6 +206,9 @@ python3 mapper.py --onnx yolo11n.onnx --cal-images ./cal_images --march nash-e
 
 # RDK S100P (Nash-M)
 python3 mapper.py --onnx yolo11n.onnx --cal-images ./cal_images --march nash-m
+
+# RDK S600 (Nash-P)
+python3 mapper.py --onnx yolo11n.onnx --cal-images ./cal_images --march nash-p
 ```
 
 The script exposes common parameters, and the defaults cover most cases.
@@ -216,7 +222,7 @@ options:
   -h, --help                        show this help message and exit
   --cal-images CAL_IMAGES           *.jpg, *.png calibration images path, 20 ~ 50 pictures is OK.
   --onnx ONNX                       origin float onnx model path.
-  --march MARCH                     S100: nash-e, S100P: nash-m
+  --march MARCH                     S100: nash-e, S100P: nash-m, S600: nash-p
   --quantized QUANTIZED             int8 first / int16 first
   --jobs JOBS                       model combine jobs.
   --optimize-level OPTIMIZE_LEVEL   O0, O1, O2
@@ -231,8 +237,9 @@ Recommended `.hbm` file names:
 
 - S100: `*_nashe_*_nv12.hbm`
 - S100P: `*_nashm_*_nv12.hbm`
+- S600: `*_nashp_*_nv12.hbm`
 
-Place model files under `model/nash-e/` or `model/nash-m/` in this sample so that `runtime/python/run.sh` and `runtime/python/main.py` can use them directly.
+Place model files under `model/nash-e/`, `model/nash-m/`, or `model/nash-p/` in this sample so that `runtime/python/run.sh` and `runtime/python/main.py` can use them directly.
 ## Input and Output Protocol
 
 ### Input Protocol
@@ -260,6 +267,7 @@ The current runtime covers the following model families and task combinations:
 | :--- | :---: | :---: | :---: | :---: |
 | YOLOv5u | Supported | Not supported | Not supported | Not supported |
 | YOLOv8 | Supported | Supported | Supported | Supported |
+| YOLOv9 | Supported | Not supported | Not supported | Not supported |
 | YOLOv10 | Supported | Not supported | Not supported | Not supported |
 | YOLO11 | Supported | Supported | Supported | Supported |
 | YOLO12 | Supported | Not supported | Not supported | Not supported |

--- a/samples/vision/ultralytics_yolo/conversion/README_cn.md
+++ b/samples/vision/ultralytics_yolo/conversion/README_cn.md
@@ -2,7 +2,7 @@
 
 # Ultralytics YOLO 模型转换与编译指南
 
-本目录提供 Ultralytics YOLO 模型导出、量化编译和 HBM 产物检查所需的脚本、资源和说明，目标产物为适配 RDK S100/S100P 的 BPU 量化 `.hbm` 模型。
+本目录提供 Ultralytics YOLO 模型导出、量化编译和 HBM 产物检查所需的脚本、资源和说明，目标产物为适配 RDK S100/S100P/S600 的 BPU 量化 `.hbm` 模型。
 
 ## 目录结构
 
@@ -17,11 +17,12 @@
 
 ## 模型编译环境
 
-模型编译请在 x86 Linux 主机的 RDK S100 OpenExplore Docker 环境中完成，不建议在板端安装编译工具链。
+模型编译请在 x86 Linux 主机的对应 RDK S OpenExplore Docker 环境中完成，不建议在板端安装编译工具链。
 
 工具链入口：
 
-- OE Docker 下载文档：<https://developer.d-robotics.cc/rdk_doc/rdk_s/Advanced_development/toolchain_development/overview>
+- OE Docker 下载（S100 / S100P）：<https://developer.d-robotics.cc/rdk_s_doc/Advanced_development/toolchain_development/algorithm_toolchain/overview?v=4.0.5&p=RDK+S100>
+- OE Docker 下载（S600）：<https://developer.d-robotics.cc/rdk_s_doc/Advanced_development/toolchain_development/algorithm_toolchain/overview?v=5.1.0&p=RDK+S600>
 - OE 工具链下载：<https://toolchain.d-robotics.cc/>
 
 ### 1. 安装 Docker
@@ -35,7 +36,10 @@ sudo docker run --rm hello-world
 
 ### 2. 获取并加载离线镜像
 
-请访问 [D-Robotics 开发者文档](https://developer.d-robotics.cc/rdk_doc/rdk_s/Advanced_development/toolchain_development/overview#docker-%E9%95%9C%E5%83%8F) 下载适配 RDK S100 系列的 CPU 版本 Docker 镜像。
+请访问 D-Robotics 开发者文档并下载对应平台的 OE Docker 镜像：
+
+- RDK S100 / S100P：<https://developer.d-robotics.cc/rdk_s_doc/Advanced_development/toolchain_development/algorithm_toolchain/overview?v=4.0.5&p=RDK+S100>
+- RDK S600：<https://developer.d-robotics.cc/rdk_s_doc/Advanced_development/toolchain_development/algorithm_toolchain/overview?v=5.1.0&p=RDK+S600>
 
 ```bash
 sudo docker load -i ai_toolchain_ubuntu_22_s100_xxx.tar
@@ -188,11 +192,12 @@ Ultralytics YOLO Pose 模型的目标检测部分与 Ultralytics YOLO Detect一�
 
 ### 3. 模型编译 (mapper)
 
-模型编译请在 RDK S100/S100P OpenExplore 工具链环境中执行。建议使用 OE Docker 离线镜像，不在板端安装和运行编译工具链。
+模型编译请在对应的 RDK S OpenExplore 工具链环境中执行。建议使用 OE Docker 离线镜像，不在板端安装和运行编译工具链。
 
 工具链入口：
 
-- OE Docker 下载：[S100 算法工具链](https://developer.d-robotics.cc/rdk_doc/rdk_s/Advanced_development/toolchain_development/overview)
+- OE Docker 下载（S100 / S100P）：[https://developer.d-robotics.cc/rdk_s_doc/Advanced_development/toolchain_development/algorithm_toolchain/overview?v=4.0.5&p=RDK+S100](https://developer.d-robotics.cc/rdk_s_doc/Advanced_development/toolchain_development/algorithm_toolchain/overview?v=4.0.5&p=RDK+S100)
+- OE Docker 下载（S600）：[https://developer.d-robotics.cc/rdk_s_doc/Advanced_development/toolchain_development/algorithm_toolchain/overview?v=5.1.0&p=RDK+S600](https://developer.d-robotics.cc/rdk_s_doc/Advanced_development/toolchain_development/algorithm_toolchain/overview?v=5.1.0&p=RDK+S600)
 - OE 工具链在线手册：[https://toolchain.d-robotics.cc/](https://toolchain.d-robotics.cc/)
 
 在 OpenExplore 工具链环境中运行本目录下的 `mapper.py`。需要准备校准图片和 ONNX 模型；脚本会自动准备校准数据和编译 YAML 配置文件，转换完成的 `.hbm` 模型会保存在 ONNX 模型同级目录或 `--output-dir` 指定目录。
@@ -205,6 +210,9 @@ python3 mapper.py --onnx yolo11n.onnx --cal-images ./cal_images --march nash-e
 
 # RDK S100P (Nash-M)
 python3 mapper.py --onnx yolo11n.onnx --cal-images ./cal_images --march nash-m
+
+# RDK S600 (Nash-P)
+python3 mapper.py --onnx yolo11n.onnx --cal-images ./cal_images --march nash-p
 ```
 
 这个脚本暴露了一些常见参数，默认值已经满足大多数需求。
@@ -218,7 +226,7 @@ options:
   -h, --help                        show this help message and exit
   --cal-images CAL_IMAGES           *.jpg, *.png calibration images path, 20 ~ 50 pictures is OK.
   --onnx ONNX                       origin float onnx model path.
-  --march MARCH                     S100: nash-e, S100P: nash-m
+  --march MARCH                     S100: nash-e, S100P: nash-m, S600: nash-p
   --quantized QUANTIZED             int8 first / int16 first
   --jobs JOBS                       model combine jobs.
   --optimize-level OPTIMIZE_LEVEL   O0, O1, O2
@@ -233,8 +241,9 @@ options:
 
 - S100: `*_nashe_*_nv12.hbm`
 - S100P: `*_nashm_*_nv12.hbm`
+- S600: `*_nashp_*_nv12.hbm`
 
-模型文件需放入 sample 的 `model/nash-e/` 或 `model/nash-m/` 目录，供 `runtime/python/run.sh` 和 `runtime/python/main.py` 使用。
+模型文件需放入 sample 的 `model/nash-e/`、`model/nash-m/` 或 `model/nash-p/` 目录，供 `runtime/python/run.sh` 和 `runtime/python/main.py` 使用。
 ## 输入输出协议
 
 ### 输入协议
@@ -262,6 +271,7 @@ Python runtime 按固定索引解析输出：
 | :--- | :---: | :---: | :---: | :---: |
 | YOLOv5u | 支持 | 不支持 | 不支持 | 不支持 |
 | YOLOv8 | 支持 | 支持 | 支持 | 支持 |
+| YOLOv9 | 支持 | 不支持 | 不支持 | 不支持 |
 | YOLOv10 | 支持 | 不支持 | 不支持 | 不支持 |
 | YOLO11 | 支持 | 支持 | 支持 | 支持 |
 | YOLO12 | 支持 | 不支持 | 不支持 | 不支持 |

--- a/samples/vision/ultralytics_yolo/conversion/mapper.py
+++ b/samples/vision/ultralytics_yolo/conversion/mapper.py
@@ -18,13 +18,13 @@
 Ultralytics YOLO Model Conversion Script (Mapper)
 
 This script automates the model conversion process for D-Robotics RDK platforms.
-It supports RDK S100/S100P (Nash architecture).
+It supports RDK S100/S100P/S600 (Nash architecture).
 
 Key Features:
 - Automates calibration data preparation (Image -> NPY).
 - Generates architecture-specific configuration files (yaml).
 - Invokes the appropriate compiler tool:
-    - `hb_compile` for Nash (S100/S100P) -> Output: *.hbm
+    - `hb_compile` for Nash (S100/S100P/S600) -> Output: *.hbm
 
 Usage:
     python3 mapper.py --onnx model.onnx --cal-images ./images --march nash-e
@@ -84,7 +84,7 @@ def main():
     
     # Architecture selection
     parser.add_argument('--march', type=str, default="nash-e", 
-                        help='Target Architecture: "nash-e" (RDK S100), "nash-m" (RDK S100P). Default: nash-e')
+                        help='Target Architecture: "nash-e" (RDK S100), "nash-m" (RDK S100P), "nash-p" (RDK S600). Default: nash-e')
     
     parser.add_argument('--quantized', type=str, default="int8", help='Quantization precision: "int8" (default) or "int16".')
     parser.add_argument('--jobs', type=int, default=16, help='Number of parallel compilation jobs.')
@@ -118,7 +118,7 @@ def main():
 
 def run_nash(opt):
     """
-    Workflow for RDK S100/S100P (Nash Architecture).
+    Workflow for RDK S100/S100P/S600 (Nash Architecture).
     Uses `hb_compile` toolchain.
     Generates `.hbm` model files.
     Calibration data format: `.npy` files (normalized 0-1).
@@ -143,7 +143,7 @@ def run_nash(opt):
         subprocess.run(['hb_compile', '--help'], capture_output=True, text=True, check=True)
         logger.info("hb_compile is available.")
     except (subprocess.CalledProcessError, FileNotFoundError):
-        logger.error("hb_compile is not available. Please ensure RDK S100 Toolchain is installed/sourced.")
+        logger.error("hb_compile is not available. Please ensure the RDK S toolchain is installed/sourced.")
         exit(1)
 
     # Validate ONNX model
@@ -261,7 +261,7 @@ compiler_parameters:
         img = cv2.imread(img_path)
         if img is None: continue
             
-        # S100 preprocessing matches ONNX export (RGB + Normalize)
+        # RDK S preprocessing matches ONNX export (RGB + Normalize)
         input_tensor = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)     # BGR2RGB
         input_tensor = cv2.resize(input_tensor, (width, height)) # resize
         input_tensor = np.transpose(input_tensor, (2, 0, 1))    # HWC2CHW
@@ -280,7 +280,7 @@ compiler_parameters:
             logger.error("hb_compile failed.")
             exit(1)
 
-        # Move Output (.hbm for S100)
+        # Move Output (.hbm for RDK S)
         output_bin_path = os.path.join(bpu_output_dir, f"{output_model_prefix}.hbm")
         final_output_path = os.path.join(opt.output_dir, f"{output_model_prefix}.hbm")
         

--- a/samples/vision/ultralytics_yolo/evaluator/README.md
+++ b/samples/vision/ultralytics_yolo/evaluator/README.md
@@ -23,8 +23,9 @@ Single-thread latency: measured per frame, using a single thread and a single BP
 Multi-thread throughput: multiple threads concurrently submit tasks to the BPU. Each BPU core can handle tasks from multiple threads. In practical engineering scenarios, using 2 threads typically achieves minimal per-frame latency while fully utilizing all BPU cores (100% utilization), striking a good balance between throughput (FPS) and frame latency.
 The table generally records results up to the point where throughput no longer increases significantly with additional threads.
 BPU latency and throughput were measured on-device using the following command. The hrt_model_exec tool is provided by the OE package, with source code located in package/board/hrt_model_exec/src within the OE package:
-bash
+```bash
 hrt_model_exec perf --thread_num 2 --model_file <model.bin / model.hbm>
+```
 Due to varying experimental conditions, reproduced results may differ. All measurements reported here were conducted under the optimal device state specified in the "Platform Details" section.
 The hrt_model_exec performance test accounts for cache warm-up and proper multi-threaded program design. The measured time spans from when the user application submits a BPU task until the task completes.
 For streaming inference, input and output memory buffers should be allocated once and reused across frames. Do not include memory allocation/deallocation time in inference timing, nor repeatedly allocate/free memory during streaming inference—this constitutes poor software design.
@@ -33,7 +34,7 @@ For streaming inference, input and output memory buffers should be allocated onc
 
 7. params(M) and FLOPs(B) represent the parameter count and computational complexity (in floating-point operations) of the original floating-point model. These values are obtained from logs printed by the Ultralytics YOLO package when calling YOLO.export() after loading a .pt model. Note that the final fixed-point BPU model’s parameters and FLOPs depend on model structure optimization, graph optimization, and compiler optimizations. Although correlated with the floating-point model’s metrics, they are not strictly proportional. Therefore, floating-point FLOPs are uniformly recorded here as a reference.
 
-Accuracy Test Instructions
+### Accuracy Test Instructions
 
 1. The meanings of the Device and Model columns are identical to those described in the "Performance Test Instructions" section.
 
@@ -47,30 +48,85 @@ Accuracy bbox-all mAP@.50:.95: Average Precision (AP) @[ IoU=0.50:0.95 area=all 
 Accuracy bbox-small mAP@.50:.95: Average Precision (AP) @[ IoU=0.50:0.95 area=small maxDets=100 ]
 Accuracy bbox-medium mAP@.50:.95: Average Precision (AP) @[ IoU=0.50:0.95 area=medium maxDets=100 ]
 Accuracy bbox-large mAP@.50:.95: Average Precision (AP) @[ IoU=0.50:0.95 area=large maxDets=100 ]
-Accuracy mask-all mAP@.50:.95: Average Precision (AP) @[ IoU=0.50:0.95 area=all maxDets=100 ]
-Accuracy mask-small mAP@.50:.95: Average Precision (AP) @[ IoU=0.50:0.95 area=small maxDets=100 ]
-Accuracy mask-medium mAP@.50:.95: Average Precision (AP) @[ IoU=0.50:0.95 area=medium maxDets=100 ]
-Accuracy mask-large mAP@.50:.95: Average Precision (AP) @[ IoU=0.50:0.95 area=large maxDets=100 ]
 Accuracy pose-all mAP@.50:.95: Average Precision (AP) @[ IoU=0.50:0.95 area=all maxDets=20 ]
 Accuracy pose-medium mAP@.50:.95: Average Precision (AP) @[ IoU=0.50:0.95 area=medium maxDets=20 ]
 Accuracy pose-large mAP@.50:.95: Average Precision (AP) @[ IoU=0.50:0.95 area=large maxDets=20 ]
-
-3. AP (Average Precision) emphasizes quality: it requires both high recall (finding targets) and high precision (accurate bounding boxes and correct classification). In contrast, AR (Average Recall) emphasizes quantity: it counts any detection that overlaps a ground truth, without penalizing false positives. Thus, a model can have high AR but low AP (e.g., by generating many low-quality detections) or high AP but low AR (e.g., by only outputting high-confidence predictions and missing many targets). This document uses AP as the primary accuracy metric.
-
-4. All tests used the 5,000 images from the COCO2017 validation set. Inference was performed directly on the device, and results were dumped to JSON files for evaluation using the third-party pycocotools library. A confidence threshold of 0.25 and an NMS IoU threshold of 0.7 were applied.
-
-5. It is normal for pycocotools to report slightly lower accuracy than Ultralytics’ own evaluation tools. This discrepancy arises because pycocotools computes the AP integral using rectangular approximation, whereas Ultralytics uses trapezoidal approximation. Our focus is on using a consistent evaluation method to compare fixed-point (quantized) and floating-point models, thereby assessing quantization-induced accuracy loss.
-
-6. For classification tasks, the ImageNet-1k dataset was used, with Top-1 and Top-5 accuracy reported to evaluate quantization-induced accuracy degradation.
-
-7. Converting BPU model input from NCHW-RGB888 to YUV420SP (NV12) introduces minor accuracy loss due to color-space transformation. This loss can be mitigated by incorporating such color-space conversion during model training.
-
-8. Minor numerical discrepancies may exist between Python and C/C++ API results, primarily due to subtle differences in how floating-point data is handled during memory copying and type conversions between the two implementations.
-
-9. The results in this table were obtained using Post-Training Quantization (PTQ) with calibration on 50 images, simulating the typical experience of a developer performing their first direct compilation without further accuracy tuning or Quantization-Aware Training (QAT). These results satisfy general validation requirements but do not represent the upper bound of achievable accuracy.
-
+Accuracy TOP1 / TOP5: Top-1 / Top-5 classification accuracy on ImageNet-1k.
 
 ## Performance
+### RDK S600
+#### Obeject Detection
+| Device   | Model           | Size(Pixels)   |   Classes | BPU Task Latency  /<br>BPU Throughput (Threads)                          | CPU Latency<br>(Single Core)   | params(M)   | FLOPs(B)   |
+|----------|-----------------|----------------|-----------|--------------------------------------------------------------------------|--------------------------------|-------------|------------|
+| S600     | YOLO11l Detect | 640×640        |       80 | 3.229 ms / 307.877 FPS (1 thread ) <br/> 9.113 ms / 1277.270 FPS (12 threads) | 2.0 ms                         | 25.3 M      | 86.9 M     |
+| S600     | YOLO11m Detect | 640×640        |       80 | 2.584 ms / 384.284 FPS (1 thread ) <br/> 7.054 ms / 1642.643 FPS (12 threads) | 2.0 ms                         | 20.1 M      | 68.0 M     |
+| S600     | YOLO11n Detect | 640×640        |       80 | 0.800 ms / 1221.628 FPS (1 thread ) <br/> 1.798 ms / 6142.695 FPS (12 threads) | 2.0 ms                         | 2.6 M       | 6.5 M      |
+| S600     | YOLO11s Detect | 640×640        |       80 | 1.204 ms / 817.752 FPS (1 thread ) <br/> 3.008 ms / 3761.944 FPS (12 threads) | 2.0 ms                         | 9.4 M       | 21.5 M     |
+| S600     | YOLO11x Detect | 640×640        |       80 | 6.543 ms / 152.382 FPS (1 thread ) <br/> 18.792 ms / 622.258 FPS (12 threads) | 2.0 ms                         | 56.9 M      | 194.9 M    |
+| S600     | YOLO12l Detect | 640×640        |       80 | 6.296 ms / 158.364 FPS (1 thread ) <br/> 19.661 ms / 595.057 FPS (12 threads) | 2.0 ms                         | 26.4 M      | 88.9 M     |
+| S600     | YOLO12m Detect | 640×640        |       80 | 4.027 ms / 247.181 FPS (1 thread ) <br/> 12.026 ms / 969.575 FPS (12 threads) | 2.0 ms                         | 20.2 M      | 67.5 M     |
+| S600     | YOLO12n Detect | 640×640        |       80 | 1.207 ms / 819.555 FPS (1 thread ) <br/> 2.986 ms / 3779.575 FPS (12 threads) | 2.0 ms                         | 2.6 M       | 7.7 M      |
+| S600     | YOLO12s Detect | 640×640        |       80 | 1.957 ms / 505.866 FPS (1 thread ) <br/> 5.155 ms / 2235.861 FPS (12 threads) | 2.0 ms                         | 9.3 M       | 21.4 M     |
+| S600     | YOLO12x Detect | 640×640        |       80 | 11.073 ms / 90.110 FPS (1 thread ) <br/> 35.574 ms / 329.594 FPS (12 threads) | 2.0 ms                         | 59.1 M      | 199.0 M    |
+| S600     | YOLOv10b Detect | 640×640        |       80 | 2.972 ms / 334.349 FPS (1 thread ) <br/> 8.042 ms / 1442.637 FPS (12 threads) | 2.0 ms                         | 19.1 M      | 92.0 M     |
+| S600     | YOLOv10l Detect | 640×640        |       80 | 3.723 ms / 267.232 FPS (1 thread ) <br/> 10.360 ms / 1123.873 FPS (12 threads) | 2.0 ms                         | 24.4 M      | 120.3 M    |
+| S600     | YOLOv10m Detect | 640×640        |       80 | 2.342 ms / 423.743 FPS (1 thread ) <br/> 6.201 ms / 1867.309 FPS (12 threads) | 2.0 ms                         | 15.4 M      | 59.1 M     |
+| S600     | YOLOv10n Detect | 640×640        |       80 | 0.781 ms / 1251.157 FPS (1 thread ) <br/> 1.690 ms / 6457.445 FPS (12 threads) | 2.0 ms                         | 2.3 M       | 6.7 M      |
+| S600     | YOLOv10s Detect | 640×640        |       80 | 1.166 ms / 847.781 FPS (1 thread ) <br/> 2.802 ms / 4025.117 FPS (12 threads) | 2.0 ms                         | 7.2 M       | 21.6 M     |
+| S600     | YOLOv10x Detect | 640×640        |       80 | 5.314 ms / 187.525 FPS (1 thread ) <br/> 15.173 ms / 769.177 FPS (12 threads) | 2.0 ms                         | 29.5 M      | 160.4 M    |
+| S600     | YOLOv5lu Detect | 640×640        |       80 | 3.980 ms / 250.292 FPS (1 thread ) <br/> 11.117 ms / 1048.306 FPS (12 threads) | 2.0 ms                         | 53.2 M      | 135.0 M    |
+| S600     | YOLOv5mu Detect | 640×640        |       80 | 2.240 ms / 442.539 FPS (1 thread ) <br/> 5.935 ms / 1941.804 FPS (12 threads) | 2.0 ms                         | 25.1 M      | 64.2 M     |
+| S600     | YOLOv5nu Detect | 640×640        |       80 | 0.719 ms / 1355.583 FPS (1 thread ) <br/> 1.528 ms / 7182.102 FPS (12 threads) | 2.0 ms                         | 2.6 M       | 7.7 M      |
+| S600     | YOLOv5su Detect | 640×640        |       80 | 1.096 ms / 898.017 FPS (1 thread ) <br/> 2.656 ms / 4213.542 FPS (12 threads) | 2.0 ms                         | 9.1 M       | 24.0 M     |
+| S600     | YOLOv5xu Detect | 640×640        |       80 | 7.333 ms / 136.001 FPS (1 thread ) <br/> 21.084 ms / 554.451 FPS (12 threads) | 2.0 ms                         | 97.2 M      | 246.4 M    |
+| S600     | YOLOv8l Detect | 640×640        |       80 | 4.514 ms / 220.583 FPS (1 thread ) <br/> 12.603 ms / 924.740 FPS (12 threads) | 2.0 ms                         | 43.7 M      | 165.2 M    |
+| S600     | YOLOv8m Detect | 640×640        |       80 | 2.677 ms / 371.027 FPS (1 thread ) <br/> 7.180 ms / 1614.922 FPS (12 threads) | 2.0 ms                         | 25.9 M      | 78.9 M     |
+| S600     | YOLOv8n Detect | 640×640        |       80 | 0.776 ms / 1258.503 FPS (1 thread ) <br/> 1.674 ms / 6512.325 FPS (12 threads) | 2.0 ms                         | 3.2 M       | 8.7 M      |
+| S600     | YOLOv8s Detect | 640×640        |       80 | 1.223 ms / 805.412 FPS (1 thread ) <br/> 2.934 ms / 3839.066 FPS (12 threads) | 2.0 ms                         | 11.2 M      | 28.6 M     |
+| S600     | YOLOv8x Detect | 640×640        |       80 | 7.210 ms / 138.386 FPS (1 thread ) <br/> 20.629 ms / 567.201 FPS (12 threads) | 2.0 ms                         | 68.2 M      | 257.8 M    |
+| S600     | YOLOv9c Detect | 640×640        |       80 | 3.149 ms / 316.157 FPS (1 thread ) <br/> 8.773 ms / 1325.812 FPS (12 threads) | 2.0 ms                         | 25.3 M      | 102.7 M    |
+| S600     | YOLOv9e Detect | 640×640        |       80 | 8.560 ms / 116.557 FPS (1 thread ) <br/> 31.421 ms / 372.969 FPS (12 threads) | 2.0 ms                         | 57.4 M      | 189.5 M    |
+| S600     | YOLOv9m Detect | 640×640        |       80 | 2.747 ms / 361.925 FPS (1 thread ) <br/> 7.518 ms / 1541.699 FPS (12 threads) | 2.0 ms                         | 20.1 M      | 76.8 M     |
+| S600     | YOLOv9s Detect | 640×640        |       80 | 1.468 ms / 672.601 FPS (1 thread ) <br/> 3.911 ms / 2921.499 FPS (12 threads) | 2.0 ms                         | 7.2 M       | 26.9 M     |
+#### Segmentation
+| Device   | Model        | Size(Pixels)   |   Classes | BPU Task Latency  /<br>BPU Throughput (Threads)                          | CPU Latency<br>(Single Core)   | params(M)   | FLOPs(B)   |
+|----------|--------------|----------------|-----------|--------------------------------------------------------------------------|--------------------------------|-------------|------------|
+| S600     | YOLO11l Seg | 640×640        |       80 | 4.268 ms / 233.082 FPS (1 thread ) <br/> 12.015 ms / 967.109 FPS (12 threads) | 5.0 ms                         | 27.6 M      | 142.2 M    |
+| S600     | YOLO11m Seg | 640×640        |       80 | 3.624 ms / 274.240 FPS (1 thread ) <br/> 9.977 ms / 1161.123 FPS (12 threads) | 5.0 ms                         | 22.4 M      | 123.3 M    |
+| S600     | YOLO11n Seg | 640×640        |       80 | 0.959 ms / 1024.863 FPS (1 thread ) <br/> 2.379 ms / 4586.104 FPS (12 threads) | 5.0 ms                         | 2.9 M       | 10.4 M     |
+| S600     | YOLO11s Seg | 640×640        |       80 | 1.513 ms / 651.042 FPS (1 thread ) <br/> 3.845 ms / 2908.329 FPS (12 threads) | 5.0 ms                         | 10.1 M      | 35.5 M     |
+| S600     | YOLO11x Seg | 640×640        |       80 | 8.831 ms / 112.923 FPS (1 thread ) <br/> 25.480 ms / 459.263 FPS (12 threads) | 5.0 ms                         | 62.1 M      | 319.0 M    |
+| S600     | YOLOv8l Seg | 640×640        |       80 | 5.585 ms / 178.335 FPS (1 thread ) <br/> 15.661 ms / 743.323 FPS (12 threads) | 5.0 ms                         | 46.0 M      | 220.5 M    |
+| S600     | YOLOv8m Seg | 640×640        |       80 | 3.298 ms / 301.000 FPS (1 thread ) <br/> 8.931 ms / 1296.706 FPS (12 threads) | 5.0 ms                         | 27.3 M      | 100.2 M    |
+| S600     | YOLOv8n Seg | 640×640        |       80 | 0.940 ms / 1038.438 FPS (1 thread ) <br/> 2.236 ms / 4790.304 FPS (12 threads) | 5.0 ms                         | 3.4 M       | 12.6 M     |
+| S600     | YOLOv8s Seg | 640×640        |       80 | 1.540 ms / 642.329 FPS (1 thread ) <br/> 3.883 ms / 2873.027 FPS (12 threads) | 5.0 ms                         | 11.8 M      | 42.6 M     |
+| S600     | YOLOv8x Seg | 640×640        |       80 | 8.884 ms / 112.265 FPS (1 thread ) <br/> 25.517 ms / 458.336 FPS (12 threads) | 5.0 ms                         | 71.8 M      | 344.1 M    |
+#### Pose Estimation
+| Device   | Model        | Size(Pixels)   |   Classes | BPU Task Latency  /<br>BPU Throughput (Threads)                          | CPU Latency<br>(Single Core)   | params(M)   | FLOPs(B)   |
+|----------|--------------|----------------|-----------|--------------------------------------------------------------------------|--------------------------------|-------------|------------|
+| S600     | YOLO11l Pose | 640×640        |       80 | 3.319 ms / 299.436 FPS (1 thread ) <br/> 9.278 ms / 1250.641 FPS (12 threads) | 1.0 ms                         | 26.2 M      | 90.7 M     |
+| S600     | YOLO11m Pose | 640×640        |       80 | 2.667 ms / 371.922 FPS (1 thread ) <br/> 7.232 ms / 1596.972 FPS (12 threads) | 1.0 ms                         | 20.9 M      | 71.7 M     |
+| S600     | YOLO11n Pose | 640×640        |       80 | 0.846 ms / 1159.078 FPS (1 thread ) <br/> 1.925 ms / 5680.205 FPS (12 threads) | 1.0 ms                         | 2.9 M       | 7.6 M      |
+| S600     | YOLO11s Pose | 640×640        |       80 | 1.275 ms / 771.542 FPS (1 thread ) <br/> 3.146 ms / 3565.380 FPS (12 threads) | 1.0 ms                         | 9.9 M       | 23.2 M     |
+| S600     | YOLO11x Pose | 640×640        |       80 | 6.768 ms / 147.282 FPS (1 thread ) <br/> 19.390 ms / 602.593 FPS (12 threads) | 1.0 ms                         | 58.8 M      | 203.3 M    |
+| S600     | YOLOv8l Pose | 640×640        |       80 | 4.621 ms / 215.565 FPS (1 thread ) <br/> 12.895 ms / 902.833 FPS (12 threads) | 1.0 ms                         | 44.4 M      | 168.6 M    |
+| S600     | YOLOv8m Pose | 640×640        |       80 | 2.760 ms / 360.059 FPS (1 thread ) <br/> 7.384 ms / 1565.411 FPS (12 threads) | 1.0 ms                         | 26.4 M      | 81.0 M     |
+| S600     | YOLOv8n Pose | 640×640        |       80 | 0.808 ms / 1204.101 FPS (1 thread ) <br/> 1.733 ms / 6280.026 FPS (12 threads) | 1.0 ms                         | 3.3 M       | 9.2 M      |
+| S600     | YOLOv8s Pose | 640×640        |       80 | 1.292 ms / 761.464 FPS (1 thread ) <br/> 3.148 ms / 3553.976 FPS (12 threads) | 1.0 ms                         | 11.6 M      | 30.2 M     |
+| S600     | YOLOv8x Pose | 640×640        |       80 | 7.392 ms / 134.881 FPS (1 thread ) <br/> 21.121 ms / 553.125 FPS (12 threads) | 1.0 ms                         | 69.4 M      | 263.2 M    |
+#### Image Classification
+| Device   | Model       | Size(Pixels)   |   Classes | BPU Task Latency  /<br>BPU Throughput (Threads)                                          | CPU Latency<br>(Single Core)   | params(M)   | FLOPs(B)   |
+|----------|-------------|----------------|-----------|------------------------------------------------------------------------------------------|--------------------------------|-------------|------------|
+| S600     | YOLO11l CLS | 224×224        |     1000 | 0.654 ms / 1497.623 FPS (1 thread ) <br/> 1.418 ms / 7986.583 FPS (12 threads)          | 0.5 ms                         | 42.6 M      | 50.4 M     |
+| S600     | YOLO11m CLS | 224×224        |     1000 | 0.534 ms / 1830.295 FPS (1 thread ) <br/> 1.042 ms / 10636.601 FPS (12 threads)         | 0.5 ms                         | 32.8 M      | 39.3 M     |
+| S600     | YOLO11n CLS | 224×224        |     1000 | 0.345 ms / 2788.428 FPS (1 thread ) <br/> 0.761 ms / 13779.799 FPS (12 threads)         | 0.5 ms                         | 5.0 M       | 5.5 M      |
+| S600     | YOLO11s CLS | 224×224        |     1000 | 0.407 ms / 2380.216 FPS (1 thread ) <br/> 0.771 ms / 14041.000 FPS (12 threads)         | 0.5 ms                         | 13.1 M      | 14.4 M     |
+| S600     | YOLO11x CLS | 224×224        |     1000 | 0.994 ms / 991.985 FPS (1 thread ) <br/> 2.669 ms / 4295.902 FPS (12 threads)           | 0.5 ms                         | 97.7 M      | 113.2 M    |
+| S600     | YOLOv8l CLS | 224×224        |     1000 | 0.877 ms / 1123.179 FPS (1 thread ) <br/> 2.737 ms / 4181.651 FPS (12 threads)          | 0.5 ms                         | 36.3 M      | 99.0 M     |
+| S600     | YOLOv8m CLS | 224×224        |     1000 | 0.568 ms / 1718.996 FPS (1 thread ) <br/> 1.359 ms / 8276.775 FPS (12 threads)          | 0.5 ms                         | 17.0 M      | 42.8 M     |
+| S600     | YOLOv8n CLS | 224×224        |     1000 | 0.315 ms / 3054.368 FPS (1 thread ) <br/> 0.612 ms / 17488.633 FPS (12 threads)         | 0.5 ms                         | 2.7 M       | 4.3 M      |
+| S600     | YOLOv8s CLS | 224×224        |     1000 | 0.362 ms / 2695.563 FPS (1 thread ) <br/> 0.697 ms / 15550.891 FPS (12 threads)         | 0.5 ms                         | 6.4 M       | 13.5 M     |
+| S600     | YOLOv8x CLS | 224×224        |     1000 | 1.249 ms / 792.299 FPS (1 thread ) <br/> 4.156 ms / 2775.157 FPS (12 threads)           | 0.5 ms                         | 57.4 M      | 154.8 M    |
 ### RDK S100P
 #### Obeject Detection
 | Device   | Model           | Size(Pixels)   |   Classes | BPU Task Latency  /<br>BPU Throughput (Threads)                          | CPU Latency<br>(Single Core)   | params(M)   | FLOPs(B)   |
@@ -147,7 +203,246 @@ Accuracy pose-large mAP@.50:.95: Average Precision (AP) @[ IoU=0.50:0.95 area=la
 | S100P    | YOLOv8m CLS | 640×640        |        80 | 0.80 ms / 1218.07 FPS (1 thread ) <br/> 1.05 ms / 1876.12 FPS (2 threads)                                         | 0.5 ms                         | 17.0 M      | 42.7 M     |
 | S100P    | YOLOv8l CLS | 640×640        |        80 | 1.44 ms / 683.65 FPS (1 thread ) <br/> 2.34 ms / 842.80 FPS (2 threads)                                           | 0.5 ms                         | 37.5 M      | 99.7 M     |
 | S100P    | YOLOv8x CLS | 640×640        |        80 | 2.09 ms / 470.34 FPS (1 thread ) <br/> 3.55 ms / 559.63 FPS (2 threads)                                           | 0.5 ms                         | 57.4 M      | 154.8 M    |
+### RDK S100
+#### Obeject Detection
+| Device   | Model           | Size(Pixels)   |   Classes | BPU Task Latency  /<br>BPU Throughput (Threads)                          | CPU Latency<br>(Single Core)   | params(M)   | FLOPs(B)   |
+|----------|-----------------|----------------|-----------|--------------------------------------------------------------------------|--------------------------------|-------------|------------|
+| S100     | YOLO12n Detect  | 640×640        |        80 | 2.65 ms / 368.54 FPS (1 thread ) <br/> 4.43 ms / 443.33 FPS (2 threads)  | 2.0 ms                         | 2.6 M       | 7.7 M      |
+| S100     | YOLO12s Detect  | 640×640        |        80 | 4.48 ms / 220.08 FPS (1 thread ) <br/> 8.10 ms / 244.66 FPS (2 threads)  | 2.0 ms                         | 9.3 M       | 21.4 M     |
+| S100     | YOLO12m Detect  | 640×640        |        80 | 9.27 ms / 107.09 FPS (1 thread ) <br/> 17.56 ms / 113.12 FPS (2 threads) | 2.0 ms                         | 20.2 M      | 67.5 M     |
+| S100     | YOLO12l Detect  | 640×640        |        80 | 14.66 ms / 67.85 FPS (1 thread ) <br/> 28.30 ms / 70.28 FPS (2 threads)  | 2.0 ms                         | 26.4 M      | 88.9 M     |
+| S100     | YOLO12x Detect  | 640×640        |        80 | 24.72 ms / 40.33 FPS (1 thread ) <br/> 48.27 ms / 41.26 FPS (2 threads)  | 2.0 ms                         | 59.1 M      | 199.0 M    |
+| S100     | YOLO11n Detect  | 640×640        |        80 | 1.62 ms / 596.53 FPS (1 thread ) <br/> 2.39 ms / 813.87 FPS (2 threads)  | 2.0 ms                         | 2.6 M       | 6.5 M      |
+| S100     | YOLO11s Detect  | 640×640        |        80 | 2.63 ms / 371.42 FPS (1 thread ) <br/> 4.39 ms / 448.18 FPS (2 threads)  | 2.0 ms                         | 9.4 M       | 21.5 M     |
+| S100     | YOLO11m Detect  | 640×640        |        80 | 5.63 ms / 175.69 FPS (1 thread ) <br/> 10.35 ms / 191.62 FPS (2 threads) | 2.0 ms                         | 20.1 M      | 68.0 M     |
+| S100     | YOLO11l Detect  | 640×640        |        80 | 6.96 ms / 142.36 FPS (1 thread ) <br/> 13.02 ms / 152.41 FPS (2 threads) | 2.0 ms                         | 25.3 M      | 86.9 M     |
+| S100     | YOLO11x Detect  | 640×640        |        80 | 13.13 ms / 75.78 FPS (1 thread ) <br/> 25.24 ms / 78.82 FPS (2 threads)  | 2.0 ms                         | 56.9 M      | 194.9 M    |
+| S100     | YOLOv10n Detect | 640×640        |        80 | 1.58 ms / 608.94 FPS (1 thread ) <br/> 2.32 ms / 837.04 FPS (2 threads)  | 2.0 ms                         | 2.3 M       | 6.7 M      |
+| S100     | YOLOv10s Detect | 640×640        |        80 | 2.53 ms / 385.50 FPS (1 thread ) <br/> 4.18 ms / 471.09 FPS (2 threads)  | 2.0 ms                         | 7.2 M       | 21.6 M     |
+| S100     | YOLOv10m Detect | 640×640        |        80 | 4.49 ms / 219.98 FPS (1 thread ) <br/> 8.11 ms / 244.17 FPS (2 threads)  | 2.0 ms                         | 15.4 M      | 59.1 M     |
+| S100     | YOLOv10b Detect | 640×640        |        80 | 6.28 ms / 157.57 FPS (1 thread ) <br/> 11.65 ms / 170.32 FPS (2 threads) | 2.0 ms                         | 19.1 M      | 92.0 M     |
+| S100     | YOLOv10l Detect | 640×640        |        80 | 7.95 ms / 124.70 FPS (1 thread ) <br/> 14.98 ms / 132.53 FPS (2 threads) | 2.0 ms                         | 24.4 M      | 120.3 M    |
+| S100     | YOLOv10x Detect | 640×640        |        80 | 10.83 ms / 91.79 FPS (1 thread ) <br/> 20.66 ms / 96.17 FPS (2 threads)  | 2.0 ms                         | 29.5 M      | 160.4 M    |
+| S100     | YOLOv9t Detect  | 640×640        |        80 | 1.77 ms / 546.03 FPS (1 thread ) <br/> 2.67 ms / 730.68 FPS (2 threads)  | 2.0 ms                         | 2.1 M       | 8.2 M      |
+| S100     | YOLOv9s Detect  | 640×640        |        80 | 2.74 ms / 357.91 FPS (1 thread ) <br/> 4.62 ms / 425.97 FPS (2 threads)  | 2.0 ms                         | 7.2 M       | 26.9 M     |
+| S100     | YOLOv9m Detect  | 640×640        |        80 | 5.52 ms / 179.23 FPS (1 thread ) <br/> 10.13 ms / 195.30 FPS (2 threads) | 2.0 ms                         | 20.1 M      | 76.8 M     |
+| S100     | YOLOv9c Detect  | 640×640        |        80 | 6.98 ms / 142.00 FPS (1 thread ) <br/> 13.05 ms / 151.95 FPS (2 threads) | 2.0 ms                         | 25.3 M      | 102.7 M    |
+| S100     | YOLOv9e Detect  | 640×640        |        80 | 17.75 ms / 56.15 FPS (1 thread ) <br/> 34.41 ms / 57.85 FPS (2 threads)  | 2.0 ms                         | 57.4 M      | 189.5 M    |
+| S100     | YOLOv8n Detect  | 640×640        |        80 | 1.53 ms / 632.06 FPS (1 thread ) <br/> 2.24 ms / 868.87 FPS (2 threads)  | 2.0 ms                         | 3.2 M       | 8.7 M      |
+| S100     | YOLOv8s Detect  | 640×640        |        80 | 2.63 ms / 371.16 FPS (1 thread ) <br/> 4.41 ms / 446.48 FPS (2 threads)  | 2.0 ms                         | 11.2 M      | 28.6 M     |
+| S100     | YOLOv8m Detect  | 640×640        |        80 | 5.18 ms / 190.64 FPS (1 thread ) <br/> 9.45 ms / 209.80 FPS (2 threads)  | 2.0 ms                         | 25.9 M      | 78.9 M     |
+| S100     | YOLOv8l Detect  | 640×640        |        80 | 9.97 ms / 99.68 FPS (1 thread ) <br/> 19.00 ms / 104.65 FPS (2 threads)  | 2.0 ms                         | 43.7 M      | 165.2 M    |
+| S100     | YOLOv8x Detect  | 640×640        |        80 | 15.77 ms / 63.15 FPS (1 thread ) <br/> 30.53 ms / 65.20 FPS (2 threads)  | 2.0 ms                         | 68.2 M      | 257.8 M    |
+| S100     | YOLOv5nu Detect | 640×640        |        80 | 1.42 ms / 674.92 FPS (1 thread ) <br/> 2.02 ms / 959.05 FPS (2 threads)  | 2.0 ms                         | 2.6 M       | 7.7 M      |
+| S100     | YOLOv5su Detect | 640×640        |        80 | 2.31 ms / 420.83 FPS (1 thread ) <br/> 3.79 ms / 519.22 FPS (2 threads)  | 2.0 ms                         | 9.1 M       | 24.0 M     |
+| S100     | YOLOv5mu Detect | 640×640        |        80 | 4.50 ms / 218.77 FPS (1 thread ) <br/> 8.11 ms / 244.06 FPS (2 threads)  | 2.0 ms                         | 25.1 M      | 64.2 M     |
+| S100     | YOLOv5lu Detect | 640×640        |        80 | 8.96 ms / 110.78 FPS (1 thread ) <br/> 16.97 ms / 117.15 FPS (2 threads) | 2.0 ms                         | 53.2 M      | 135.0 M    |
+| S100     | YOLOv5xu Detect | 640×640        |        80 | 15.97 ms / 62.32 FPS (1 thread ) <br/> 30.90 ms / 64.41 FPS (2 threads)  | 2.0 ms                         | 97.2 M      | 246.4 M    |
+#### Instance Segmentation
+| Device   | Model       | Size(Pixels)   |   Classes | BPU Task Latency  /<br>BPU Throughput (Threads)                          | CPU Latency<br>(Single Core)   | params(M)   | FLOPs(B)   |
+|----------|-------------|----------------|-----------|--------------------------------------------------------------------------|--------------------------------|-------------|------------|
+| S100     | YOLO11n Seg | 640×640        |        80 | 2.06 ms / 463.93 FPS (1 thread ) <br/> 3.17 ms / 613.76 FPS (2 threads)  | 5.0 ms                         | 2.9 M       | 10.4 M     |
+| S100     | YOLO11s Seg | 640×640        |        80 | 3.34 ms / 291.16 FPS (1 thread ) <br/> 5.69 ms / 344.91 FPS (2 threads)  | 5.0 ms                         | 10.1 M      | 35.5 M     |
+| S100     | YOLO11m Seg | 640×640        |        80 | 7.86 ms / 125.63 FPS (1 thread ) <br/> 14.67 ms / 135.16 FPS (2 threads) | 5.0 ms                         | 22.4 M      | 123.3 M    |
+| S100     | YOLO11l Seg | 640×640        |        80 | 9.17 ms / 108.00 FPS (1 thread ) <br/> 17.29 ms / 114.67 FPS (2 threads) | 5.0 ms                         | 27.6 M      | 142.2 M    |
+| S100     | YOLO11x Seg | 640×640        |        80 | 17.74 ms / 56.07 FPS (1 thread ) <br/> 34.33 ms / 57.96 FPS (2 threads)  | 5.0 ms                         | 62.1 M      | 319.0 M    |
+| S100     | YOLOv9c Seg | 640×640        |        80 | 9.07 ms / 109.16 FPS (1 thread ) <br/> 17.12 ms / 115.80 FPS (2 threads) | 5.0 ms                         | 27.7 M      | 158.0 M    |
+| S100     | YOLOv9e Seg | 640×640        |        80 | 20.15 ms / 49.38 FPS (1 thread ) <br/> 39.07 ms / 50.91 FPS (2 threads)  | 5.0 ms                         | 59.7 M      | 244.8 M    |
+| S100     | YOLOv8n Seg | 640×640        |        80 | 1.93 ms / 495.35 FPS (1 thread ) <br/> 2.98 ms / 652.21 FPS (2 threads)  | 5.0 ms                         | 3.4 M       | 12.6 M     |
+| S100     | YOLOv8s Seg | 640×640        |        80 | 3.37 ms / 288.70 FPS (1 thread ) <br/> 5.76 ms / 341.12 FPS (2 threads)  | 5.0 ms                         | 11.8 M      | 42.6 M     |
+| S100     | YOLOv8m Seg | 640×640        |        80 | 6.65 ms / 148.28 FPS (1 thread ) <br/> 12.29 ms / 161.07 FPS (2 threads) | 5.0 ms                         | 27.3 M      | 100.2 M    |
+| S100     | YOLOv8l Seg | 640×640        |        80 | 12.21 ms / 81.34 FPS (1 thread ) <br/> 23.32 ms / 85.17 FPS (2 threads)  | 5.0 ms                         | 46.0 M      | 220.5 M    |
+| S100     | YOLOv8x Seg | 640×640        |        80 | 19.51 ms / 51.00 FPS (1 thread ) <br/> 37.80 ms / 52.62 FPS (2 threads)  | 5.0 ms                         | 71.8 M      | 344.1 M    |
+#### Pose Estimation
+| Device   | Model        | Size(Pixels)   |   Classes | BPU Task Latency  /<br>BPU Throughput (Threads)                          | CPU Latency<br>(Single Core)   | params(M)   | FLOPs(B)   |
+|----------|--------------|----------------|-----------|--------------------------------------------------------------------------|--------------------------------|-------------|------------|
+| S100     | YOLO11n Pose | 640×640        |        80 | 1.69 ms / 568.00 FPS (1 thread ) <br/> 2.48 ms / 780.47 FPS (2 threads)  | 1.0 ms                         | 2.9 M       | 7.6 M      |
+| S100     | YOLO11s Pose | 640×640        |        80 | 2.76 ms / 354.06 FPS (1 thread ) <br/> 4.62 ms / 424.92 FPS (2 threads)  | 1.0 ms                         | 9.9 M       | 23.2 M     |
+| S100     | YOLO11m Pose | 640×640        |        80 | 5.89 ms / 167.50 FPS (1 thread ) <br/> 10.79 ms / 183.34 FPS (2 threads) | 1.0 ms                         | 20.9 M      | 71.7 M     |
+| S100     | YOLO11l Pose | 640×640        |        80 | 7.23 ms / 136.91 FPS (1 thread ) <br/> 13.48 ms / 147.21 FPS (2 threads) | 1.0 ms                         | 26.2 M      | 90.7 M     |
+| S100     | YOLO11x Pose | 640×640        |        80 | 13.61 ms / 73.02 FPS (1 thread ) <br/> 26.16 ms / 76.04 FPS (2 threads)  | 1.0 ms                         | 58.8 M      | 203.3 M    |
+| S100     | YOLOv8n Pose | 640×640        |        80 | 1.62 ms / 587.59 FPS (1 thread ) <br/> 2.31 ms / 837.95 FPS (2 threads)  | 1.0 ms                         | 3.3 M       | 9.2 M      |
+| S100     | YOLOv8s Pose | 640×640        |        80 | 2.83 ms / 344.35 FPS (1 thread ) <br/> 4.71 ms / 417.72 FPS (2 threads)  | 1.0 ms                         | 11.6 M      | 30.2 M     |
+| S100     | YOLOv8m Pose | 640×640        |        80 | 5.47 ms / 180.46 FPS (1 thread ) <br/> 9.92 ms / 199.50 FPS (2 threads)  | 1.0 ms                         | 26.4 M      | 81.0 M     |
+| S100     | YOLOv8l Pose | 640×640        |        80 | 10.31 ms / 96.20 FPS (1 thread ) <br/> 19.55 ms / 101.60 FPS (2 threads) | 1.0 ms                         | 44.4 M      | 168.6 M    |
+| S100     | YOLOv8x Pose | 640×640        |        80 | 16.07 ms / 61.88 FPS (1 thread ) <br/> 31.01 ms / 64.14 FPS (2 threads)  | 1.0 ms                         | 69.4 M      | 263.2 M    |
+#### Image Classification
+| Device   | Model       | Size(Pixels)   |   Classes | BPU Task Latency  /<br>BPU Throughput (Threads)                                                                   | CPU Latency<br>(Single Core)   | params(M)   | FLOPs(B)   |
+|----------|-------------|----------------|-----------|-------------------------------------------------------------------------------------------------------------------|--------------------------------|-------------|------------|
+| S100     | YOLO11n CLS | 640×640        |        80 | 0.53 ms / 1827.92 FPS (1 thread ) <br/> 0.62 ms / 3115.65 FPS (2 threads) <br/> 0.70 ms / 4141.22 FPS (3 threads) | 0.5 ms                         | 2.8 M       | 4.2 M      |
+| S100     | YOLO11s CLS | 640×640        |        80 | 0.68 ms / 1415.98 FPS (1 thread ) <br/> 0.76 ms / 2553.99 FPS (2 threads) <br/> 1.05 ms / 2767.63 FPS (3 threads) | 0.5 ms                         | 6.7 M       | 13.0 M     |
+| S100     | YOLO11m CLS | 640×640        |        80 | 1.02 ms / 955.28 FPS (1 thread ) <br/> 1.35 ms / 1445.18 FPS (2 threads)                                          | 0.5 ms                         | 11.6 M      | 40.3 M     |
+| S100     | YOLO11l CLS | 640×640        |        80 | 1.21 ms / 805.52 FPS (1 thread ) <br/> 1.73 ms / 1139.48 FPS (2 threads)                                          | 0.5 ms                         | 14.1 M      | 50.4 M     |
+| S100     | YOLO11x CLS | 640×640        |        80 | 1.97 ms / 501.49 FPS (1 thread ) <br/> 3.23 ms / 612.29 FPS (2 threads)                                           | 0.5 ms                         | 29.6 M      | 111.3 M    |
+| S100     | YOLOv8n CLS | 640×640        |        80 | 0.49 ms / 1928.23 FPS (1 thread ) <br/> 0.57 ms / 3399.86 FPS (2 threads) <br/> 0.66 ms / 4410.92 FPS (3 threads) | 0.5 ms                         | 2.7 M       | 4.3 M      |
+| S100     | YOLOv8s CLS | 640×640        |        80 | 0.62 ms / 1562.83 FPS (1 thread ) <br/> 0.71 ms / 2712.53 FPS (2 threads) <br/> 0.89 ms / 3279.66 FPS (3 threads) | 0.5 ms                         | 6.4 M       | 13.5 M     |
+| S100     | YOLOv8m CLS | 640×640        |        80 | 1.00 ms / 970.04 FPS (1 thread ) <br/> 1.31 ms / 1500.86 FPS (2 threads)                                          | 0.5 ms                         | 17.0 M      | 42.7 M     |
+| S100     | YOLOv8l CLS | 640×640        |        80 | 1.98 ms / 497.58 FPS (1 thread ) <br/> 3.22 ms / 614.92 FPS (2 threads)                                           | 0.5 ms                         | 37.5 M      | 99.7 M     |
+| S100     | YOLOv8x CLS | 640×640        |        80 | 2.77 ms / 357.03 FPS (1 thread ) <br/> 4.81 ms / 412.60 FPS (2 threads)                                           | 0.5 ms                         | 57.4 M      | 154.8 M    |
+### RDK X5
+#### Obeject Detection
+| Device   | Model           | Size(Pixels)   |   Classes | BPU Task Latency  /<br>BPU Throughput (Threads)                          | CPU Latency<br>(Single Core)   | params(M)   | FLOPs(B)   |
+|----------|-----------------|----------------|-----------|--------------------------------------------------------------------------|--------------------------------|-------------|------------|
+| X5       | YOLO12n Detect  | 640×640        |        80 | 39.70 ms / 25.17 FPS (1 thread ) <br/> 73.19 ms / 27.24 FPS (2 threads)  | 5.0 ms                         | 2.6 M       | 7.7 M      |
+| X5       | YOLO12s Detect  | 640×640        |        80 | 63.74 ms / 15.68 FPS (1 thread ) <br/> 121.24 ms / 16.45 FPS (2 threads) | 5.0 ms                         | 9.3 M       | 21.4 M     |
+| X5       | YOLO12m Detect  | 640×640        |        80 | 103.02 ms / 9.70 FPS (1 thread ) <br/> 199.58 ms / 9.99 FPS (2 threads)  | 5.0 ms                         | 20.2 M      | 67.5 M     |
+| X5       | YOLO12l Detect  | 640×640        |        80 | 183.00 ms / 5.46 FPS (1 thread ) <br/> 359.03 ms / 5.56 FPS (2 threads)  | 5.0 ms                         | 26.4 M      | 88.9 M     |
+| X5       | YOLO12x Detect  | 640×640        |        80 | 315.16 ms / 3.17 FPS (1 thread )                                         | 5.0 ms                         | 59.1 M      | 199.0 M    |
+| X5       | YOLO11n Detect  | 640×640        |        80 | 8.25 ms / 121.05 FPS (1 thread ) <br/> 10.56 ms / 188.57 FPS (2 threads) | 5.0 ms                         | 2.6 M       | 6.5 M      |
+| X5       | YOLO11s Detect  | 640×640        |        80 | 15.81 ms / 63.16 FPS (1 thread ) <br/> 25.74 ms / 77.43 FPS (2 threads)  | 5.0 ms                         | 9.4 M       | 21.5 M     |
+| X5       | YOLO11m Detect  | 640×640        |        80 | 34.68 ms / 28.82 FPS (1 thread ) <br/> 63.30 ms / 31.51 FPS (2 threads)  | 5.0 ms                         | 20.1 M      | 68.0 M     |
+| X5       | YOLO11l Detect  | 640×640        |        80 | 45.23 ms / 22.10 FPS (1 thread ) <br/> 84.30 ms / 23.66 FPS (2 threads)  | 5.0 ms                         | 25.3 M      | 86.9 M     |
+| X5       | YOLO11x Detect  | 640×640        |        80 | 96.70 ms / 10.34 FPS (1 thread ) <br/> 186.76 ms / 10.68 FPS (2 threads) | 5.0 ms                         | 56.9 M      | 194.9 M    |
+| X5       | YOLOv10n Detect | 640×640        |        80 | 8.75 ms / 114.19 FPS (1 thread ) <br/> 11.60 ms / 171.72 FPS (2 threads) | 5.0 ms                         | 2.3 M       | 6.7 M      |
+| X5       | YOLOv10s Detect | 640×640        |        80 | 14.84 ms / 67.32 FPS (1 thread ) <br/> 23.85 ms / 83.58 FPS (2 threads)  | 5.0 ms                         | 7.2 M       | 21.6 M     |
+| X5       | YOLOv10m Detect | 640×640        |        80 | 29.40 ms / 33.99 FPS (1 thread ) <br/> 52.83 ms / 37.75 FPS (2 threads)  | 5.0 ms                         | 15.4 M      | 59.1 M     |
+| X5       | YOLOv10b Detect | 640×640        |        80 | 40.14 ms / 24.90 FPS (1 thread ) <br/> 74.20 ms / 26.88 FPS (2 threads)  | 5.0 ms                         | 19.1 M      | 92.0 M     |
+| X5       | YOLOv10l Detect | 640×640        |        80 | 49.89 ms / 20.04 FPS (1 thread ) <br/> 93.66 ms / 21.30 FPS (2 threads)  | 5.0 ms                         | 24.4 M      | 120.3 M    |
+| X5       | YOLOv10x Detect | 640×640        |        80 | 68.92 ms / 14.51 FPS (1 thread ) <br/> 131.54 ms / 15.16 FPS (2 threads) | 5.0 ms                         | 29.5 M      | 160.4 M    |
+| X5       | YOLOv9t Detect  | 640×640        |        80 | 6.97 ms / 143.14 FPS (1 thread ) <br/> 7.96 ms / 250.11 FPS (2 threads)  | 5.0 ms                         | 2.1 M       | 8.2 M      |
+| X5       | YOLOv9s Detect  | 640×640        |        80 | 13.00 ms / 76.81 FPS (1 thread ) <br/> 20.16 ms / 98.81 FPS (2 threads)  | 5.0 ms                         | 7.2 M       | 26.9 M     |
+| X5       | YOLOv9m Detect  | 640×640        |        80 | 32.63 ms / 30.63 FPS (1 thread ) <br/> 59.31 ms / 33.62 FPS (2 threads)  | 5.0 ms                         | 20.1 M      | 76.8 M     |
+| X5       | YOLOv9c Detect  | 640×640        |        80 | 40.46 ms / 24.71 FPS (1 thread ) <br/> 74.77 ms / 26.67 FPS (2 threads)  | 5.0 ms                         | 25.3 M      | 102.7 M    |
+| X5       | YOLOv9e Detect  | 640×640        |        80 | 119.80 ms / 8.35 FPS (1 thread ) <br/> 233.08 ms / 8.56 FPS (2 threads)  | 5.0 ms                         | 57.4 M      | 189.5 M    |
+| X5       | YOLOv8n Detect  | 640×640        |        80 | 7.00 ms / 142.60 FPS (1 thread ) <br/> 8.06 ms / 246.82 FPS (2 threads)  | 5.0 ms                         | 3.2 M       | 8.7 M      |
+| X5       | YOLOv8s Detect  | 640×640        |        80 | 13.63 ms / 73.30 FPS (1 thread ) <br/> 21.38 ms / 93.20 FPS (2 threads)  | 5.0 ms                         | 11.2 M      | 28.6 M     |
+| X5       | YOLOv8m Detect  | 640×640        |        80 | 30.74 ms / 32.51 FPS (1 thread ) <br/> 55.51 ms / 35.93 FPS (2 threads)  | 5.0 ms                         | 25.9 M      | 78.9 M     |
+| X5       | YOLOv8l Detect  | 640×640        |        80 | 59.51 ms / 16.80 FPS (1 thread ) <br/> 112.80 ms / 17.68 FPS (2 threads) | 5.0 ms                         | 43.7 M      | 165.2 M    |
+| X5       | YOLOv8x Detect  | 640×640        |        80 | 92.72 ms / 10.78 FPS (1 thread ) <br/> 178.95 ms / 11.15 FPS (2 threads) | 5.0 ms                         | 68.2 M      | 257.8 M    |
+| X5       | YOLOv5nu Detect | 640×640        |        80 | 6.33 ms / 157.59 FPS (1 thread ) <br/> 6.80 ms / 291.89 FPS (2 threads)  | 5.0 ms                         | 2.6 M       | 7.7 M      |
+| X5       | YOLOv5su Detect | 640×640        |        80 | 12.33 ms / 81.04 FPS (1 thread ) <br/> 18.88 ms / 105.56 FPS (2 threads) | 5.0 ms                         | 9.1 M       | 24.0 M     |
+| X5       | YOLOv5mu Detect | 640×640        |        80 | 26.57 ms / 37.62 FPS (1 thread ) <br/> 47.20 ms / 42.24 FPS (2 threads)  | 5.0 ms                         | 25.1 M      | 64.2 M     |
+| X5       | YOLOv5lu Detect | 640×640        |        80 | 52.83 ms / 18.92 FPS (1 thread ) <br/> 99.42 ms / 20.06 FPS (2 threads)  | 5.0 ms                         | 53.2 M      | 135.0 M    |
+| X5       | YOLOv5xu Detect | 640×640        |        80 | 91.55 ms / 10.92 FPS (1 thread ) <br/> 176.49 ms / 11.30 FPS (2 threads) | 5.0 ms                         | 97.2 M      | 246.4 M    |
+#### Instance Segmentation
+| Device   | Model       | Size(Pixels)   |   Classes | BPU Task Latency  /<br>BPU Throughput (Threads)                          | CPU Latency<br>(Single Core)   | params(M)   | FLOPs(B)   |
+|----------|-------------|----------------|-----------|--------------------------------------------------------------------------|--------------------------------|-------------|------------|
+| X5       | YOLO11n Seg | 640×640        |        80 | 11.55 ms / 86.39 FPS (1 thread ) <br/> 12.83 ms / 155.10 FPS (2 threads) | 20.0 ms                        | 2.9 M       | 10.4 M     |
+| X5       | YOLO11s Seg | 640×640        |        80 | 21.62 ms / 46.22 FPS (1 thread ) <br/> 33.12 ms / 60.20 FPS (2 threads)  | 20.0 ms                        | 10.1 M      | 35.5 M     |
+| X5       | YOLO11m Seg | 640×640        |        80 | 50.43 ms / 19.82 FPS (1 thread ) <br/> 90.49 ms / 22.04 FPS (2 threads)  | 20.0 ms                        | 22.4 M      | 123.3 M    |
+| X5       | YOLO11l Seg | 640×640        |        80 | 60.60 ms / 16.50 FPS (1 thread ) <br/> 110.99 ms / 17.97 FPS (2 threads) | 20.0 ms                        | 27.6 M      | 142.2 M    |
+| X5       | YOLO11x Seg | 640×640        |        80 | 130.40 ms / 7.67 FPS (1 thread ) <br/> 249.71 ms / 7.99 FPS (2 threads)  | 20.0 ms                        | 62.1 M      | 319.0 M    |
+| X5       | YOLOv9c Seg | 640×640        |        80 | 55.85 ms / 17.90 FPS (1 thread ) <br/> 101.47 ms / 19.65 FPS (2 threads) | 20.0 ms                        | 27.7 M      | 158.0 M    |
+| X5       | YOLOv9e Seg | 640×640        |        80 | 135.34 ms / 7.39 FPS (1 thread ) <br/> 260.08 ms / 7.67 FPS (2 threads)  | 20.0 ms                        | 59.7 M      | 244.8 M    |
+| X5       | YOLOv8n Seg | 640×640        |        80 | 10.40 ms / 96.02 FPS (1 thread ) <br/> 10.75 ms / 185.21 FPS (2 threads) | 20.0 ms                        | 3.4 M       | 12.6 M     |
+| X5       | YOLOv8s Seg | 640×640        |        80 | 19.56 ms / 51.08 FPS (1 thread ) <br/> 28.99 ms / 68.76 FPS (2 threads)  | 20.0 ms                        | 11.8 M      | 42.6 M     |
+| X5       | YOLOv8m Seg | 640×640        |        80 | 40.52 ms / 24.67 FPS (1 thread ) <br/> 70.70 ms / 28.21 FPS (2 threads)  | 20.0 ms                        | 27.3 M      | 100.2 M    |
+| X5       | YOLOv8l Seg | 640×640        |        80 | 75.00 ms / 13.33 FPS (1 thread ) <br/> 139.61 ms / 14.29 FPS (2 threads) | 20.0 ms                        | 46.0 M      | 220.5 M    |
+| X5       | YOLOv8x Seg | 640×640        |        80 | 115.94 ms / 8.62 FPS (1 thread ) <br/> 221.06 ms / 9.02 FPS (2 threads)  | 20.0 ms                        | 71.8 M      | 344.1 M    |
+#### Pose Estimation
+| Device   | Model        | Size(Pixels)   |   Classes | BPU Task Latency  /<br>BPU Throughput (Threads)                          | CPU Latency<br>(Single Core)   | params(M)   | FLOPs(B)   |
+|----------|--------------|----------------|-----------|--------------------------------------------------------------------------|--------------------------------|-------------|------------|
+| X5       | YOLO11n Pose | 640×640        |        80 | 8.36 ms / 119.43 FPS (1 thread ) <br/> 10.97 ms / 181.61 FPS (2 threads) | 10.0 ms                        | 2.9 M       | 7.6 M      |
+| X5       | YOLO11s Pose | 640×640        |        80 | 16.35 ms / 61.11 FPS (1 thread ) <br/> 26.99 ms / 73.85 FPS (2 threads)  | 10.0 ms                        | 9.9 M       | 23.2 M     |
+| X5       | YOLO11m Pose | 640×640        |        80 | 35.74 ms / 27.97 FPS (1 thread ) <br/> 65.60 ms / 30.40 FPS (2 threads)  | 10.0 ms                        | 20.9 M      | 71.7 M     |
+| X5       | YOLO11l Pose | 640×640        |        80 | 46.38 ms / 21.55 FPS (1 thread ) <br/> 86.82 ms / 22.97 FPS (2 threads)  | 10.0 ms                        | 26.2 M      | 90.7 M     |
+| X5       | YOLO11x Pose | 640×640        |        80 | 98.88 ms / 10.11 FPS (1 thread ) <br/> 191.38 ms / 10.42 FPS (2 threads) | 10.0 ms                        | 58.8 M      | 203.3 M    |
+| X5       | YOLOv8n Pose | 640×640        |        80 | 6.95 ms / 143.64 FPS (1 thread ) <br/> 8.23 ms / 241.76 FPS (2 threads)  | 10.0 ms                        | 3.3 M       | 9.2 M      |
+| X5       | YOLOv8s Pose | 640×640        |        80 | 14.16 ms / 70.54 FPS (1 thread ) <br/> 22.62 ms / 88.09 FPS (2 threads)  | 10.0 ms                        | 11.6 M      | 30.2 M     |
+| X5       | YOLOv8m Pose | 640×640        |        80 | 31.60 ms / 31.62 FPS (1 thread ) <br/> 57.34 ms / 34.78 FPS (2 threads)  | 10.0 ms                        | 26.4 M      | 81.0 M     |
+| X5       | YOLOv8l Pose | 640×640        |        80 | 60.37 ms / 16.56 FPS (1 thread ) <br/> 114.73 ms / 17.38 FPS (2 threads) | 10.0 ms                        | 44.4 M      | 168.6 M    |
+| X5       | YOLOv8x Pose | 640×640        |        80 | 94.15 ms / 10.62 FPS (1 thread ) <br/> 182.08 ms / 10.96 FPS (2 threads) | 10.0 ms                        | 69.4 M      | 263.2 M    |
+#### Image Classification
+| Device   | Model       | Size(Pixels)   |   Classes | BPU Task Latency  /<br>BPU Throughput (Threads)                           | CPU Latency<br>(Single Core)   | params(M)   | FLOPs(B)   |
+|----------|-------------|----------------|-----------|---------------------------------------------------------------------------|--------------------------------|-------------|------------|
+| X5       | YOLO11n CLS | 640×640        |        80 | 1.06 ms / 939.95 FPS (1 thread ) <br/> 1.61 ms / 1236.07 FPS (2 threads)  | 0.5 ms                         | 2.8 M       | 4.2 M      |
+| X5       | YOLO11s CLS | 640×640        |        80 | 2.01 ms / 495.14 FPS (1 thread ) <br/> 3.49 ms / 569.44 FPS (2 threads)   | 0.5 ms                         | 6.7 M       | 13.0 M     |
+| X5       | YOLO11m CLS | 640×640        |        80 | 3.82 ms / 261.13 FPS (1 thread ) <br/> 7.09 ms / 280.82 FPS (2 threads)   | 0.5 ms                         | 11.6 M      | 40.3 M     |
+| X5       | YOLO11l CLS | 640×640        |        80 | 5.02 ms / 199.15 FPS (1 thread ) <br/> 9.49 ms / 210.12 FPS (2 threads)   | 0.5 ms                         | 14.1 M      | 50.4 M     |
+| X5       | YOLO11x CLS | 640×640        |        80 | 10.04 ms / 99.49 FPS (1 thread ) <br/> 19.48 ms / 102.39 FPS (2 threads)  | 0.5 ms                         | 29.6 M      | 111.3 M    |
+| X5       | YOLOv8n CLS | 640×640        |        80 | 0.74 ms / 1348.98 FPS (1 thread ) <br/> 0.98 ms / 2018.94 FPS (2 threads) | 0.5 ms                         | 2.7 M       | 4.3 M      |
+| X5       | YOLOv8s CLS | 640×640        |        80 | 1.44 ms / 690.86 FPS (1 thread ) <br/> 2.36 ms / 842.52 FPS (2 threads)   | 0.5 ms                         | 6.4 M       | 13.5 M     |
+| X5       | YOLOv8m CLS | 640×640        |        80 | 3.66 ms / 272.72 FPS (1 thread ) <br/> 6.78 ms / 294.01 FPS (2 threads)   | 0.5 ms                         | 17.0 M      | 42.7 M     |
+| X5       | YOLOv8l CLS | 640×640        |        80 | 7.98 ms / 125.23 FPS (1 thread ) <br/> 15.38 ms / 129.63 FPS (2 threads)  | 0.5 ms                         | 37.5 M      | 99.7 M     |
+| X5       | YOLOv8x CLS | 640×640        |        80 | 13.12 ms / 76.18 FPS (1 thread ) <br/> 25.64 ms / 77.78 FPS (2 threads)   | 0.5 ms                         | 57.4 M      | 154.8 M    |
+
 ## Accuracy
+### RDK S600
+#### Obeject Detection
+| Device   | Model           | Accuracy bbox-all mAP@.50:.95 <br/> FP32 / BPU Python   | Accuracy bbox-small mAP@.50:.95 <br/> FP32 / BPU Python   | Accuracy bbox-medium mAP@.50:.95 <br/> FP32 / BPU Python   | Accuracy bbox-large mAP@.50:.95 <br/> FP32 / BPU Python   |
+|----------|-----------------|---------------------------------------------------------|-----------------------------------------------------------|------------------------------------------------------------|-----------------------------------------------------------|
+| S600     | YOLO12n Detect  | 0.338 / 0.320 (94.7 %)                                  | 0.128 / 0.104 (81.3 %)                                    | 0.374 / 0.350 (93.6 %)                                     | 0.524 / 0.514 (98.1 %)                                    |
+| S600     | YOLO12s Detect  | 0.403 / 0.385 (95.5 %)                                  | 0.201 / 0.158 (78.6 %)                                    | 0.450 / 0.436 (96.9 %)                                     | 0.602 / 0.586 (97.3 %)                                    |
+| S600     | YOLO12m Detect  | 0.452 / 0.436 (96.5 %)                                  | 0.251 / 0.228 (90.8 %)                                    | 0.509 / 0.497 (97.6 %)                                     | 0.638 / 0.626 (98.1 %)                                    |
+| S600     | YOLO12l Detect  | 0.463 / 0.441 (95.2 %)                                  | 0.268 / 0.226 (84.3 %)                                    | 0.522 / 0.505 (96.7 %)                                     | 0.646 / 0.640 (99.1 %)                                    |
+| S600     | YOLO12x Detect  | 0.475 / 0.455 (95.8 %)                                  | 0.276 / 0.238 (86.2 %)                                    | 0.536 / 0.527 (98.3 %)                                     | 0.659 / 0.618 (93.8 %)                                    |
+| S600     | YOLO11s Detect  | 0.400 / 0.382 (95.5 %)                                  | 0.198 / 0.165 (83.3 %)                                    | 0.445 / 0.430 (96.6 %)                                     | 0.587 / 0.586 (99.8 %)                                    |
+| S600     | YOLO11m Detect  | 0.444 / 0.429 (96.6 %)                                  | 0.247 / 0.220 (89.1 %)                                    | 0.497 / 0.488 (98.2 %)                                     | 0.627 / 0.610 (97.3 %)                                    |
+| S600     | YOLO11l Detect  | 0.460 / 0.448 (97.4 %)                                  | 0.267 / 0.238 (89.1 %)                                    | 0.520 / 0.514 (98.8 %)                                     | 0.638 / 0.622 (97.5 %)                                    |
+| S600     | YOLO11x Detect  | 0.474 / 0.457 (96.4 %)                                  | 0.283 / 0.244 (86.2 %)                                    | 0.529 / 0.517 (97.7 %)                                     | 0.652 / 0.639 (98.0 %)                                    |
+| S600     | YOLOv10n Detect | 0.303 / 0.285 (94.1 %)                                  | 0.099 / 0.075 (75.8 %)                                    | 0.330 / 0.306 (92.7 %)                                     | 0.478 / 0.469 (98.1 %)                                    |
+| S600     | YOLOv10s Detect | 0.386 / 0.363 (94.0 %)                                  | 0.175 / 0.144 (82.3 %)                                    | 0.434 / 0.410 (94.5 %)                                     | 0.574 / 0.528 (92.0 %)                                    |
+| S600     | YOLOv10m Detect | 0.425 / 0.389 (91.5 %)                                  | 0.221 / 0.202 (91.4 %)                                    | 0.481 / 0.450 (93.6 %)                                     | 0.603 / 0.505 (83.7 %)                                    |
+| S600     | YOLOv10b Detect | 0.443 / 0.388 (87.6 %)                                  | 0.242 / 0.189 (78.1 %)                                    | 0.498 / 0.447 (89.8 %)                                     | 0.618 / 0.496 (80.3 %)                                    |
+| S600     | YOLOv10l Detect | 0.445 / 0.392 (88.1 %)                                  | 0.258 / 0.215 (83.3 %)                                    | 0.498 / 0.463 (93.0 %)                                     | 0.626 / 0.492 (78.6 %)                                    |
+| S600     | YOLOv10x Detect | 0.459 / 0.424 (92.4 %)                                  | 0.258 / 0.228 (88.4 %)                                    | 0.518 / 0.490 (94.6 %)                                     | 0.639 / 0.546 (85.4 %)                                    |
+| S600     | YOLOv9s Detect  | 0.400 / 0.387 (96.8 %)                                  | 0.191 / 0.169 (88.5 %)                                    | 0.444 / 0.433 (97.5 %)                                     | 0.583 / 0.564 (96.7 %)                                    |
+| S600     | YOLOv9m Detect  | 0.449 / 0.441 (98.2 %)                                  | 0.253 / 0.232 (91.7 %)                                    | 0.504 / 0.496 (98.4 %)                                     | 0.617 / 0.611 (99.0 %)                                    |
+| S600     | YOLOv9c Detect  | 0.461 / 0.451 (97.8 %)                                  | 0.269 / 0.251 (93.3 %)                                    | 0.512 / 0.509 (99.4 %)                                     | 0.640 / 0.612 (95.6 %)                                    |
+| S600     | YOLOv9e Detect  | 0.481 / 0.470 (97.7 %)                                  | 0.298 / 0.273 (91.6 %)                                    | 0.538 / 0.525 (97.6 %)                                     | 0.662 / 0.650 (98.2 %)                                    |
+| S600     | YOLOv8s Detect  | 0.391 / 0.376 (96.2 %)                                  | 0.195 / 0.169 (86.7 %)                                    | 0.437 / 0.423 (96.8 %)                                     | 0.566 / 0.558 (98.6 %)                                    |
+| S600     | YOLOv8m Detect  | 0.441 / 0.429 (97.3 %)                                  | 0.249 / 0.222 (89.2 %)                                    | 0.494 / 0.486 (98.4 %)                                     | 0.618 / 0.607 (98.2 %)                                    |
+| S600     | YOLOv8l Detect  | 0.461 / 0.448 (97.2 %)                                  | 0.271 / 0.245 (90.4 %)                                    | 0.516 / 0.505 (97.9 %)                                     | 0.651 / 0.642 (98.6 %)                                    |
+| S600     | YOLOv8x Detect  | 0.474 / 0.459 (96.8 %)                                  | 0.280 / 0.253 (90.4 %)                                    | 0.527 / 0.516 (97.9 %)                                     | 0.658 / 0.647 (98.3 %)                                    |
+| S600     | YOLOv5nu Detect | 0.278 / 0.269 (96.8 %)                                  | 0.093 / 0.083 (89.2 %)                                    | 0.309 / 0.296 (95.8 %)                                     | 0.417 / 0.412 (98.8 %)                                    |
+| S600     | YOLOv5su Detect | 0.367 / 0.355 (96.7 %)                                  | 0.169 / 0.140 (82.8 %)                                    | 0.416 / 0.406 (97.6 %)                                     | 0.530 / 0.531 (100.2 %)                                   |
+| S600     | YOLOv5mu Detect | 0.425 / 0.415 (97.6 %)                                  | 0.226 / 0.207 (91.6 %)                                    | 0.477 / 0.470 (98.5 %)                                     | 0.603 / 0.604 (100.2 %)                                   |
+| S600     | YOLOv5lu Detect | 0.458 / 0.451 (98.5 %)                                  | 0.260 / 0.238 (91.5 %)                                    | 0.516 / 0.511 (99.0 %)                                     | 0.641 / 0.637 (99.4 %)                                    |
+| S600     | YOLOv5xu Detect | 0.466 / 0.454 (97.4 %)                                  | 0.281 / 0.246 (87.5 %)                                    | 0.523 / 0.517 (98.9 %)                                     | 0.645 / 0.647 (100.3 %)                                   |
+
+#### Instance Segmentation
+##### bbox
+| Device   | Model       | Accuracy bbox-all mAP@.50:.95 <br/> FP32 / BPU Python   | Accuracy bbox-small mAP@.50:.95 <br/> FP32 / BPU Python   | Accuracy bbox-medium mAP@.50:.95 <br/> FP32 / BPU Python   | Accuracy bbox-large mAP@.50:.95 <br/> FP32 / BPU Python   |
+|----------|-------------|---------------------------------------------------------|-----------------------------------------------------------|------------------------------------------------------------|-----------------------------------------------------------|
+| S600     | YOLO11s Seg | 0.394 / 0.383 (97.2 %)                                  | 0.184 / 0.162 (88.0 %)                                    | 0.442 / 0.434 (98.2 %)                                     | 0.582 / 0.581 (99.8 %)                                    |
+| S600     | YOLO11m Seg | 0.443 / 0.427 (96.4 %)                                  | 0.246 / 0.224 (91.1 %)                                    | 0.497 / 0.484 (97.4 %)                                     | 0.627 / 0.607 (96.8 %)                                    |
+| S600     | YOLO11l Seg | 0.460 / 0.443 (96.3 %)                                  | 0.267 / 0.236 (88.4 %)                                    | 0.520 / 0.508 (97.7 %)                                     | 0.638 / 0.614 (96.2 %)                                    |
+| S600     | YOLO11x Seg | 0.474 / 0.456 (96.2 %)                                  | 0.283 / 0.244 (86.2 %)                                    | 0.529 / 0.515 (97.4 %)                                     | 0.652 / 0.636 (97.5 %)                                    |
+| S600     | YOLOv8s Seg | 0.386 / 0.375 (97.2 %)                                  | 0.180 / 0.162 (90.0 %)                                    | 0.432 / 0.419 (97.0 %)                                     | 0.564 / 0.560 (99.3 %)                                    |
+| S600     | YOLOv8m Seg | 0.431 / 0.420 (97.4 %)                                  | 0.228 / 0.209 (91.7 %)                                    | 0.486 / 0.478 (98.4 %)                                     | 0.608 / 0.605 (99.5 %)                                    |
+| S600     | YOLOv8l Seg | 0.453 / 0.435 (96.0 %)                                  | 0.258 / 0.223 (86.4 %)                                    | 0.502 / 0.496 (98.8 %)                                     | 0.626 / 0.611 (97.6 %)                                    |
+| S600     | YOLOv8x Seg | 0.465 / 0.454 (97.6 %)                                  | 0.268 / 0.236 (88.1 %)                                    | 0.520 / 0.514 (98.8 %)                                     | 0.641 / 0.633 (98.8 %)                                    |
+
+##### mask
+| Device   | Model       | Accuracy mask-all mAP@.50:.95 <br/> FP32 / BPU Python   | Accuracy mask-small mAP@.50:.95 <br/> FP32 / BPU Python   | Accuracy mask-medium mAP@.50:.95 <br/> FP32 / BPU Python   | Accuracy mask-large mAP@.50:.95 <br/> FP32 / BPU Python   |
+|----------|-------------|---------------------------------------------------------|-----------------------------------------------------------|------------------------------------------------------------|-----------------------------------------------------------|
+| S600     | YOLO11s Seg | 0.311 / 0.295 (94.9 %)                                  | 0.099 / 0.088 (88.9 %)                                    | 0.350 / 0.327 (93.4 %)                                     | 0.509 / 0.486 (95.5 %)                                    |
+| S600     | YOLO11m Seg | 0.347 / 0.322 (92.8 %)                                  | 0.136 / 0.123 (90.4 %)                                    | 0.396 / 0.362 (91.4 %)                                     | 0.549 / 0.506 (92.2 %)                                    |
+| S600     | YOLO11l Seg | 0.357 / 0.331 (92.7 %)                                  | 0.143 / 0.126 (88.1 %)                                    | 0.409 / 0.377 (92.2 %)                                     | 0.560 / 0.511 (91.3 %)                                    |
+| S600     | YOLO11x Seg | 0.366 / 0.339 (92.6 %)                                  | 0.149 / 0.124 (83.2 %)                                    | 0.420 / 0.384 (91.4 %)                                     | 0.572 / 0.529 (92.5 %)                                    |
+| S600     | YOLOv8s Seg | 0.305 / 0.290 (95.1 %)                                  | 0.096 / 0.085 (88.5 %)                                    | 0.343 / 0.317 (92.4 %)                                     | 0.496 / 0.476 (96.0 %)                                    |
+| S600     | YOLOv8m Seg | 0.337 / 0.319 (94.7 %)                                  | 0.121 / 0.109 (90.1 %)                                    | 0.386 / 0.360 (93.3 %)                                     | 0.533 / 0.506 (94.9 %)                                    |
+| S600     | YOLOv8l Seg | 0.351 / 0.331 (94.3 %)                                  | 0.137 / 0.119 (86.9 %)                                    | 0.398 / 0.374 (94.0 %)                                     | 0.550 / 0.516 (93.8 %)                                    |
+| S600     | YOLOv8x Seg | 0.358 / 0.338 (94.4 %)                                  | 0.139 / 0.122 (87.8 %)                                    | 0.409 / 0.382 (93.4 %)                                     | 0.562 / 0.529 (94.1 %)                                    |
+
+#### Pose Estimation
+| Device   | Model        | Accuracy pose-all mAP@.50:.95 <br/> FP32 / BPU Python   | Accuracy pose-medium mAP@.50:.95 <br/> FP32 / BPU Python   | Accuracy pose-large mAP@.50:.95 <br/> FP32 / BPU Python   |
+|----------|--------------|---------------------------------------------------------|------------------------------------------------------------|-----------------------------------------------------------|
+| S600     | YOLO11n Pose | 0.465 / 0.448 (96.3 %)                                  | 0.386 / 0.374 (96.9 %)                                     | 0.597 / 0.572 (95.8 %)                                    |
+| S600     | YOLO11s Pose | 0.559 / 0.541 (96.8 %)                                  | 0.495 / 0.476 (96.2 %)                                     | 0.672 / 0.648 (96.4 %)                                    |
+| S600     | YOLO11m Pose | 0.627 / 0.605 (96.5 %)                                  | 0.586 / 0.566 (96.6 %)                                     | 0.711 / 0.688 (96.8 %)                                    |
+| S600     | YOLO11l Pose | 0.636 / 0.617 (97.0 %)                                  | 0.592 / 0.568 (95.9 %)                                     | 0.726 / 0.707 (97.4 %)                                    |
+| S600     | YOLO11x Pose | 0.672 / 0.651 (96.9 %)                                  | 0.634 / 0.610 (96.2 %)                                     | 0.750 / 0.731 (97.5 %)                                    |
+| S600     | YOLOv8n Pose | 0.476 / 0.461 (96.8 %)                                  | 0.391 / 0.373 (95.4 %)                                     | 0.610 / 0.593 (97.2 %)                                    |
+| S600     | YOLOv8s Pose | 0.578 / 0.552 (95.5 %)                                  | 0.510 / 0.486 (95.3 %)                                     | 0.692 / 0.667 (96.4 %)                                    |
+| S600     | YOLOv8m Pose | 0.630 / 0.605 (96.0 %)                                  | 0.578 / 0.552 (95.5 %)                                     | 0.724 / 0.703 (97.1 %)                                    |
+| S600     | YOLOv8l Pose | 0.657 / 0.633 (96.3 %)                                  | 0.607 / 0.581 (95.7 %)                                     | 0.747 / 0.719 (96.3 %)                                    |
+| S600     | YOLOv8x Pose | 0.671 / 0.651 (97.0 %)                                  | 0.624 / 0.603 (96.6 %)                                     | 0.757 / 0.739 (97.6 %)                                    |
+
+#### Image Classification
+| Device   | Model       | Accuracy TOP1 <br/> FP32 / BPU Python   | Accuracy TOP5 <br/> FP32 / BPU Python   |
+|----------|-------------|-----------------------------------------|-----------------------------------------|
+| S600     | YOLO11n CLS | 0.700 / 0.556 (79.4 %)                  | 0.894 / 0.794 (88.9 %)                  |
+| S600     | YOLO11s CLS | 0.754 / 0.666 (88.3 %)                  | 0.927 / 0.875 (94.3 %)                  |
+| S600     | YOLO11m CLS | 0.773 / 0.700 (90.5 %)                  | 0.939 / 0.897 (95.5 %)                  |
+| S600     | YOLO11l CLS | 0.783 / 0.718 (91.7 %)                  | 0.942 / 0.908 (96.4 %)                  |
+| S600     | YOLO11x CLS | 0.795 / 0.731 (92.0 %)                  | 0.949 / 0.917 (96.6 %)                  |
+| S600     | YOLOv8n CLS | 0.689 / 0.571 (82.9 %)                  | 0.883 / 0.803 (90.9 %)                  |
+| S600     | YOLOv8s CLS | 0.737 / 0.626 (84.9 %)                  | 0.917 / 0.844 (92.0 %)                  |
+| S600     | YOLOv8m CLS | 0.768 / 0.700 (91.1 %)                  | 0.935 / 0.899 (96.1 %)                  |
+| S600     | YOLOv8l CLS | 0.783 / 0.723 (92.3 %)                  | 0.942 / 0.909 (96.5 %)                  |
+| S600     | YOLOv8x CLS | 0.790 / 0.737 (93.3 %)                  | 0.945 / 0.920 (97.4 %)                  |
+### RDK S100P
 #### Obeject Detection
 | Device   | Model           | Accuracy bbox-all mAP@.50:.95 <br/> FP32 / BPU Python   | Accuracy bbox-small mAP@.50:.95 <br/> FP32 / BPU Python   | Accuracy bbox-medium mAP@.50:.95 <br/> FP32 / BPU Python   | Accuracy bbox-large mAP@.50:.95 <br/> FP32 / BPU Python   |
 |----------|-----------------|---------------------------------------------------------|-----------------------------------------------------------|------------------------------------------------------------|-----------------------------------------------------------|
@@ -239,84 +534,8 @@ Accuracy pose-large mAP@.50:.95: Average Precision (AP) @[ IoU=0.50:0.95 area=la
 | S100P    | YOLOv8m CLS | 0.768 / 0.703 (91.6 %)                  | 0.935 / 0.899 (96.2 %)                  |
 | S100P    | YOLOv8l CLS | 0.783 / 0.723 (92.3 %)                  | 0.942 / 0.910 (96.6 %)                  |
 | S100P    | YOLOv8x CLS | 0.790 / 0.742 (93.9 %)                  | 0.945 / 0.923 (97.6 %)                  |
-## Performance
+
 ### RDK S100
-#### Obeject Detection
-| Device   | Model           | Size(Pixels)   |   Classes | BPU Task Latency  /<br>BPU Throughput (Threads)                          | CPU Latency<br>(Single Core)   | params(M)   | FLOPs(B)   |
-|----------|-----------------|----------------|-----------|--------------------------------------------------------------------------|--------------------------------|-------------|------------|
-| S100     | YOLO12n Detect  | 640×640        |        80 | 2.65 ms / 368.54 FPS (1 thread ) <br/> 4.43 ms / 443.33 FPS (2 threads)  | 2.0 ms                         | 2.6 M       | 7.7 M      |
-| S100     | YOLO12s Detect  | 640×640        |        80 | 4.48 ms / 220.08 FPS (1 thread ) <br/> 8.10 ms / 244.66 FPS (2 threads)  | 2.0 ms                         | 9.3 M       | 21.4 M     |
-| S100     | YOLO12m Detect  | 640×640        |        80 | 9.27 ms / 107.09 FPS (1 thread ) <br/> 17.56 ms / 113.12 FPS (2 threads) | 2.0 ms                         | 20.2 M      | 67.5 M     |
-| S100     | YOLO12l Detect  | 640×640        |        80 | 14.66 ms / 67.85 FPS (1 thread ) <br/> 28.30 ms / 70.28 FPS (2 threads)  | 2.0 ms                         | 26.4 M      | 88.9 M     |
-| S100     | YOLO12x Detect  | 640×640        |        80 | 24.72 ms / 40.33 FPS (1 thread ) <br/> 48.27 ms / 41.26 FPS (2 threads)  | 2.0 ms                         | 59.1 M      | 199.0 M    |
-| S100     | YOLO11n Detect  | 640×640        |        80 | 1.62 ms / 596.53 FPS (1 thread ) <br/> 2.39 ms / 813.87 FPS (2 threads)  | 2.0 ms                         | 2.6 M       | 6.5 M      |
-| S100     | YOLO11s Detect  | 640×640        |        80 | 2.63 ms / 371.42 FPS (1 thread ) <br/> 4.39 ms / 448.18 FPS (2 threads)  | 2.0 ms                         | 9.4 M       | 21.5 M     |
-| S100     | YOLO11m Detect  | 640×640        |        80 | 5.63 ms / 175.69 FPS (1 thread ) <br/> 10.35 ms / 191.62 FPS (2 threads) | 2.0 ms                         | 20.1 M      | 68.0 M     |
-| S100     | YOLO11l Detect  | 640×640        |        80 | 6.96 ms / 142.36 FPS (1 thread ) <br/> 13.02 ms / 152.41 FPS (2 threads) | 2.0 ms                         | 25.3 M      | 86.9 M     |
-| S100     | YOLO11x Detect  | 640×640        |        80 | 13.13 ms / 75.78 FPS (1 thread ) <br/> 25.24 ms / 78.82 FPS (2 threads)  | 2.0 ms                         | 56.9 M      | 194.9 M    |
-| S100     | YOLOv10n Detect | 640×640        |        80 | 1.58 ms / 608.94 FPS (1 thread ) <br/> 2.32 ms / 837.04 FPS (2 threads)  | 2.0 ms                         | 2.3 M       | 6.7 M      |
-| S100     | YOLOv10s Detect | 640×640        |        80 | 2.53 ms / 385.50 FPS (1 thread ) <br/> 4.18 ms / 471.09 FPS (2 threads)  | 2.0 ms                         | 7.2 M       | 21.6 M     |
-| S100     | YOLOv10m Detect | 640×640        |        80 | 4.49 ms / 219.98 FPS (1 thread ) <br/> 8.11 ms / 244.17 FPS (2 threads)  | 2.0 ms                         | 15.4 M      | 59.1 M     |
-| S100     | YOLOv10b Detect | 640×640        |        80 | 6.28 ms / 157.57 FPS (1 thread ) <br/> 11.65 ms / 170.32 FPS (2 threads) | 2.0 ms                         | 19.1 M      | 92.0 M     |
-| S100     | YOLOv10l Detect | 640×640        |        80 | 7.95 ms / 124.70 FPS (1 thread ) <br/> 14.98 ms / 132.53 FPS (2 threads) | 2.0 ms                         | 24.4 M      | 120.3 M    |
-| S100     | YOLOv10x Detect | 640×640        |        80 | 10.83 ms / 91.79 FPS (1 thread ) <br/> 20.66 ms / 96.17 FPS (2 threads)  | 2.0 ms                         | 29.5 M      | 160.4 M    |
-| S100     | YOLOv9t Detect  | 640×640        |        80 | 1.77 ms / 546.03 FPS (1 thread ) <br/> 2.67 ms / 730.68 FPS (2 threads)  | 2.0 ms                         | 2.1 M       | 8.2 M      |
-| S100     | YOLOv9s Detect  | 640×640        |        80 | 2.74 ms / 357.91 FPS (1 thread ) <br/> 4.62 ms / 425.97 FPS (2 threads)  | 2.0 ms                         | 7.2 M       | 26.9 M     |
-| S100     | YOLOv9m Detect  | 640×640        |        80 | 5.52 ms / 179.23 FPS (1 thread ) <br/> 10.13 ms / 195.30 FPS (2 threads) | 2.0 ms                         | 20.1 M      | 76.8 M     |
-| S100     | YOLOv9c Detect  | 640×640        |        80 | 6.98 ms / 142.00 FPS (1 thread ) <br/> 13.05 ms / 151.95 FPS (2 threads) | 2.0 ms                         | 25.3 M      | 102.7 M    |
-| S100     | YOLOv9e Detect  | 640×640        |        80 | 17.75 ms / 56.15 FPS (1 thread ) <br/> 34.41 ms / 57.85 FPS (2 threads)  | 2.0 ms                         | 57.4 M      | 189.5 M    |
-| S100     | YOLOv8n Detect  | 640×640        |        80 | 1.53 ms / 632.06 FPS (1 thread ) <br/> 2.24 ms / 868.87 FPS (2 threads)  | 2.0 ms                         | 3.2 M       | 8.7 M      |
-| S100     | YOLOv8s Detect  | 640×640        |        80 | 2.63 ms / 371.16 FPS (1 thread ) <br/> 4.41 ms / 446.48 FPS (2 threads)  | 2.0 ms                         | 11.2 M      | 28.6 M     |
-| S100     | YOLOv8m Detect  | 640×640        |        80 | 5.18 ms / 190.64 FPS (1 thread ) <br/> 9.45 ms / 209.80 FPS (2 threads)  | 2.0 ms                         | 25.9 M      | 78.9 M     |
-| S100     | YOLOv8l Detect  | 640×640        |        80 | 9.97 ms / 99.68 FPS (1 thread ) <br/> 19.00 ms / 104.65 FPS (2 threads)  | 2.0 ms                         | 43.7 M      | 165.2 M    |
-| S100     | YOLOv8x Detect  | 640×640        |        80 | 15.77 ms / 63.15 FPS (1 thread ) <br/> 30.53 ms / 65.20 FPS (2 threads)  | 2.0 ms                         | 68.2 M      | 257.8 M    |
-| S100     | YOLOv5nu Detect | 640×640        |        80 | 1.42 ms / 674.92 FPS (1 thread ) <br/> 2.02 ms / 959.05 FPS (2 threads)  | 2.0 ms                         | 2.6 M       | 7.7 M      |
-| S100     | YOLOv5su Detect | 640×640        |        80 | 2.31 ms / 420.83 FPS (1 thread ) <br/> 3.79 ms / 519.22 FPS (2 threads)  | 2.0 ms                         | 9.1 M       | 24.0 M     |
-| S100     | YOLOv5mu Detect | 640×640        |        80 | 4.50 ms / 218.77 FPS (1 thread ) <br/> 8.11 ms / 244.06 FPS (2 threads)  | 2.0 ms                         | 25.1 M      | 64.2 M     |
-| S100     | YOLOv5lu Detect | 640×640        |        80 | 8.96 ms / 110.78 FPS (1 thread ) <br/> 16.97 ms / 117.15 FPS (2 threads) | 2.0 ms                         | 53.2 M      | 135.0 M    |
-| S100     | YOLOv5xu Detect | 640×640        |        80 | 15.97 ms / 62.32 FPS (1 thread ) <br/> 30.90 ms / 64.41 FPS (2 threads)  | 2.0 ms                         | 97.2 M      | 246.4 M    |
-#### Instance Segmentation
-| Device   | Model       | Size(Pixels)   |   Classes | BPU Task Latency  /<br>BPU Throughput (Threads)                          | CPU Latency<br>(Single Core)   | params(M)   | FLOPs(B)   |
-|----------|-------------|----------------|-----------|--------------------------------------------------------------------------|--------------------------------|-------------|------------|
-| S100     | YOLO11n Seg | 640×640        |        80 | 2.06 ms / 463.93 FPS (1 thread ) <br/> 3.17 ms / 613.76 FPS (2 threads)  | 5.0 ms                         | 2.9 M       | 10.4 M     |
-| S100     | YOLO11s Seg | 640×640        |        80 | 3.34 ms / 291.16 FPS (1 thread ) <br/> 5.69 ms / 344.91 FPS (2 threads)  | 5.0 ms                         | 10.1 M      | 35.5 M     |
-| S100     | YOLO11m Seg | 640×640        |        80 | 7.86 ms / 125.63 FPS (1 thread ) <br/> 14.67 ms / 135.16 FPS (2 threads) | 5.0 ms                         | 22.4 M      | 123.3 M    |
-| S100     | YOLO11l Seg | 640×640        |        80 | 9.17 ms / 108.00 FPS (1 thread ) <br/> 17.29 ms / 114.67 FPS (2 threads) | 5.0 ms                         | 27.6 M      | 142.2 M    |
-| S100     | YOLO11x Seg | 640×640        |        80 | 17.74 ms / 56.07 FPS (1 thread ) <br/> 34.33 ms / 57.96 FPS (2 threads)  | 5.0 ms                         | 62.1 M      | 319.0 M    |
-| S100     | YOLOv9c Seg | 640×640        |        80 | 9.07 ms / 109.16 FPS (1 thread ) <br/> 17.12 ms / 115.80 FPS (2 threads) | 5.0 ms                         | 27.7 M      | 158.0 M    |
-| S100     | YOLOv9e Seg | 640×640        |        80 | 20.15 ms / 49.38 FPS (1 thread ) <br/> 39.07 ms / 50.91 FPS (2 threads)  | 5.0 ms                         | 59.7 M      | 244.8 M    |
-| S100     | YOLOv8n Seg | 640×640        |        80 | 1.93 ms / 495.35 FPS (1 thread ) <br/> 2.98 ms / 652.21 FPS (2 threads)  | 5.0 ms                         | 3.4 M       | 12.6 M     |
-| S100     | YOLOv8s Seg | 640×640        |        80 | 3.37 ms / 288.70 FPS (1 thread ) <br/> 5.76 ms / 341.12 FPS (2 threads)  | 5.0 ms                         | 11.8 M      | 42.6 M     |
-| S100     | YOLOv8m Seg | 640×640        |        80 | 6.65 ms / 148.28 FPS (1 thread ) <br/> 12.29 ms / 161.07 FPS (2 threads) | 5.0 ms                         | 27.3 M      | 100.2 M    |
-| S100     | YOLOv8l Seg | 640×640        |        80 | 12.21 ms / 81.34 FPS (1 thread ) <br/> 23.32 ms / 85.17 FPS (2 threads)  | 5.0 ms                         | 46.0 M      | 220.5 M    |
-| S100     | YOLOv8x Seg | 640×640        |        80 | 19.51 ms / 51.00 FPS (1 thread ) <br/> 37.80 ms / 52.62 FPS (2 threads)  | 5.0 ms                         | 71.8 M      | 344.1 M    |
-#### Pose Estimation
-| Device   | Model        | Size(Pixels)   |   Classes | BPU Task Latency  /<br>BPU Throughput (Threads)                          | CPU Latency<br>(Single Core)   | params(M)   | FLOPs(B)   |
-|----------|--------------|----------------|-----------|--------------------------------------------------------------------------|--------------------------------|-------------|------------|
-| S100     | YOLO11n Pose | 640×640        |        80 | 1.69 ms / 568.00 FPS (1 thread ) <br/> 2.48 ms / 780.47 FPS (2 threads)  | 1.0 ms                         | 2.9 M       | 7.6 M      |
-| S100     | YOLO11s Pose | 640×640        |        80 | 2.76 ms / 354.06 FPS (1 thread ) <br/> 4.62 ms / 424.92 FPS (2 threads)  | 1.0 ms                         | 9.9 M       | 23.2 M     |
-| S100     | YOLO11m Pose | 640×640        |        80 | 5.89 ms / 167.50 FPS (1 thread ) <br/> 10.79 ms / 183.34 FPS (2 threads) | 1.0 ms                         | 20.9 M      | 71.7 M     |
-| S100     | YOLO11l Pose | 640×640        |        80 | 7.23 ms / 136.91 FPS (1 thread ) <br/> 13.48 ms / 147.21 FPS (2 threads) | 1.0 ms                         | 26.2 M      | 90.7 M     |
-| S100     | YOLO11x Pose | 640×640        |        80 | 13.61 ms / 73.02 FPS (1 thread ) <br/> 26.16 ms / 76.04 FPS (2 threads)  | 1.0 ms                         | 58.8 M      | 203.3 M    |
-| S100     | YOLOv8n Pose | 640×640        |        80 | 1.62 ms / 587.59 FPS (1 thread ) <br/> 2.31 ms / 837.95 FPS (2 threads)  | 1.0 ms                         | 3.3 M       | 9.2 M      |
-| S100     | YOLOv8s Pose | 640×640        |        80 | 2.83 ms / 344.35 FPS (1 thread ) <br/> 4.71 ms / 417.72 FPS (2 threads)  | 1.0 ms                         | 11.6 M      | 30.2 M     |
-| S100     | YOLOv8m Pose | 640×640        |        80 | 5.47 ms / 180.46 FPS (1 thread ) <br/> 9.92 ms / 199.50 FPS (2 threads)  | 1.0 ms                         | 26.4 M      | 81.0 M     |
-| S100     | YOLOv8l Pose | 640×640        |        80 | 10.31 ms / 96.20 FPS (1 thread ) <br/> 19.55 ms / 101.60 FPS (2 threads) | 1.0 ms                         | 44.4 M      | 168.6 M    |
-| S100     | YOLOv8x Pose | 640×640        |        80 | 16.07 ms / 61.88 FPS (1 thread ) <br/> 31.01 ms / 64.14 FPS (2 threads)  | 1.0 ms                         | 69.4 M      | 263.2 M    |
-#### Image Classification
-| Device   | Model       | Size(Pixels)   |   Classes | BPU Task Latency  /<br>BPU Throughput (Threads)                                                                   | CPU Latency<br>(Single Core)   | params(M)   | FLOPs(B)   |
-|----------|-------------|----------------|-----------|-------------------------------------------------------------------------------------------------------------------|--------------------------------|-------------|------------|
-| S100     | YOLO11n CLS | 640×640        |        80 | 0.53 ms / 1827.92 FPS (1 thread ) <br/> 0.62 ms / 3115.65 FPS (2 threads) <br/> 0.70 ms / 4141.22 FPS (3 threads) | 0.5 ms                         | 2.8 M       | 4.2 M      |
-| S100     | YOLO11s CLS | 640×640        |        80 | 0.68 ms / 1415.98 FPS (1 thread ) <br/> 0.76 ms / 2553.99 FPS (2 threads) <br/> 1.05 ms / 2767.63 FPS (3 threads) | 0.5 ms                         | 6.7 M       | 13.0 M     |
-| S100     | YOLO11m CLS | 640×640        |        80 | 1.02 ms / 955.28 FPS (1 thread ) <br/> 1.35 ms / 1445.18 FPS (2 threads)                                          | 0.5 ms                         | 11.6 M      | 40.3 M     |
-| S100     | YOLO11l CLS | 640×640        |        80 | 1.21 ms / 805.52 FPS (1 thread ) <br/> 1.73 ms / 1139.48 FPS (2 threads)                                          | 0.5 ms                         | 14.1 M      | 50.4 M     |
-| S100     | YOLO11x CLS | 640×640        |        80 | 1.97 ms / 501.49 FPS (1 thread ) <br/> 3.23 ms / 612.29 FPS (2 threads)                                           | 0.5 ms                         | 29.6 M      | 111.3 M    |
-| S100     | YOLOv8n CLS | 640×640        |        80 | 0.49 ms / 1928.23 FPS (1 thread ) <br/> 0.57 ms / 3399.86 FPS (2 threads) <br/> 0.66 ms / 4410.92 FPS (3 threads) | 0.5 ms                         | 2.7 M       | 4.3 M      |
-| S100     | YOLOv8s CLS | 640×640        |        80 | 0.62 ms / 1562.83 FPS (1 thread ) <br/> 0.71 ms / 2712.53 FPS (2 threads) <br/> 0.89 ms / 3279.66 FPS (3 threads) | 0.5 ms                         | 6.4 M       | 13.5 M     |
-| S100     | YOLOv8m CLS | 640×640        |        80 | 1.00 ms / 970.04 FPS (1 thread ) <br/> 1.31 ms / 1500.86 FPS (2 threads)                                          | 0.5 ms                         | 17.0 M      | 42.7 M     |
-| S100     | YOLOv8l CLS | 640×640        |        80 | 1.98 ms / 497.58 FPS (1 thread ) <br/> 3.22 ms / 614.92 FPS (2 threads)                                           | 0.5 ms                         | 37.5 M      | 99.7 M     |
-| S100     | YOLOv8x CLS | 640×640        |        80 | 2.77 ms / 357.03 FPS (1 thread ) <br/> 4.81 ms / 412.60 FPS (2 threads)                                           | 0.5 ms                         | 57.4 M      | 154.8 M    |
-## Accuracy
 #### Obeject Detection
 | Device   | Model           | Accuracy bbox-all mAP@.50:.95 <br/> FP32 / BPU Python   | Accuracy bbox-small mAP@.50:.95 <br/> FP32 / BPU Python   | Accuracy bbox-medium mAP@.50:.95 <br/> FP32 / BPU Python   | Accuracy bbox-large mAP@.50:.95 <br/> FP32 / BPU Python   |
 |----------|-----------------|---------------------------------------------------------|-----------------------------------------------------------|------------------------------------------------------------|-----------------------------------------------------------|
@@ -408,84 +627,8 @@ Accuracy pose-large mAP@.50:.95: Average Precision (AP) @[ IoU=0.50:0.95 area=la
 | S100     | YOLOv8m CLS | 0.768 / 0.702 (91.4 %)                  | 0.935 / 0.899 (96.2 %)                  |
 | S100     | YOLOv8l CLS | 0.783 / 0.723 (92.3 %)                  | 0.942 / 0.909 (96.5 %)                  |
 | S100     | YOLOv8x CLS | 0.790 / 0.742 (93.9 %)                  | 0.945 / 0.921 (97.5 %)                  |
-## Performance
+
 ### RDK X5
-#### Obeject Detection
-| Device   | Model           | Size(Pixels)   |   Classes | BPU Task Latency  /<br>BPU Throughput (Threads)                          | CPU Latency<br>(Single Core)   | params(M)   | FLOPs(B)   |
-|----------|-----------------|----------------|-----------|--------------------------------------------------------------------------|--------------------------------|-------------|------------|
-| X5       | YOLO12n Detect  | 640×640        |        80 | 39.70 ms / 25.17 FPS (1 thread ) <br/> 73.19 ms / 27.24 FPS (2 threads)  | 5.0 ms                         | 2.6 M       | 7.7 M      |
-| X5       | YOLO12s Detect  | 640×640        |        80 | 63.74 ms / 15.68 FPS (1 thread ) <br/> 121.24 ms / 16.45 FPS (2 threads) | 5.0 ms                         | 9.3 M       | 21.4 M     |
-| X5       | YOLO12m Detect  | 640×640        |        80 | 103.02 ms / 9.70 FPS (1 thread ) <br/> 199.58 ms / 9.99 FPS (2 threads)  | 5.0 ms                         | 20.2 M      | 67.5 M     |
-| X5       | YOLO12l Detect  | 640×640        |        80 | 183.00 ms / 5.46 FPS (1 thread ) <br/> 359.03 ms / 5.56 FPS (2 threads)  | 5.0 ms                         | 26.4 M      | 88.9 M     |
-| X5       | YOLO12x Detect  | 640×640        |        80 | 315.16 ms / 3.17 FPS (1 thread )                                         | 5.0 ms                         | 59.1 M      | 199.0 M    |
-| X5       | YOLO11n Detect  | 640×640        |        80 | 8.25 ms / 121.05 FPS (1 thread ) <br/> 10.56 ms / 188.57 FPS (2 threads) | 5.0 ms                         | 2.6 M       | 6.5 M      |
-| X5       | YOLO11s Detect  | 640×640        |        80 | 15.81 ms / 63.16 FPS (1 thread ) <br/> 25.74 ms / 77.43 FPS (2 threads)  | 5.0 ms                         | 9.4 M       | 21.5 M     |
-| X5       | YOLO11m Detect  | 640×640        |        80 | 34.68 ms / 28.82 FPS (1 thread ) <br/> 63.30 ms / 31.51 FPS (2 threads)  | 5.0 ms                         | 20.1 M      | 68.0 M     |
-| X5       | YOLO11l Detect  | 640×640        |        80 | 45.23 ms / 22.10 FPS (1 thread ) <br/> 84.30 ms / 23.66 FPS (2 threads)  | 5.0 ms                         | 25.3 M      | 86.9 M     |
-| X5       | YOLO11x Detect  | 640×640        |        80 | 96.70 ms / 10.34 FPS (1 thread ) <br/> 186.76 ms / 10.68 FPS (2 threads) | 5.0 ms                         | 56.9 M      | 194.9 M    |
-| X5       | YOLOv10n Detect | 640×640        |        80 | 8.75 ms / 114.19 FPS (1 thread ) <br/> 11.60 ms / 171.72 FPS (2 threads) | 5.0 ms                         | 2.3 M       | 6.7 M      |
-| X5       | YOLOv10s Detect | 640×640        |        80 | 14.84 ms / 67.32 FPS (1 thread ) <br/> 23.85 ms / 83.58 FPS (2 threads)  | 5.0 ms                         | 7.2 M       | 21.6 M     |
-| X5       | YOLOv10m Detect | 640×640        |        80 | 29.40 ms / 33.99 FPS (1 thread ) <br/> 52.83 ms / 37.75 FPS (2 threads)  | 5.0 ms                         | 15.4 M      | 59.1 M     |
-| X5       | YOLOv10b Detect | 640×640        |        80 | 40.14 ms / 24.90 FPS (1 thread ) <br/> 74.20 ms / 26.88 FPS (2 threads)  | 5.0 ms                         | 19.1 M      | 92.0 M     |
-| X5       | YOLOv10l Detect | 640×640        |        80 | 49.89 ms / 20.04 FPS (1 thread ) <br/> 93.66 ms / 21.30 FPS (2 threads)  | 5.0 ms                         | 24.4 M      | 120.3 M    |
-| X5       | YOLOv10x Detect | 640×640        |        80 | 68.92 ms / 14.51 FPS (1 thread ) <br/> 131.54 ms / 15.16 FPS (2 threads) | 5.0 ms                         | 29.5 M      | 160.4 M    |
-| X5       | YOLOv9t Detect  | 640×640        |        80 | 6.97 ms / 143.14 FPS (1 thread ) <br/> 7.96 ms / 250.11 FPS (2 threads)  | 5.0 ms                         | 2.1 M       | 8.2 M      |
-| X5       | YOLOv9s Detect  | 640×640        |        80 | 13.00 ms / 76.81 FPS (1 thread ) <br/> 20.16 ms / 98.81 FPS (2 threads)  | 5.0 ms                         | 7.2 M       | 26.9 M     |
-| X5       | YOLOv9m Detect  | 640×640        |        80 | 32.63 ms / 30.63 FPS (1 thread ) <br/> 59.31 ms / 33.62 FPS (2 threads)  | 5.0 ms                         | 20.1 M      | 76.8 M     |
-| X5       | YOLOv9c Detect  | 640×640        |        80 | 40.46 ms / 24.71 FPS (1 thread ) <br/> 74.77 ms / 26.67 FPS (2 threads)  | 5.0 ms                         | 25.3 M      | 102.7 M    |
-| X5       | YOLOv9e Detect  | 640×640        |        80 | 119.80 ms / 8.35 FPS (1 thread ) <br/> 233.08 ms / 8.56 FPS (2 threads)  | 5.0 ms                         | 57.4 M      | 189.5 M    |
-| X5       | YOLOv8n Detect  | 640×640        |        80 | 7.00 ms / 142.60 FPS (1 thread ) <br/> 8.06 ms / 246.82 FPS (2 threads)  | 5.0 ms                         | 3.2 M       | 8.7 M      |
-| X5       | YOLOv8s Detect  | 640×640        |        80 | 13.63 ms / 73.30 FPS (1 thread ) <br/> 21.38 ms / 93.20 FPS (2 threads)  | 5.0 ms                         | 11.2 M      | 28.6 M     |
-| X5       | YOLOv8m Detect  | 640×640        |        80 | 30.74 ms / 32.51 FPS (1 thread ) <br/> 55.51 ms / 35.93 FPS (2 threads)  | 5.0 ms                         | 25.9 M      | 78.9 M     |
-| X5       | YOLOv8l Detect  | 640×640        |        80 | 59.51 ms / 16.80 FPS (1 thread ) <br/> 112.80 ms / 17.68 FPS (2 threads) | 5.0 ms                         | 43.7 M      | 165.2 M    |
-| X5       | YOLOv8x Detect  | 640×640        |        80 | 92.72 ms / 10.78 FPS (1 thread ) <br/> 178.95 ms / 11.15 FPS (2 threads) | 5.0 ms                         | 68.2 M      | 257.8 M    |
-| X5       | YOLOv5nu Detect | 640×640        |        80 | 6.33 ms / 157.59 FPS (1 thread ) <br/> 6.80 ms / 291.89 FPS (2 threads)  | 5.0 ms                         | 2.6 M       | 7.7 M      |
-| X5       | YOLOv5su Detect | 640×640        |        80 | 12.33 ms / 81.04 FPS (1 thread ) <br/> 18.88 ms / 105.56 FPS (2 threads) | 5.0 ms                         | 9.1 M       | 24.0 M     |
-| X5       | YOLOv5mu Detect | 640×640        |        80 | 26.57 ms / 37.62 FPS (1 thread ) <br/> 47.20 ms / 42.24 FPS (2 threads)  | 5.0 ms                         | 25.1 M      | 64.2 M     |
-| X5       | YOLOv5lu Detect | 640×640        |        80 | 52.83 ms / 18.92 FPS (1 thread ) <br/> 99.42 ms / 20.06 FPS (2 threads)  | 5.0 ms                         | 53.2 M      | 135.0 M    |
-| X5       | YOLOv5xu Detect | 640×640        |        80 | 91.55 ms / 10.92 FPS (1 thread ) <br/> 176.49 ms / 11.30 FPS (2 threads) | 5.0 ms                         | 97.2 M      | 246.4 M    |
-#### Instance Segmentation
-| Device   | Model       | Size(Pixels)   |   Classes | BPU Task Latency  /<br>BPU Throughput (Threads)                          | CPU Latency<br>(Single Core)   | params(M)   | FLOPs(B)   |
-|----------|-------------|----------------|-----------|--------------------------------------------------------------------------|--------------------------------|-------------|------------|
-| X5       | YOLO11n Seg | 640×640        |        80 | 11.55 ms / 86.39 FPS (1 thread ) <br/> 12.83 ms / 155.10 FPS (2 threads) | 20.0 ms                        | 2.9 M       | 10.4 M     |
-| X5       | YOLO11s Seg | 640×640        |        80 | 21.62 ms / 46.22 FPS (1 thread ) <br/> 33.12 ms / 60.20 FPS (2 threads)  | 20.0 ms                        | 10.1 M      | 35.5 M     |
-| X5       | YOLO11m Seg | 640×640        |        80 | 50.43 ms / 19.82 FPS (1 thread ) <br/> 90.49 ms / 22.04 FPS (2 threads)  | 20.0 ms                        | 22.4 M      | 123.3 M    |
-| X5       | YOLO11l Seg | 640×640        |        80 | 60.60 ms / 16.50 FPS (1 thread ) <br/> 110.99 ms / 17.97 FPS (2 threads) | 20.0 ms                        | 27.6 M      | 142.2 M    |
-| X5       | YOLO11x Seg | 640×640        |        80 | 130.40 ms / 7.67 FPS (1 thread ) <br/> 249.71 ms / 7.99 FPS (2 threads)  | 20.0 ms                        | 62.1 M      | 319.0 M    |
-| X5       | YOLOv9c Seg | 640×640        |        80 | 55.85 ms / 17.90 FPS (1 thread ) <br/> 101.47 ms / 19.65 FPS (2 threads) | 20.0 ms                        | 27.7 M      | 158.0 M    |
-| X5       | YOLOv9e Seg | 640×640        |        80 | 135.34 ms / 7.39 FPS (1 thread ) <br/> 260.08 ms / 7.67 FPS (2 threads)  | 20.0 ms                        | 59.7 M      | 244.8 M    |
-| X5       | YOLOv8n Seg | 640×640        |        80 | 10.40 ms / 96.02 FPS (1 thread ) <br/> 10.75 ms / 185.21 FPS (2 threads) | 20.0 ms                        | 3.4 M       | 12.6 M     |
-| X5       | YOLOv8s Seg | 640×640        |        80 | 19.56 ms / 51.08 FPS (1 thread ) <br/> 28.99 ms / 68.76 FPS (2 threads)  | 20.0 ms                        | 11.8 M      | 42.6 M     |
-| X5       | YOLOv8m Seg | 640×640        |        80 | 40.52 ms / 24.67 FPS (1 thread ) <br/> 70.70 ms / 28.21 FPS (2 threads)  | 20.0 ms                        | 27.3 M      | 100.2 M    |
-| X5       | YOLOv8l Seg | 640×640        |        80 | 75.00 ms / 13.33 FPS (1 thread ) <br/> 139.61 ms / 14.29 FPS (2 threads) | 20.0 ms                        | 46.0 M      | 220.5 M    |
-| X5       | YOLOv8x Seg | 640×640        |        80 | 115.94 ms / 8.62 FPS (1 thread ) <br/> 221.06 ms / 9.02 FPS (2 threads)  | 20.0 ms                        | 71.8 M      | 344.1 M    |
-#### Pose Estimation
-| Device   | Model        | Size(Pixels)   |   Classes | BPU Task Latency  /<br>BPU Throughput (Threads)                          | CPU Latency<br>(Single Core)   | params(M)   | FLOPs(B)   |
-|----------|--------------|----------------|-----------|--------------------------------------------------------------------------|--------------------------------|-------------|------------|
-| X5       | YOLO11n Pose | 640×640        |        80 | 8.36 ms / 119.43 FPS (1 thread ) <br/> 10.97 ms / 181.61 FPS (2 threads) | 10.0 ms                        | 2.9 M       | 7.6 M      |
-| X5       | YOLO11s Pose | 640×640        |        80 | 16.35 ms / 61.11 FPS (1 thread ) <br/> 26.99 ms / 73.85 FPS (2 threads)  | 10.0 ms                        | 9.9 M       | 23.2 M     |
-| X5       | YOLO11m Pose | 640×640        |        80 | 35.74 ms / 27.97 FPS (1 thread ) <br/> 65.60 ms / 30.40 FPS (2 threads)  | 10.0 ms                        | 20.9 M      | 71.7 M     |
-| X5       | YOLO11l Pose | 640×640        |        80 | 46.38 ms / 21.55 FPS (1 thread ) <br/> 86.82 ms / 22.97 FPS (2 threads)  | 10.0 ms                        | 26.2 M      | 90.7 M     |
-| X5       | YOLO11x Pose | 640×640        |        80 | 98.88 ms / 10.11 FPS (1 thread ) <br/> 191.38 ms / 10.42 FPS (2 threads) | 10.0 ms                        | 58.8 M      | 203.3 M    |
-| X5       | YOLOv8n Pose | 640×640        |        80 | 6.95 ms / 143.64 FPS (1 thread ) <br/> 8.23 ms / 241.76 FPS (2 threads)  | 10.0 ms                        | 3.3 M       | 9.2 M      |
-| X5       | YOLOv8s Pose | 640×640        |        80 | 14.16 ms / 70.54 FPS (1 thread ) <br/> 22.62 ms / 88.09 FPS (2 threads)  | 10.0 ms                        | 11.6 M      | 30.2 M     |
-| X5       | YOLOv8m Pose | 640×640        |        80 | 31.60 ms / 31.62 FPS (1 thread ) <br/> 57.34 ms / 34.78 FPS (2 threads)  | 10.0 ms                        | 26.4 M      | 81.0 M     |
-| X5       | YOLOv8l Pose | 640×640        |        80 | 60.37 ms / 16.56 FPS (1 thread ) <br/> 114.73 ms / 17.38 FPS (2 threads) | 10.0 ms                        | 44.4 M      | 168.6 M    |
-| X5       | YOLOv8x Pose | 640×640        |        80 | 94.15 ms / 10.62 FPS (1 thread ) <br/> 182.08 ms / 10.96 FPS (2 threads) | 10.0 ms                        | 69.4 M      | 263.2 M    |
-#### Image Classification
-| Device   | Model       | Size(Pixels)   |   Classes | BPU Task Latency  /<br>BPU Throughput (Threads)                           | CPU Latency<br>(Single Core)   | params(M)   | FLOPs(B)   |
-|----------|-------------|----------------|-----------|---------------------------------------------------------------------------|--------------------------------|-------------|------------|
-| X5       | YOLO11n CLS | 640×640        |        80 | 1.06 ms / 939.95 FPS (1 thread ) <br/> 1.61 ms / 1236.07 FPS (2 threads)  | 0.5 ms                         | 2.8 M       | 4.2 M      |
-| X5       | YOLO11s CLS | 640×640        |        80 | 2.01 ms / 495.14 FPS (1 thread ) <br/> 3.49 ms / 569.44 FPS (2 threads)   | 0.5 ms                         | 6.7 M       | 13.0 M     |
-| X5       | YOLO11m CLS | 640×640        |        80 | 3.82 ms / 261.13 FPS (1 thread ) <br/> 7.09 ms / 280.82 FPS (2 threads)   | 0.5 ms                         | 11.6 M      | 40.3 M     |
-| X5       | YOLO11l CLS | 640×640        |        80 | 5.02 ms / 199.15 FPS (1 thread ) <br/> 9.49 ms / 210.12 FPS (2 threads)   | 0.5 ms                         | 14.1 M      | 50.4 M     |
-| X5       | YOLO11x CLS | 640×640        |        80 | 10.04 ms / 99.49 FPS (1 thread ) <br/> 19.48 ms / 102.39 FPS (2 threads)  | 0.5 ms                         | 29.6 M      | 111.3 M    |
-| X5       | YOLOv8n CLS | 640×640        |        80 | 0.74 ms / 1348.98 FPS (1 thread ) <br/> 0.98 ms / 2018.94 FPS (2 threads) | 0.5 ms                         | 2.7 M       | 4.3 M      |
-| X5       | YOLOv8s CLS | 640×640        |        80 | 1.44 ms / 690.86 FPS (1 thread ) <br/> 2.36 ms / 842.52 FPS (2 threads)   | 0.5 ms                         | 6.4 M       | 13.5 M     |
-| X5       | YOLOv8m CLS | 640×640        |        80 | 3.66 ms / 272.72 FPS (1 thread ) <br/> 6.78 ms / 294.01 FPS (2 threads)   | 0.5 ms                         | 17.0 M      | 42.7 M     |
-| X5       | YOLOv8l CLS | 640×640        |        80 | 7.98 ms / 125.23 FPS (1 thread ) <br/> 15.38 ms / 129.63 FPS (2 threads)  | 0.5 ms                         | 37.5 M      | 99.7 M     |
-| X5       | YOLOv8x CLS | 640×640        |        80 | 13.12 ms / 76.18 FPS (1 thread ) <br/> 25.64 ms / 77.78 FPS (2 threads)   | 0.5 ms                         | 57.4 M      | 154.8 M    |
-## Accuracy
 #### Obeject Detection
 | Device   | Model           | Accuracy bbox-all mAP@.50:.95 <br/> FP32 / BPU Python   | Accuracy bbox-small mAP@.50:.95 <br/> FP32 / BPU Python   | Accuracy bbox-medium mAP@.50:.95 <br/> FP32 / BPU Python   | Accuracy bbox-large mAP@.50:.95 <br/> FP32 / BPU Python   |
 |----------|-----------------|---------------------------------------------------------|-----------------------------------------------------------|------------------------------------------------------------|-----------------------------------------------------------|

--- a/samples/vision/ultralytics_yolo/evaluator/README_cn.md
+++ b/samples/vision/ultralytics_yolo/evaluator/README_cn.md
@@ -24,7 +24,6 @@ hrt_model_exec perf --thread_num 2 --model_file < model.bin / model.hbm >
 6. `CPU Latency (Single Core)`指的是后处理时间, 目前对后处理有做性能优化, 后处理时间与有效目标的个数正相关, 这里的后处理时间一般是目标图片中有效目标的个数小于100时的性能数据. Python和C/C++的后处理时间会有一点差距, 但是由于Python后处理程序基本也是numpy深度优化了, 所以两者差距并不是很大.
 7. `params(M)`和`FLOPs(B)`是原始浮点模型的参数量和计算量, 使用Ultralytics YOLO软件包在加载完pt模型后, 使用YOLO.export方法时日志中打印的浮点模型参数量和计算量信息. 由于最终生成的BPU定点模型的参数量和计算量与模型结构优化, 图优化, 编译器优化有关系, 与浮点模型的参数量和计算量正相关但是不一定成正比例, 所以这里统一记录浮点计算量为参考.
 
-
 ### Accuracy Test Instructions
 1. `Device`列和`Model`列含义与`Performance Test Instructions`章节的含义相同.
 2. 精度数据使用微软官方的无修改的`pycocotools`库进行计算, 目标检测(`Obeject Detection`)任务的测评模式为iouType="bbox", 和实例分割(`Instance Segmentation`)任务的测评模式为`iouType="bbox"`和`iouType="segm"`, 人体关键点估计的测评模式为`iouType="keypoints"`.
@@ -48,6 +47,79 @@ hrt_model_exec perf --thread_num 2 --model_file < model.bin / model.hbm >
 9. 本表格是使用PTQ(训练后量化)使用50张图片进行校准和编译的结果, 用于模拟普通开发者第一次直接编译的精度情况, 并没有进行精度调优或者QAT(量化感知训练), 满足常规使用验证需求, 不代表精度上限.
 
 ## Performance
+### RDK S600
+#### Obeject Detection
+| Device   | Model           | Size(Pixels)   |   Classes | BPU Task Latency  /<br>BPU Throughput (Threads)                          | CPU Latency<br>(Single Core)   | params(M)   | FLOPs(B)   |
+|----------|-----------------|----------------|-----------|--------------------------------------------------------------------------|--------------------------------|-------------|------------|
+| S600     | YOLO11l Detect | 640×640        |       80 | 3.229 ms / 307.877 FPS (1 thread ) <br/> 9.113 ms / 1277.270 FPS (12 threads) | 2.0 ms                         | 25.3 M      | 86.9 M     |
+| S600     | YOLO11m Detect | 640×640        |       80 | 2.584 ms / 384.284 FPS (1 thread ) <br/> 7.054 ms / 1642.643 FPS (12 threads) | 2.0 ms                         | 20.1 M      | 68.0 M     |
+| S600     | YOLO11n Detect | 640×640        |       80 | 0.800 ms / 1221.628 FPS (1 thread ) <br/> 1.798 ms / 6142.695 FPS (12 threads) | 2.0 ms                         | 2.6 M       | 6.5 M      |
+| S600     | YOLO11s Detect | 640×640        |       80 | 1.204 ms / 817.752 FPS (1 thread ) <br/> 3.008 ms / 3761.944 FPS (12 threads) | 2.0 ms                         | 9.4 M       | 21.5 M     |
+| S600     | YOLO11x Detect | 640×640        |       80 | 6.543 ms / 152.382 FPS (1 thread ) <br/> 18.792 ms / 622.258 FPS (12 threads) | 2.0 ms                         | 56.9 M      | 194.9 M    |
+| S600     | YOLO12l Detect | 640×640        |       80 | 6.296 ms / 158.364 FPS (1 thread ) <br/> 19.661 ms / 595.057 FPS (12 threads) | 2.0 ms                         | 26.4 M      | 88.9 M     |
+| S600     | YOLO12m Detect | 640×640        |       80 | 4.027 ms / 247.181 FPS (1 thread ) <br/> 12.026 ms / 969.575 FPS (12 threads) | 2.0 ms                         | 20.2 M      | 67.5 M     |
+| S600     | YOLO12n Detect | 640×640        |       80 | 1.207 ms / 819.555 FPS (1 thread ) <br/> 2.986 ms / 3779.575 FPS (12 threads) | 2.0 ms                         | 2.6 M       | 7.7 M      |
+| S600     | YOLO12s Detect | 640×640        |       80 | 1.957 ms / 505.866 FPS (1 thread ) <br/> 5.155 ms / 2235.861 FPS (12 threads) | 2.0 ms                         | 9.3 M       | 21.4 M     |
+| S600     | YOLO12x Detect | 640×640        |       80 | 11.073 ms / 90.110 FPS (1 thread ) <br/> 35.574 ms / 329.594 FPS (12 threads) | 2.0 ms                         | 59.1 M      | 199.0 M    |
+| S600     | YOLOv10b Detect | 640×640        |       80 | 2.972 ms / 334.349 FPS (1 thread ) <br/> 8.042 ms / 1442.637 FPS (12 threads) | 2.0 ms                         | 19.1 M      | 92.0 M     |
+| S600     | YOLOv10l Detect | 640×640        |       80 | 3.723 ms / 267.232 FPS (1 thread ) <br/> 10.360 ms / 1123.873 FPS (12 threads) | 2.0 ms                         | 24.4 M      | 120.3 M    |
+| S600     | YOLOv10m Detect | 640×640        |       80 | 2.342 ms / 423.743 FPS (1 thread ) <br/> 6.201 ms / 1867.309 FPS (12 threads) | 2.0 ms                         | 15.4 M      | 59.1 M     |
+| S600     | YOLOv10n Detect | 640×640        |       80 | 0.781 ms / 1251.157 FPS (1 thread ) <br/> 1.690 ms / 6457.445 FPS (12 threads) | 2.0 ms                         | 2.3 M       | 6.7 M      |
+| S600     | YOLOv10s Detect | 640×640        |       80 | 1.166 ms / 847.781 FPS (1 thread ) <br/> 2.802 ms / 4025.117 FPS (12 threads) | 2.0 ms                         | 7.2 M       | 21.6 M     |
+| S600     | YOLOv10x Detect | 640×640        |       80 | 5.314 ms / 187.525 FPS (1 thread ) <br/> 15.173 ms / 769.177 FPS (12 threads) | 2.0 ms                         | 29.5 M      | 160.4 M    |
+| S600     | YOLOv5lu Detect | 640×640        |       80 | 3.980 ms / 250.292 FPS (1 thread ) <br/> 11.117 ms / 1048.306 FPS (12 threads) | 2.0 ms                         | 53.2 M      | 135.0 M    |
+| S600     | YOLOv5mu Detect | 640×640        |       80 | 2.240 ms / 442.539 FPS (1 thread ) <br/> 5.935 ms / 1941.804 FPS (12 threads) | 2.0 ms                         | 25.1 M      | 64.2 M     |
+| S600     | YOLOv5nu Detect | 640×640        |       80 | 0.719 ms / 1355.583 FPS (1 thread ) <br/> 1.528 ms / 7182.102 FPS (12 threads) | 2.0 ms                         | 2.6 M       | 7.7 M      |
+| S600     | YOLOv5su Detect | 640×640        |       80 | 1.096 ms / 898.017 FPS (1 thread ) <br/> 2.656 ms / 4213.542 FPS (12 threads) | 2.0 ms                         | 9.1 M       | 24.0 M     |
+| S600     | YOLOv5xu Detect | 640×640        |       80 | 7.333 ms / 136.001 FPS (1 thread ) <br/> 21.084 ms / 554.451 FPS (12 threads) | 2.0 ms                         | 97.2 M      | 246.4 M    |
+| S600     | YOLOv8l Detect | 640×640        |       80 | 4.514 ms / 220.583 FPS (1 thread ) <br/> 12.603 ms / 924.740 FPS (12 threads) | 2.0 ms                         | 43.7 M      | 165.2 M    |
+| S600     | YOLOv8m Detect | 640×640        |       80 | 2.677 ms / 371.027 FPS (1 thread ) <br/> 7.180 ms / 1614.922 FPS (12 threads) | 2.0 ms                         | 25.9 M      | 78.9 M     |
+| S600     | YOLOv8n Detect | 640×640        |       80 | 0.776 ms / 1258.503 FPS (1 thread ) <br/> 1.674 ms / 6512.325 FPS (12 threads) | 2.0 ms                         | 3.2 M       | 8.7 M      |
+| S600     | YOLOv8s Detect | 640×640        |       80 | 1.223 ms / 805.412 FPS (1 thread ) <br/> 2.934 ms / 3839.066 FPS (12 threads) | 2.0 ms                         | 11.2 M      | 28.6 M     |
+| S600     | YOLOv8x Detect | 640×640        |       80 | 7.210 ms / 138.386 FPS (1 thread ) <br/> 20.629 ms / 567.201 FPS (12 threads) | 2.0 ms                         | 68.2 M      | 257.8 M    |
+| S600     | YOLOv9c Detect | 640×640        |       80 | 3.149 ms / 316.157 FPS (1 thread ) <br/> 8.773 ms / 1325.812 FPS (12 threads) | 2.0 ms                         | 25.3 M      | 102.7 M    |
+| S600     | YOLOv9e Detect | 640×640        |       80 | 8.560 ms / 116.557 FPS (1 thread ) <br/> 31.421 ms / 372.969 FPS (12 threads) | 2.0 ms                         | 57.4 M      | 189.5 M    |
+| S600     | YOLOv9m Detect | 640×640        |       80 | 2.747 ms / 361.925 FPS (1 thread ) <br/> 7.518 ms / 1541.699 FPS (12 threads) | 2.0 ms                         | 20.1 M      | 76.8 M     |
+| S600     | YOLOv9s Detect | 640×640        |       80 | 1.468 ms / 672.601 FPS (1 thread ) <br/> 3.911 ms / 2921.499 FPS (12 threads) | 2.0 ms                         | 7.2 M       | 26.9 M     |
+#### Segmentation
+| Device   | Model        | Size(Pixels)   |   Classes | BPU Task Latency  /<br>BPU Throughput (Threads)                          | CPU Latency<br>(Single Core)   | params(M)   | FLOPs(B)   |
+|----------|--------------|----------------|-----------|--------------------------------------------------------------------------|--------------------------------|-------------|------------|
+| S600     | YOLO11l Seg | 640×640        |       80 | 4.268 ms / 233.082 FPS (1 thread ) <br/> 12.015 ms / 967.109 FPS (12 threads) | 5.0 ms                         | 27.6 M      | 142.2 M    |
+| S600     | YOLO11m Seg | 640×640        |       80 | 3.624 ms / 274.240 FPS (1 thread ) <br/> 9.977 ms / 1161.123 FPS (12 threads) | 5.0 ms                         | 22.4 M      | 123.3 M    |
+| S600     | YOLO11n Seg | 640×640        |       80 | 0.959 ms / 1024.863 FPS (1 thread ) <br/> 2.379 ms / 4586.104 FPS (12 threads) | 5.0 ms                         | 2.9 M       | 10.4 M     |
+| S600     | YOLO11s Seg | 640×640        |       80 | 1.513 ms / 651.042 FPS (1 thread ) <br/> 3.845 ms / 2908.329 FPS (12 threads) | 5.0 ms                         | 10.1 M      | 35.5 M     |
+| S600     | YOLO11x Seg | 640×640        |       80 | 8.831 ms / 112.923 FPS (1 thread ) <br/> 25.480 ms / 459.263 FPS (12 threads) | 5.0 ms                         | 62.1 M      | 319.0 M    |
+| S600     | YOLOv8l Seg | 640×640        |       80 | 5.585 ms / 178.335 FPS (1 thread ) <br/> 15.661 ms / 743.323 FPS (12 threads) | 5.0 ms                         | 46.0 M      | 220.5 M    |
+| S600     | YOLOv8m Seg | 640×640        |       80 | 3.298 ms / 301.000 FPS (1 thread ) <br/> 8.931 ms / 1296.706 FPS (12 threads) | 5.0 ms                         | 27.3 M      | 100.2 M    |
+| S600     | YOLOv8n Seg | 640×640        |       80 | 0.940 ms / 1038.438 FPS (1 thread ) <br/> 2.236 ms / 4790.304 FPS (12 threads) | 5.0 ms                         | 3.4 M       | 12.6 M     |
+| S600     | YOLOv8s Seg | 640×640        |       80 | 1.540 ms / 642.329 FPS (1 thread ) <br/> 3.883 ms / 2873.027 FPS (12 threads) | 5.0 ms                         | 11.8 M      | 42.6 M     |
+| S600     | YOLOv8x Seg | 640×640        |       80 | 8.884 ms / 112.265 FPS (1 thread ) <br/> 25.517 ms / 458.336 FPS (12 threads) | 5.0 ms                         | 71.8 M      | 344.1 M    |
+#### Pose Estimation
+| Device   | Model        | Size(Pixels)   |   Classes | BPU Task Latency  /<br>BPU Throughput (Threads)                          | CPU Latency<br>(Single Core)   | params(M)   | FLOPs(B)   |
+|----------|--------------|----------------|-----------|--------------------------------------------------------------------------|--------------------------------|-------------|------------|
+| S600     | YOLO11l Pose | 640×640        |       80 | 3.319 ms / 299.436 FPS (1 thread ) <br/> 9.278 ms / 1250.641 FPS (12 threads) | 1.0 ms                         | 26.2 M      | 90.7 M     |
+| S600     | YOLO11m Pose | 640×640        |       80 | 2.667 ms / 371.922 FPS (1 thread ) <br/> 7.232 ms / 1596.972 FPS (12 threads) | 1.0 ms                         | 20.9 M      | 71.7 M     |
+| S600     | YOLO11n Pose | 640×640        |       80 | 0.846 ms / 1159.078 FPS (1 thread ) <br/> 1.925 ms / 5680.205 FPS (12 threads) | 1.0 ms                         | 2.9 M       | 7.6 M      |
+| S600     | YOLO11s Pose | 640×640        |       80 | 1.275 ms / 771.542 FPS (1 thread ) <br/> 3.146 ms / 3565.380 FPS (12 threads) | 1.0 ms                         | 9.9 M       | 23.2 M     |
+| S600     | YOLO11x Pose | 640×640        |       80 | 6.768 ms / 147.282 FPS (1 thread ) <br/> 19.390 ms / 602.593 FPS (12 threads) | 1.0 ms                         | 58.8 M      | 203.3 M    |
+| S600     | YOLOv8l Pose | 640×640        |       80 | 4.621 ms / 215.565 FPS (1 thread ) <br/> 12.895 ms / 902.833 FPS (12 threads) | 1.0 ms                         | 44.4 M      | 168.6 M    |
+| S600     | YOLOv8m Pose | 640×640        |       80 | 2.760 ms / 360.059 FPS (1 thread ) <br/> 7.384 ms / 1565.411 FPS (12 threads) | 1.0 ms                         | 26.4 M      | 81.0 M     |
+| S600     | YOLOv8n Pose | 640×640        |       80 | 0.808 ms / 1204.101 FPS (1 thread ) <br/> 1.733 ms / 6280.026 FPS (12 threads) | 1.0 ms                         | 3.3 M       | 9.2 M      |
+| S600     | YOLOv8s Pose | 640×640        |       80 | 1.292 ms / 761.464 FPS (1 thread ) <br/> 3.148 ms / 3553.976 FPS (12 threads) | 1.0 ms                         | 11.6 M      | 30.2 M     |
+| S600     | YOLOv8x Pose | 640×640        |       80 | 7.392 ms / 134.881 FPS (1 thread ) <br/> 21.121 ms / 553.125 FPS (12 threads) | 1.0 ms                         | 69.4 M      | 263.2 M    |
+#### Image Classification
+| Device   | Model       | Size(Pixels)   |   Classes | BPU Task Latency  /<br>BPU Throughput (Threads)                                          | CPU Latency<br>(Single Core)   | params(M)   | FLOPs(B)   |
+|----------|-------------|----------------|-----------|------------------------------------------------------------------------------------------|--------------------------------|-------------|------------|
+| S600     | YOLO11l CLS | 224×224        |     1000 | 0.654 ms / 1497.623 FPS (1 thread ) <br/> 1.418 ms / 7986.583 FPS (12 threads)          | 0.5 ms                         | 42.6 M      | 50.4 M     |
+| S600     | YOLO11m CLS | 224×224        |     1000 | 0.534 ms / 1830.295 FPS (1 thread ) <br/> 1.042 ms / 10636.601 FPS (12 threads)         | 0.5 ms                         | 32.8 M      | 39.3 M     |
+| S600     | YOLO11n CLS | 224×224        |     1000 | 0.345 ms / 2788.428 FPS (1 thread ) <br/> 0.761 ms / 13779.799 FPS (12 threads)         | 0.5 ms                         | 5.0 M       | 5.5 M      |
+| S600     | YOLO11s CLS | 224×224        |     1000 | 0.407 ms / 2380.216 FPS (1 thread ) <br/> 0.771 ms / 14041.000 FPS (12 threads)         | 0.5 ms                         | 13.1 M      | 14.4 M     |
+| S600     | YOLO11x CLS | 224×224        |     1000 | 0.994 ms / 991.985 FPS (1 thread ) <br/> 2.669 ms / 4295.902 FPS (12 threads)           | 0.5 ms                         | 97.7 M      | 113.2 M    |
+| S600     | YOLOv8l CLS | 224×224        |     1000 | 0.877 ms / 1123.179 FPS (1 thread ) <br/> 2.737 ms / 4181.651 FPS (12 threads)          | 0.5 ms                         | 36.3 M      | 99.0 M     |
+| S600     | YOLOv8m CLS | 224×224        |     1000 | 0.568 ms / 1718.996 FPS (1 thread ) <br/> 1.359 ms / 8276.775 FPS (12 threads)          | 0.5 ms                         | 17.0 M      | 42.8 M     |
+| S600     | YOLOv8n CLS | 224×224        |     1000 | 0.315 ms / 3054.368 FPS (1 thread ) <br/> 0.612 ms / 17488.633 FPS (12 threads)         | 0.5 ms                         | 2.7 M       | 4.3 M      |
+| S600     | YOLOv8s CLS | 224×224        |     1000 | 0.362 ms / 2695.563 FPS (1 thread ) <br/> 0.697 ms / 15550.891 FPS (12 threads)         | 0.5 ms                         | 6.4 M       | 13.5 M     |
+| S600     | YOLOv8x CLS | 224×224        |     1000 | 1.249 ms / 792.299 FPS (1 thread ) <br/> 4.156 ms / 2775.157 FPS (12 threads)           | 0.5 ms                         | 57.4 M      | 154.8 M    |
 ### RDK S100P
 #### Obeject Detection
 | Device   | Model           | Size(Pixels)   |   Classes | BPU Task Latency  /<br>BPU Throughput (Threads)                          | CPU Latency<br>(Single Core)   | params(M)   | FLOPs(B)   |
@@ -124,7 +196,246 @@ hrt_model_exec perf --thread_num 2 --model_file < model.bin / model.hbm >
 | S100P    | YOLOv8m CLS | 640×640        |        80 | 0.80 ms / 1218.07 FPS (1 thread ) <br/> 1.05 ms / 1876.12 FPS (2 threads)                                         | 0.5 ms                         | 17.0 M      | 42.7 M     |
 | S100P    | YOLOv8l CLS | 640×640        |        80 | 1.44 ms / 683.65 FPS (1 thread ) <br/> 2.34 ms / 842.80 FPS (2 threads)                                           | 0.5 ms                         | 37.5 M      | 99.7 M     |
 | S100P    | YOLOv8x CLS | 640×640        |        80 | 2.09 ms / 470.34 FPS (1 thread ) <br/> 3.55 ms / 559.63 FPS (2 threads)                                           | 0.5 ms                         | 57.4 M      | 154.8 M    |
+### RDK S100
+#### Obeject Detection
+| Device   | Model           | Size(Pixels)   |   Classes | BPU Task Latency  /<br>BPU Throughput (Threads)                          | CPU Latency<br>(Single Core)   | params(M)   | FLOPs(B)   |
+|----------|-----------------|----------------|-----------|--------------------------------------------------------------------------|--------------------------------|-------------|------------|
+| S100     | YOLO12n Detect  | 640×640        |        80 | 2.65 ms / 368.54 FPS (1 thread ) <br/> 4.43 ms / 443.33 FPS (2 threads)  | 2.0 ms                         | 2.6 M       | 7.7 M      |
+| S100     | YOLO12s Detect  | 640×640        |        80 | 4.48 ms / 220.08 FPS (1 thread ) <br/> 8.10 ms / 244.66 FPS (2 threads)  | 2.0 ms                         | 9.3 M       | 21.4 M     |
+| S100     | YOLO12m Detect  | 640×640        |        80 | 9.27 ms / 107.09 FPS (1 thread ) <br/> 17.56 ms / 113.12 FPS (2 threads) | 2.0 ms                         | 20.2 M      | 67.5 M     |
+| S100     | YOLO12l Detect  | 640×640        |        80 | 14.66 ms / 67.85 FPS (1 thread ) <br/> 28.30 ms / 70.28 FPS (2 threads)  | 2.0 ms                         | 26.4 M      | 88.9 M     |
+| S100     | YOLO12x Detect  | 640×640        |        80 | 24.72 ms / 40.33 FPS (1 thread ) <br/> 48.27 ms / 41.26 FPS (2 threads)  | 2.0 ms                         | 59.1 M      | 199.0 M    |
+| S100     | YOLO11n Detect  | 640×640        |        80 | 1.62 ms / 596.53 FPS (1 thread ) <br/> 2.39 ms / 813.87 FPS (2 threads)  | 2.0 ms                         | 2.6 M       | 6.5 M      |
+| S100     | YOLO11s Detect  | 640×640        |        80 | 2.63 ms / 371.42 FPS (1 thread ) <br/> 4.39 ms / 448.18 FPS (2 threads)  | 2.0 ms                         | 9.4 M       | 21.5 M     |
+| S100     | YOLO11m Detect  | 640×640        |        80 | 5.63 ms / 175.69 FPS (1 thread ) <br/> 10.35 ms / 191.62 FPS (2 threads) | 2.0 ms                         | 20.1 M      | 68.0 M     |
+| S100     | YOLO11l Detect  | 640×640        |        80 | 6.96 ms / 142.36 FPS (1 thread ) <br/> 13.02 ms / 152.41 FPS (2 threads) | 2.0 ms                         | 25.3 M      | 86.9 M     |
+| S100     | YOLO11x Detect  | 640×640        |        80 | 13.13 ms / 75.78 FPS (1 thread ) <br/> 25.24 ms / 78.82 FPS (2 threads)  | 2.0 ms                         | 56.9 M      | 194.9 M    |
+| S100     | YOLOv10n Detect | 640×640        |        80 | 1.58 ms / 608.94 FPS (1 thread ) <br/> 2.32 ms / 837.04 FPS (2 threads)  | 2.0 ms                         | 2.3 M       | 6.7 M      |
+| S100     | YOLOv10s Detect | 640×640        |        80 | 2.53 ms / 385.50 FPS (1 thread ) <br/> 4.18 ms / 471.09 FPS (2 threads)  | 2.0 ms                         | 7.2 M       | 21.6 M     |
+| S100     | YOLOv10m Detect | 640×640        |        80 | 4.49 ms / 219.98 FPS (1 thread ) <br/> 8.11 ms / 244.17 FPS (2 threads)  | 2.0 ms                         | 15.4 M      | 59.1 M     |
+| S100     | YOLOv10b Detect | 640×640        |        80 | 6.28 ms / 157.57 FPS (1 thread ) <br/> 11.65 ms / 170.32 FPS (2 threads) | 2.0 ms                         | 19.1 M      | 92.0 M     |
+| S100     | YOLOv10l Detect | 640×640        |        80 | 7.95 ms / 124.70 FPS (1 thread ) <br/> 14.98 ms / 132.53 FPS (2 threads) | 2.0 ms                         | 24.4 M      | 120.3 M    |
+| S100     | YOLOv10x Detect | 640×640        |        80 | 10.83 ms / 91.79 FPS (1 thread ) <br/> 20.66 ms / 96.17 FPS (2 threads)  | 2.0 ms                         | 29.5 M      | 160.4 M    |
+| S100     | YOLOv9t Detect  | 640×640        |        80 | 1.77 ms / 546.03 FPS (1 thread ) <br/> 2.67 ms / 730.68 FPS (2 threads)  | 2.0 ms                         | 2.1 M       | 8.2 M      |
+| S100     | YOLOv9s Detect  | 640×640        |        80 | 2.74 ms / 357.91 FPS (1 thread ) <br/> 4.62 ms / 425.97 FPS (2 threads)  | 2.0 ms                         | 7.2 M       | 26.9 M     |
+| S100     | YOLOv9m Detect  | 640×640        |        80 | 5.52 ms / 179.23 FPS (1 thread ) <br/> 10.13 ms / 195.30 FPS (2 threads) | 2.0 ms                         | 20.1 M      | 76.8 M     |
+| S100     | YOLOv9c Detect  | 640×640        |        80 | 6.98 ms / 142.00 FPS (1 thread ) <br/> 13.05 ms / 151.95 FPS (2 threads) | 2.0 ms                         | 25.3 M      | 102.7 M    |
+| S100     | YOLOv9e Detect  | 640×640        |        80 | 17.75 ms / 56.15 FPS (1 thread ) <br/> 34.41 ms / 57.85 FPS (2 threads)  | 2.0 ms                         | 57.4 M      | 189.5 M    |
+| S100     | YOLOv8n Detect  | 640×640        |        80 | 1.53 ms / 632.06 FPS (1 thread ) <br/> 2.24 ms / 868.87 FPS (2 threads)  | 2.0 ms                         | 3.2 M       | 8.7 M      |
+| S100     | YOLOv8s Detect  | 640×640        |        80 | 2.63 ms / 371.16 FPS (1 thread ) <br/> 4.41 ms / 446.48 FPS (2 threads)  | 2.0 ms                         | 11.2 M      | 28.6 M     |
+| S100     | YOLOv8m Detect  | 640×640        |        80 | 5.18 ms / 190.64 FPS (1 thread ) <br/> 9.45 ms / 209.80 FPS (2 threads)  | 2.0 ms                         | 25.9 M      | 78.9 M     |
+| S100     | YOLOv8l Detect  | 640×640        |        80 | 9.97 ms / 99.68 FPS (1 thread ) <br/> 19.00 ms / 104.65 FPS (2 threads)  | 2.0 ms                         | 43.7 M      | 165.2 M    |
+| S100     | YOLOv8x Detect  | 640×640        |        80 | 15.77 ms / 63.15 FPS (1 thread ) <br/> 30.53 ms / 65.20 FPS (2 threads)  | 2.0 ms                         | 68.2 M      | 257.8 M    |
+| S100     | YOLOv5nu Detect | 640×640        |        80 | 1.42 ms / 674.92 FPS (1 thread ) <br/> 2.02 ms / 959.05 FPS (2 threads)  | 2.0 ms                         | 2.6 M       | 7.7 M      |
+| S100     | YOLOv5su Detect | 640×640        |        80 | 2.31 ms / 420.83 FPS (1 thread ) <br/> 3.79 ms / 519.22 FPS (2 threads)  | 2.0 ms                         | 9.1 M       | 24.0 M     |
+| S100     | YOLOv5mu Detect | 640×640        |        80 | 4.50 ms / 218.77 FPS (1 thread ) <br/> 8.11 ms / 244.06 FPS (2 threads)  | 2.0 ms                         | 25.1 M      | 64.2 M     |
+| S100     | YOLOv5lu Detect | 640×640        |        80 | 8.96 ms / 110.78 FPS (1 thread ) <br/> 16.97 ms / 117.15 FPS (2 threads) | 2.0 ms                         | 53.2 M      | 135.0 M    |
+| S100     | YOLOv5xu Detect | 640×640        |        80 | 15.97 ms / 62.32 FPS (1 thread ) <br/> 30.90 ms / 64.41 FPS (2 threads)  | 2.0 ms                         | 97.2 M      | 246.4 M    |
+#### Instance Segmentation
+| Device   | Model       | Size(Pixels)   |   Classes | BPU Task Latency  /<br>BPU Throughput (Threads)                          | CPU Latency<br>(Single Core)   | params(M)   | FLOPs(B)   |
+|----------|-------------|----------------|-----------|--------------------------------------------------------------------------|--------------------------------|-------------|------------|
+| S100     | YOLO11n Seg | 640×640        |        80 | 2.06 ms / 463.93 FPS (1 thread ) <br/> 3.17 ms / 613.76 FPS (2 threads)  | 5.0 ms                         | 2.9 M       | 10.4 M     |
+| S100     | YOLO11s Seg | 640×640        |        80 | 3.34 ms / 291.16 FPS (1 thread ) <br/> 5.69 ms / 344.91 FPS (2 threads)  | 5.0 ms                         | 10.1 M      | 35.5 M     |
+| S100     | YOLO11m Seg | 640×640        |        80 | 7.86 ms / 125.63 FPS (1 thread ) <br/> 14.67 ms / 135.16 FPS (2 threads) | 5.0 ms                         | 22.4 M      | 123.3 M    |
+| S100     | YOLO11l Seg | 640×640        |        80 | 9.17 ms / 108.00 FPS (1 thread ) <br/> 17.29 ms / 114.67 FPS (2 threads) | 5.0 ms                         | 27.6 M      | 142.2 M    |
+| S100     | YOLO11x Seg | 640×640        |        80 | 17.74 ms / 56.07 FPS (1 thread ) <br/> 34.33 ms / 57.96 FPS (2 threads)  | 5.0 ms                         | 62.1 M      | 319.0 M    |
+| S100     | YOLOv9c Seg | 640×640        |        80 | 9.07 ms / 109.16 FPS (1 thread ) <br/> 17.12 ms / 115.80 FPS (2 threads) | 5.0 ms                         | 27.7 M      | 158.0 M    |
+| S100     | YOLOv9e Seg | 640×640        |        80 | 20.15 ms / 49.38 FPS (1 thread ) <br/> 39.07 ms / 50.91 FPS (2 threads)  | 5.0 ms                         | 59.7 M      | 244.8 M    |
+| S100     | YOLOv8n Seg | 640×640        |        80 | 1.93 ms / 495.35 FPS (1 thread ) <br/> 2.98 ms / 652.21 FPS (2 threads)  | 5.0 ms                         | 3.4 M       | 12.6 M     |
+| S100     | YOLOv8s Seg | 640×640        |        80 | 3.37 ms / 288.70 FPS (1 thread ) <br/> 5.76 ms / 341.12 FPS (2 threads)  | 5.0 ms                         | 11.8 M      | 42.6 M     |
+| S100     | YOLOv8m Seg | 640×640        |        80 | 6.65 ms / 148.28 FPS (1 thread ) <br/> 12.29 ms / 161.07 FPS (2 threads) | 5.0 ms                         | 27.3 M      | 100.2 M    |
+| S100     | YOLOv8l Seg | 640×640        |        80 | 12.21 ms / 81.34 FPS (1 thread ) <br/> 23.32 ms / 85.17 FPS (2 threads)  | 5.0 ms                         | 46.0 M      | 220.5 M    |
+| S100     | YOLOv8x Seg | 640×640        |        80 | 19.51 ms / 51.00 FPS (1 thread ) <br/> 37.80 ms / 52.62 FPS (2 threads)  | 5.0 ms                         | 71.8 M      | 344.1 M    |
+#### Pose Estimation
+| Device   | Model        | Size(Pixels)   |   Classes | BPU Task Latency  /<br>BPU Throughput (Threads)                          | CPU Latency<br>(Single Core)   | params(M)   | FLOPs(B)   |
+|----------|--------------|----------------|-----------|--------------------------------------------------------------------------|--------------------------------|-------------|------------|
+| S100     | YOLO11n Pose | 640×640        |        80 | 1.69 ms / 568.00 FPS (1 thread ) <br/> 2.48 ms / 780.47 FPS (2 threads)  | 1.0 ms                         | 2.9 M       | 7.6 M      |
+| S100     | YOLO11s Pose | 640×640        |        80 | 2.76 ms / 354.06 FPS (1 thread ) <br/> 4.62 ms / 424.92 FPS (2 threads)  | 1.0 ms                         | 9.9 M       | 23.2 M     |
+| S100     | YOLO11m Pose | 640×640        |        80 | 5.89 ms / 167.50 FPS (1 thread ) <br/> 10.79 ms / 183.34 FPS (2 threads) | 1.0 ms                         | 20.9 M      | 71.7 M     |
+| S100     | YOLO11l Pose | 640×640        |        80 | 7.23 ms / 136.91 FPS (1 thread ) <br/> 13.48 ms / 147.21 FPS (2 threads) | 1.0 ms                         | 26.2 M      | 90.7 M     |
+| S100     | YOLO11x Pose | 640×640        |        80 | 13.61 ms / 73.02 FPS (1 thread ) <br/> 26.16 ms / 76.04 FPS (2 threads)  | 1.0 ms                         | 58.8 M      | 203.3 M    |
+| S100     | YOLOv8n Pose | 640×640        |        80 | 1.62 ms / 587.59 FPS (1 thread ) <br/> 2.31 ms / 837.95 FPS (2 threads)  | 1.0 ms                         | 3.3 M       | 9.2 M      |
+| S100     | YOLOv8s Pose | 640×640        |        80 | 2.83 ms / 344.35 FPS (1 thread ) <br/> 4.71 ms / 417.72 FPS (2 threads)  | 1.0 ms                         | 11.6 M      | 30.2 M     |
+| S100     | YOLOv8m Pose | 640×640        |        80 | 5.47 ms / 180.46 FPS (1 thread ) <br/> 9.92 ms / 199.50 FPS (2 threads)  | 1.0 ms                         | 26.4 M      | 81.0 M     |
+| S100     | YOLOv8l Pose | 640×640        |        80 | 10.31 ms / 96.20 FPS (1 thread ) <br/> 19.55 ms / 101.60 FPS (2 threads) | 1.0 ms                         | 44.4 M      | 168.6 M    |
+| S100     | YOLOv8x Pose | 640×640        |        80 | 16.07 ms / 61.88 FPS (1 thread ) <br/> 31.01 ms / 64.14 FPS (2 threads)  | 1.0 ms                         | 69.4 M      | 263.2 M    |
+#### Image Classification
+| Device   | Model       | Size(Pixels)   |   Classes | BPU Task Latency  /<br>BPU Throughput (Threads)                                                                   | CPU Latency<br>(Single Core)   | params(M)   | FLOPs(B)   |
+|----------|-------------|----------------|-----------|-------------------------------------------------------------------------------------------------------------------|--------------------------------|-------------|------------|
+| S100     | YOLO11n CLS | 640×640        |        80 | 0.53 ms / 1827.92 FPS (1 thread ) <br/> 0.62 ms / 3115.65 FPS (2 threads) <br/> 0.70 ms / 4141.22 FPS (3 threads) | 0.5 ms                         | 2.8 M       | 4.2 M      |
+| S100     | YOLO11s CLS | 640×640        |        80 | 0.68 ms / 1415.98 FPS (1 thread ) <br/> 0.76 ms / 2553.99 FPS (2 threads) <br/> 1.05 ms / 2767.63 FPS (3 threads) | 0.5 ms                         | 6.7 M       | 13.0 M     |
+| S100     | YOLO11m CLS | 640×640        |        80 | 1.02 ms / 955.28 FPS (1 thread ) <br/> 1.35 ms / 1445.18 FPS (2 threads)                                          | 0.5 ms                         | 11.6 M      | 40.3 M     |
+| S100     | YOLO11l CLS | 640×640        |        80 | 1.21 ms / 805.52 FPS (1 thread ) <br/> 1.73 ms / 1139.48 FPS (2 threads)                                          | 0.5 ms                         | 14.1 M      | 50.4 M     |
+| S100     | YOLO11x CLS | 640×640        |        80 | 1.97 ms / 501.49 FPS (1 thread ) <br/> 3.23 ms / 612.29 FPS (2 threads)                                           | 0.5 ms                         | 29.6 M      | 111.3 M    |
+| S100     | YOLOv8n CLS | 640×640        |        80 | 0.49 ms / 1928.23 FPS (1 thread ) <br/> 0.57 ms / 3399.86 FPS (2 threads) <br/> 0.66 ms / 4410.92 FPS (3 threads) | 0.5 ms                         | 2.7 M       | 4.3 M      |
+| S100     | YOLOv8s CLS | 640×640        |        80 | 0.62 ms / 1562.83 FPS (1 thread ) <br/> 0.71 ms / 2712.53 FPS (2 threads) <br/> 0.89 ms / 3279.66 FPS (3 threads) | 0.5 ms                         | 6.4 M       | 13.5 M     |
+| S100     | YOLOv8m CLS | 640×640        |        80 | 1.00 ms / 970.04 FPS (1 thread ) <br/> 1.31 ms / 1500.86 FPS (2 threads)                                          | 0.5 ms                         | 17.0 M      | 42.7 M     |
+| S100     | YOLOv8l CLS | 640×640        |        80 | 1.98 ms / 497.58 FPS (1 thread ) <br/> 3.22 ms / 614.92 FPS (2 threads)                                           | 0.5 ms                         | 37.5 M      | 99.7 M     |
+| S100     | YOLOv8x CLS | 640×640        |        80 | 2.77 ms / 357.03 FPS (1 thread ) <br/> 4.81 ms / 412.60 FPS (2 threads)                                           | 0.5 ms                         | 57.4 M      | 154.8 M    |
+### RDK X5
+#### Obeject Detection
+| Device   | Model           | Size(Pixels)   |   Classes | BPU Task Latency  /<br>BPU Throughput (Threads)                          | CPU Latency<br>(Single Core)   | params(M)   | FLOPs(B)   |
+|----------|-----------------|----------------|-----------|--------------------------------------------------------------------------|--------------------------------|-------------|------------|
+| X5       | YOLO12n Detect  | 640×640        |        80 | 39.70 ms / 25.17 FPS (1 thread ) <br/> 73.19 ms / 27.24 FPS (2 threads)  | 5.0 ms                         | 2.6 M       | 7.7 M      |
+| X5       | YOLO12s Detect  | 640×640        |        80 | 63.74 ms / 15.68 FPS (1 thread ) <br/> 121.24 ms / 16.45 FPS (2 threads) | 5.0 ms                         | 9.3 M       | 21.4 M     |
+| X5       | YOLO12m Detect  | 640×640        |        80 | 103.02 ms / 9.70 FPS (1 thread ) <br/> 199.58 ms / 9.99 FPS (2 threads)  | 5.0 ms                         | 20.2 M      | 67.5 M     |
+| X5       | YOLO12l Detect  | 640×640        |        80 | 183.00 ms / 5.46 FPS (1 thread ) <br/> 359.03 ms / 5.56 FPS (2 threads)  | 5.0 ms                         | 26.4 M      | 88.9 M     |
+| X5       | YOLO12x Detect  | 640×640        |        80 | 315.16 ms / 3.17 FPS (1 thread )                                         | 5.0 ms                         | 59.1 M      | 199.0 M    |
+| X5       | YOLO11n Detect  | 640×640        |        80 | 8.25 ms / 121.05 FPS (1 thread ) <br/> 10.56 ms / 188.57 FPS (2 threads) | 5.0 ms                         | 2.6 M       | 6.5 M      |
+| X5       | YOLO11s Detect  | 640×640        |        80 | 15.81 ms / 63.16 FPS (1 thread ) <br/> 25.74 ms / 77.43 FPS (2 threads)  | 5.0 ms                         | 9.4 M       | 21.5 M     |
+| X5       | YOLO11m Detect  | 640×640        |        80 | 34.68 ms / 28.82 FPS (1 thread ) <br/> 63.30 ms / 31.51 FPS (2 threads)  | 5.0 ms                         | 20.1 M      | 68.0 M     |
+| X5       | YOLO11l Detect  | 640×640        |        80 | 45.23 ms / 22.10 FPS (1 thread ) <br/> 84.30 ms / 23.66 FPS (2 threads)  | 5.0 ms                         | 25.3 M      | 86.9 M     |
+| X5       | YOLO11x Detect  | 640×640        |        80 | 96.70 ms / 10.34 FPS (1 thread ) <br/> 186.76 ms / 10.68 FPS (2 threads) | 5.0 ms                         | 56.9 M      | 194.9 M    |
+| X5       | YOLOv10n Detect | 640×640        |        80 | 8.75 ms / 114.19 FPS (1 thread ) <br/> 11.60 ms / 171.72 FPS (2 threads) | 5.0 ms                         | 2.3 M       | 6.7 M      |
+| X5       | YOLOv10s Detect | 640×640        |        80 | 14.84 ms / 67.32 FPS (1 thread ) <br/> 23.85 ms / 83.58 FPS (2 threads)  | 5.0 ms                         | 7.2 M       | 21.6 M     |
+| X5       | YOLOv10m Detect | 640×640        |        80 | 29.40 ms / 33.99 FPS (1 thread ) <br/> 52.83 ms / 37.75 FPS (2 threads)  | 5.0 ms                         | 15.4 M      | 59.1 M     |
+| X5       | YOLOv10b Detect | 640×640        |        80 | 40.14 ms / 24.90 FPS (1 thread ) <br/> 74.20 ms / 26.88 FPS (2 threads)  | 5.0 ms                         | 19.1 M      | 92.0 M     |
+| X5       | YOLOv10l Detect | 640×640        |        80 | 49.89 ms / 20.04 FPS (1 thread ) <br/> 93.66 ms / 21.30 FPS (2 threads)  | 5.0 ms                         | 24.4 M      | 120.3 M    |
+| X5       | YOLOv10x Detect | 640×640        |        80 | 68.92 ms / 14.51 FPS (1 thread ) <br/> 131.54 ms / 15.16 FPS (2 threads) | 5.0 ms                         | 29.5 M      | 160.4 M    |
+| X5       | YOLOv9t Detect  | 640×640        |        80 | 6.97 ms / 143.14 FPS (1 thread ) <br/> 7.96 ms / 250.11 FPS (2 threads)  | 5.0 ms                         | 2.1 M       | 8.2 M      |
+| X5       | YOLOv9s Detect  | 640×640        |        80 | 13.00 ms / 76.81 FPS (1 thread ) <br/> 20.16 ms / 98.81 FPS (2 threads)  | 5.0 ms                         | 7.2 M       | 26.9 M     |
+| X5       | YOLOv9m Detect  | 640×640        |        80 | 32.63 ms / 30.63 FPS (1 thread ) <br/> 59.31 ms / 33.62 FPS (2 threads)  | 5.0 ms                         | 20.1 M      | 76.8 M     |
+| X5       | YOLOv9c Detect  | 640×640        |        80 | 40.46 ms / 24.71 FPS (1 thread ) <br/> 74.77 ms / 26.67 FPS (2 threads)  | 5.0 ms                         | 25.3 M      | 102.7 M    |
+| X5       | YOLOv9e Detect  | 640×640        |        80 | 119.80 ms / 8.35 FPS (1 thread ) <br/> 233.08 ms / 8.56 FPS (2 threads)  | 5.0 ms                         | 57.4 M      | 189.5 M    |
+| X5       | YOLOv8n Detect  | 640×640        |        80 | 7.00 ms / 142.60 FPS (1 thread ) <br/> 8.06 ms / 246.82 FPS (2 threads)  | 5.0 ms                         | 3.2 M       | 8.7 M      |
+| X5       | YOLOv8s Detect  | 640×640        |        80 | 13.63 ms / 73.30 FPS (1 thread ) <br/> 21.38 ms / 93.20 FPS (2 threads)  | 5.0 ms                         | 11.2 M      | 28.6 M     |
+| X5       | YOLOv8m Detect  | 640×640        |        80 | 30.74 ms / 32.51 FPS (1 thread ) <br/> 55.51 ms / 35.93 FPS (2 threads)  | 5.0 ms                         | 25.9 M      | 78.9 M     |
+| X5       | YOLOv8l Detect  | 640×640        |        80 | 59.51 ms / 16.80 FPS (1 thread ) <br/> 112.80 ms / 17.68 FPS (2 threads) | 5.0 ms                         | 43.7 M      | 165.2 M    |
+| X5       | YOLOv8x Detect  | 640×640        |        80 | 92.72 ms / 10.78 FPS (1 thread ) <br/> 178.95 ms / 11.15 FPS (2 threads) | 5.0 ms                         | 68.2 M      | 257.8 M    |
+| X5       | YOLOv5nu Detect | 640×640        |        80 | 6.33 ms / 157.59 FPS (1 thread ) <br/> 6.80 ms / 291.89 FPS (2 threads)  | 5.0 ms                         | 2.6 M       | 7.7 M      |
+| X5       | YOLOv5su Detect | 640×640        |        80 | 12.33 ms / 81.04 FPS (1 thread ) <br/> 18.88 ms / 105.56 FPS (2 threads) | 5.0 ms                         | 9.1 M       | 24.0 M     |
+| X5       | YOLOv5mu Detect | 640×640        |        80 | 26.57 ms / 37.62 FPS (1 thread ) <br/> 47.20 ms / 42.24 FPS (2 threads)  | 5.0 ms                         | 25.1 M      | 64.2 M     |
+| X5       | YOLOv5lu Detect | 640×640        |        80 | 52.83 ms / 18.92 FPS (1 thread ) <br/> 99.42 ms / 20.06 FPS (2 threads)  | 5.0 ms                         | 53.2 M      | 135.0 M    |
+| X5       | YOLOv5xu Detect | 640×640        |        80 | 91.55 ms / 10.92 FPS (1 thread ) <br/> 176.49 ms / 11.30 FPS (2 threads) | 5.0 ms                         | 97.2 M      | 246.4 M    |
+#### Instance Segmentation
+| Device   | Model       | Size(Pixels)   |   Classes | BPU Task Latency  /<br>BPU Throughput (Threads)                          | CPU Latency<br>(Single Core)   | params(M)   | FLOPs(B)   |
+|----------|-------------|----------------|-----------|--------------------------------------------------------------------------|--------------------------------|-------------|------------|
+| X5       | YOLO11n Seg | 640×640        |        80 | 11.55 ms / 86.39 FPS (1 thread ) <br/> 12.83 ms / 155.10 FPS (2 threads) | 20.0 ms                        | 2.9 M       | 10.4 M     |
+| X5       | YOLO11s Seg | 640×640        |        80 | 21.62 ms / 46.22 FPS (1 thread ) <br/> 33.12 ms / 60.20 FPS (2 threads)  | 20.0 ms                        | 10.1 M      | 35.5 M     |
+| X5       | YOLO11m Seg | 640×640        |        80 | 50.43 ms / 19.82 FPS (1 thread ) <br/> 90.49 ms / 22.04 FPS (2 threads)  | 20.0 ms                        | 22.4 M      | 123.3 M    |
+| X5       | YOLO11l Seg | 640×640        |        80 | 60.60 ms / 16.50 FPS (1 thread ) <br/> 110.99 ms / 17.97 FPS (2 threads) | 20.0 ms                        | 27.6 M      | 142.2 M    |
+| X5       | YOLO11x Seg | 640×640        |        80 | 130.40 ms / 7.67 FPS (1 thread ) <br/> 249.71 ms / 7.99 FPS (2 threads)  | 20.0 ms                        | 62.1 M      | 319.0 M    |
+| X5       | YOLOv9c Seg | 640×640        |        80 | 55.85 ms / 17.90 FPS (1 thread ) <br/> 101.47 ms / 19.65 FPS (2 threads) | 20.0 ms                        | 27.7 M      | 158.0 M    |
+| X5       | YOLOv9e Seg | 640×640        |        80 | 135.34 ms / 7.39 FPS (1 thread ) <br/> 260.08 ms / 7.67 FPS (2 threads)  | 20.0 ms                        | 59.7 M      | 244.8 M    |
+| X5       | YOLOv8n Seg | 640×640        |        80 | 10.40 ms / 96.02 FPS (1 thread ) <br/> 10.75 ms / 185.21 FPS (2 threads) | 20.0 ms                        | 3.4 M       | 12.6 M     |
+| X5       | YOLOv8s Seg | 640×640        |        80 | 19.56 ms / 51.08 FPS (1 thread ) <br/> 28.99 ms / 68.76 FPS (2 threads)  | 20.0 ms                        | 11.8 M      | 42.6 M     |
+| X5       | YOLOv8m Seg | 640×640        |        80 | 40.52 ms / 24.67 FPS (1 thread ) <br/> 70.70 ms / 28.21 FPS (2 threads)  | 20.0 ms                        | 27.3 M      | 100.2 M    |
+| X5       | YOLOv8l Seg | 640×640        |        80 | 75.00 ms / 13.33 FPS (1 thread ) <br/> 139.61 ms / 14.29 FPS (2 threads) | 20.0 ms                        | 46.0 M      | 220.5 M    |
+| X5       | YOLOv8x Seg | 640×640        |        80 | 115.94 ms / 8.62 FPS (1 thread ) <br/> 221.06 ms / 9.02 FPS (2 threads)  | 20.0 ms                        | 71.8 M      | 344.1 M    |
+#### Pose Estimation
+| Device   | Model        | Size(Pixels)   |   Classes | BPU Task Latency  /<br>BPU Throughput (Threads)                          | CPU Latency<br>(Single Core)   | params(M)   | FLOPs(B)   |
+|----------|--------------|----------------|-----------|--------------------------------------------------------------------------|--------------------------------|-------------|------------|
+| X5       | YOLO11n Pose | 640×640        |        80 | 8.36 ms / 119.43 FPS (1 thread ) <br/> 10.97 ms / 181.61 FPS (2 threads) | 10.0 ms                        | 2.9 M       | 7.6 M      |
+| X5       | YOLO11s Pose | 640×640        |        80 | 16.35 ms / 61.11 FPS (1 thread ) <br/> 26.99 ms / 73.85 FPS (2 threads)  | 10.0 ms                        | 9.9 M       | 23.2 M     |
+| X5       | YOLO11m Pose | 640×640        |        80 | 35.74 ms / 27.97 FPS (1 thread ) <br/> 65.60 ms / 30.40 FPS (2 threads)  | 10.0 ms                        | 20.9 M      | 71.7 M     |
+| X5       | YOLO11l Pose | 640×640        |        80 | 46.38 ms / 21.55 FPS (1 thread ) <br/> 86.82 ms / 22.97 FPS (2 threads)  | 10.0 ms                        | 26.2 M      | 90.7 M     |
+| X5       | YOLO11x Pose | 640×640        |        80 | 98.88 ms / 10.11 FPS (1 thread ) <br/> 191.38 ms / 10.42 FPS (2 threads) | 10.0 ms                        | 58.8 M      | 203.3 M    |
+| X5       | YOLOv8n Pose | 640×640        |        80 | 6.95 ms / 143.64 FPS (1 thread ) <br/> 8.23 ms / 241.76 FPS (2 threads)  | 10.0 ms                        | 3.3 M       | 9.2 M      |
+| X5       | YOLOv8s Pose | 640×640        |        80 | 14.16 ms / 70.54 FPS (1 thread ) <br/> 22.62 ms / 88.09 FPS (2 threads)  | 10.0 ms                        | 11.6 M      | 30.2 M     |
+| X5       | YOLOv8m Pose | 640×640        |        80 | 31.60 ms / 31.62 FPS (1 thread ) <br/> 57.34 ms / 34.78 FPS (2 threads)  | 10.0 ms                        | 26.4 M      | 81.0 M     |
+| X5       | YOLOv8l Pose | 640×640        |        80 | 60.37 ms / 16.56 FPS (1 thread ) <br/> 114.73 ms / 17.38 FPS (2 threads) | 10.0 ms                        | 44.4 M      | 168.6 M    |
+| X5       | YOLOv8x Pose | 640×640        |        80 | 94.15 ms / 10.62 FPS (1 thread ) <br/> 182.08 ms / 10.96 FPS (2 threads) | 10.0 ms                        | 69.4 M      | 263.2 M    |
+#### Image Classification
+| Device   | Model       | Size(Pixels)   |   Classes | BPU Task Latency  /<br>BPU Throughput (Threads)                           | CPU Latency<br>(Single Core)   | params(M)   | FLOPs(B)   |
+|----------|-------------|----------------|-----------|---------------------------------------------------------------------------|--------------------------------|-------------|------------|
+| X5       | YOLO11n CLS | 640×640        |        80 | 1.06 ms / 939.95 FPS (1 thread ) <br/> 1.61 ms / 1236.07 FPS (2 threads)  | 0.5 ms                         | 2.8 M       | 4.2 M      |
+| X5       | YOLO11s CLS | 640×640        |        80 | 2.01 ms / 495.14 FPS (1 thread ) <br/> 3.49 ms / 569.44 FPS (2 threads)   | 0.5 ms                         | 6.7 M       | 13.0 M     |
+| X5       | YOLO11m CLS | 640×640        |        80 | 3.82 ms / 261.13 FPS (1 thread ) <br/> 7.09 ms / 280.82 FPS (2 threads)   | 0.5 ms                         | 11.6 M      | 40.3 M     |
+| X5       | YOLO11l CLS | 640×640        |        80 | 5.02 ms / 199.15 FPS (1 thread ) <br/> 9.49 ms / 210.12 FPS (2 threads)   | 0.5 ms                         | 14.1 M      | 50.4 M     |
+| X5       | YOLO11x CLS | 640×640        |        80 | 10.04 ms / 99.49 FPS (1 thread ) <br/> 19.48 ms / 102.39 FPS (2 threads)  | 0.5 ms                         | 29.6 M      | 111.3 M    |
+| X5       | YOLOv8n CLS | 640×640        |        80 | 0.74 ms / 1348.98 FPS (1 thread ) <br/> 0.98 ms / 2018.94 FPS (2 threads) | 0.5 ms                         | 2.7 M       | 4.3 M      |
+| X5       | YOLOv8s CLS | 640×640        |        80 | 1.44 ms / 690.86 FPS (1 thread ) <br/> 2.36 ms / 842.52 FPS (2 threads)   | 0.5 ms                         | 6.4 M       | 13.5 M     |
+| X5       | YOLOv8m CLS | 640×640        |        80 | 3.66 ms / 272.72 FPS (1 thread ) <br/> 6.78 ms / 294.01 FPS (2 threads)   | 0.5 ms                         | 17.0 M      | 42.7 M     |
+| X5       | YOLOv8l CLS | 640×640        |        80 | 7.98 ms / 125.23 FPS (1 thread ) <br/> 15.38 ms / 129.63 FPS (2 threads)  | 0.5 ms                         | 37.5 M      | 99.7 M     |
+| X5       | YOLOv8x CLS | 640×640        |        80 | 13.12 ms / 76.18 FPS (1 thread ) <br/> 25.64 ms / 77.78 FPS (2 threads)   | 0.5 ms                         | 57.4 M      | 154.8 M    |
+
 ## Accuracy
+### RDK S600
+#### Obeject Detection
+| Device   | Model           | Accuracy bbox-all mAP@.50:.95 <br/> FP32 / BPU Python   | Accuracy bbox-small mAP@.50:.95 <br/> FP32 / BPU Python   | Accuracy bbox-medium mAP@.50:.95 <br/> FP32 / BPU Python   | Accuracy bbox-large mAP@.50:.95 <br/> FP32 / BPU Python   |
+|----------|-----------------|---------------------------------------------------------|-----------------------------------------------------------|------------------------------------------------------------|-----------------------------------------------------------|
+| S600     | YOLO12n Detect  | 0.338 / 0.320 (94.7 %)                                  | 0.128 / 0.104 (81.3 %)                                    | 0.374 / 0.350 (93.6 %)                                     | 0.524 / 0.514 (98.1 %)                                    |
+| S600     | YOLO12s Detect  | 0.403 / 0.385 (95.5 %)                                  | 0.201 / 0.158 (78.6 %)                                    | 0.450 / 0.436 (96.9 %)                                     | 0.602 / 0.586 (97.3 %)                                    |
+| S600     | YOLO12m Detect  | 0.452 / 0.436 (96.5 %)                                  | 0.251 / 0.228 (90.8 %)                                    | 0.509 / 0.497 (97.6 %)                                     | 0.638 / 0.626 (98.1 %)                                    |
+| S600     | YOLO12l Detect  | 0.463 / 0.441 (95.2 %)                                  | 0.268 / 0.226 (84.3 %)                                    | 0.522 / 0.505 (96.7 %)                                     | 0.646 / 0.640 (99.1 %)                                    |
+| S600     | YOLO12x Detect  | 0.475 / 0.455 (95.8 %)                                  | 0.276 / 0.238 (86.2 %)                                    | 0.536 / 0.527 (98.3 %)                                     | 0.659 / 0.618 (93.8 %)                                    |
+| S600     | YOLO11s Detect  | 0.400 / 0.382 (95.5 %)                                  | 0.198 / 0.165 (83.3 %)                                    | 0.445 / 0.430 (96.6 %)                                     | 0.587 / 0.586 (99.8 %)                                    |
+| S600     | YOLO11m Detect  | 0.444 / 0.429 (96.6 %)                                  | 0.247 / 0.220 (89.1 %)                                    | 0.497 / 0.488 (98.2 %)                                     | 0.627 / 0.610 (97.3 %)                                    |
+| S600     | YOLO11l Detect  | 0.460 / 0.448 (97.4 %)                                  | 0.267 / 0.238 (89.1 %)                                    | 0.520 / 0.514 (98.8 %)                                     | 0.638 / 0.622 (97.5 %)                                    |
+| S600     | YOLO11x Detect  | 0.474 / 0.457 (96.4 %)                                  | 0.283 / 0.244 (86.2 %)                                    | 0.529 / 0.517 (97.7 %)                                     | 0.652 / 0.639 (98.0 %)                                    |
+| S600     | YOLOv10n Detect | 0.303 / 0.285 (94.1 %)                                  | 0.099 / 0.075 (75.8 %)                                    | 0.330 / 0.306 (92.7 %)                                     | 0.478 / 0.469 (98.1 %)                                    |
+| S600     | YOLOv10s Detect | 0.386 / 0.363 (94.0 %)                                  | 0.175 / 0.144 (82.3 %)                                    | 0.434 / 0.410 (94.5 %)                                     | 0.574 / 0.528 (92.0 %)                                    |
+| S600     | YOLOv10m Detect | 0.425 / 0.389 (91.5 %)                                  | 0.221 / 0.202 (91.4 %)                                    | 0.481 / 0.450 (93.6 %)                                     | 0.603 / 0.505 (83.7 %)                                    |
+| S600     | YOLOv10b Detect | 0.443 / 0.388 (87.6 %)                                  | 0.242 / 0.189 (78.1 %)                                    | 0.498 / 0.447 (89.8 %)                                     | 0.618 / 0.496 (80.3 %)                                    |
+| S600     | YOLOv10l Detect | 0.445 / 0.392 (88.1 %)                                  | 0.258 / 0.215 (83.3 %)                                    | 0.498 / 0.463 (93.0 %)                                     | 0.626 / 0.492 (78.6 %)                                    |
+| S600     | YOLOv10x Detect | 0.459 / 0.424 (92.4 %)                                  | 0.258 / 0.228 (88.4 %)                                    | 0.518 / 0.490 (94.6 %)                                     | 0.639 / 0.546 (85.4 %)                                    |
+| S600     | YOLOv9s Detect  | 0.400 / 0.387 (96.8 %)                                  | 0.191 / 0.169 (88.5 %)                                    | 0.444 / 0.433 (97.5 %)                                     | 0.583 / 0.564 (96.7 %)                                    |
+| S600     | YOLOv9m Detect  | 0.449 / 0.441 (98.2 %)                                  | 0.253 / 0.232 (91.7 %)                                    | 0.504 / 0.496 (98.4 %)                                     | 0.617 / 0.611 (99.0 %)                                    |
+| S600     | YOLOv9c Detect  | 0.461 / 0.451 (97.8 %)                                  | 0.269 / 0.251 (93.3 %)                                    | 0.512 / 0.509 (99.4 %)                                     | 0.640 / 0.612 (95.6 %)                                    |
+| S600     | YOLOv9e Detect  | 0.481 / 0.470 (97.7 %)                                  | 0.298 / 0.273 (91.6 %)                                    | 0.538 / 0.525 (97.6 %)                                     | 0.662 / 0.650 (98.2 %)                                    |
+| S600     | YOLOv8s Detect  | 0.391 / 0.376 (96.2 %)                                  | 0.195 / 0.169 (86.7 %)                                    | 0.437 / 0.423 (96.8 %)                                     | 0.566 / 0.558 (98.6 %)                                    |
+| S600     | YOLOv8m Detect  | 0.441 / 0.429 (97.3 %)                                  | 0.249 / 0.222 (89.2 %)                                    | 0.494 / 0.486 (98.4 %)                                     | 0.618 / 0.607 (98.2 %)                                    |
+| S600     | YOLOv8l Detect  | 0.461 / 0.448 (97.2 %)                                  | 0.271 / 0.245 (90.4 %)                                    | 0.516 / 0.505 (97.9 %)                                     | 0.651 / 0.642 (98.6 %)                                    |
+| S600     | YOLOv8x Detect  | 0.474 / 0.459 (96.8 %)                                  | 0.280 / 0.253 (90.4 %)                                    | 0.527 / 0.516 (97.9 %)                                     | 0.658 / 0.647 (98.3 %)                                    |
+| S600     | YOLOv5nu Detect | 0.278 / 0.269 (96.8 %)                                  | 0.093 / 0.083 (89.2 %)                                    | 0.309 / 0.296 (95.8 %)                                     | 0.417 / 0.412 (98.8 %)                                    |
+| S600     | YOLOv5su Detect | 0.367 / 0.355 (96.7 %)                                  | 0.169 / 0.140 (82.8 %)                                    | 0.416 / 0.406 (97.6 %)                                     | 0.530 / 0.531 (100.2 %)                                   |
+| S600     | YOLOv5mu Detect | 0.425 / 0.415 (97.6 %)                                  | 0.226 / 0.207 (91.6 %)                                    | 0.477 / 0.470 (98.5 %)                                     | 0.603 / 0.604 (100.2 %)                                   |
+| S600     | YOLOv5lu Detect | 0.458 / 0.451 (98.5 %)                                  | 0.260 / 0.238 (91.5 %)                                    | 0.516 / 0.511 (99.0 %)                                     | 0.641 / 0.637 (99.4 %)                                    |
+| S600     | YOLOv5xu Detect | 0.466 / 0.454 (97.4 %)                                  | 0.281 / 0.246 (87.5 %)                                    | 0.523 / 0.517 (98.9 %)                                     | 0.645 / 0.647 (100.3 %)                                   |
+
+#### Instance Segmentation
+##### bbox
+| Device   | Model       | Accuracy bbox-all mAP@.50:.95 <br/> FP32 / BPU Python   | Accuracy bbox-small mAP@.50:.95 <br/> FP32 / BPU Python   | Accuracy bbox-medium mAP@.50:.95 <br/> FP32 / BPU Python   | Accuracy bbox-large mAP@.50:.95 <br/> FP32 / BPU Python   |
+|----------|-------------|---------------------------------------------------------|-----------------------------------------------------------|------------------------------------------------------------|-----------------------------------------------------------|
+| S600     | YOLO11s Seg | 0.394 / 0.383 (97.2 %)                                  | 0.184 / 0.162 (88.0 %)                                    | 0.442 / 0.434 (98.2 %)                                     | 0.582 / 0.581 (99.8 %)                                    |
+| S600     | YOLO11m Seg | 0.443 / 0.427 (96.4 %)                                  | 0.246 / 0.224 (91.1 %)                                    | 0.497 / 0.484 (97.4 %)                                     | 0.627 / 0.607 (96.8 %)                                    |
+| S600     | YOLO11l Seg | 0.460 / 0.443 (96.3 %)                                  | 0.267 / 0.236 (88.4 %)                                    | 0.520 / 0.508 (97.7 %)                                     | 0.638 / 0.614 (96.2 %)                                    |
+| S600     | YOLO11x Seg | 0.474 / 0.456 (96.2 %)                                  | 0.283 / 0.244 (86.2 %)                                    | 0.529 / 0.515 (97.4 %)                                     | 0.652 / 0.636 (97.5 %)                                    |
+| S600     | YOLOv8s Seg | 0.386 / 0.375 (97.2 %)                                  | 0.180 / 0.162 (90.0 %)                                    | 0.432 / 0.419 (97.0 %)                                     | 0.564 / 0.560 (99.3 %)                                    |
+| S600     | YOLOv8m Seg | 0.431 / 0.420 (97.4 %)                                  | 0.228 / 0.209 (91.7 %)                                    | 0.486 / 0.478 (98.4 %)                                     | 0.608 / 0.605 (99.5 %)                                    |
+| S600     | YOLOv8l Seg | 0.453 / 0.435 (96.0 %)                                  | 0.258 / 0.223 (86.4 %)                                    | 0.502 / 0.496 (98.8 %)                                     | 0.626 / 0.611 (97.6 %)                                    |
+| S600     | YOLOv8x Seg | 0.465 / 0.454 (97.6 %)                                  | 0.268 / 0.236 (88.1 %)                                    | 0.520 / 0.514 (98.8 %)                                     | 0.641 / 0.633 (98.8 %)                                    |
+
+##### mask
+| Device   | Model       | Accuracy mask-all mAP@.50:.95 <br/> FP32 / BPU Python   | Accuracy mask-small mAP@.50:.95 <br/> FP32 / BPU Python   | Accuracy mask-medium mAP@.50:.95 <br/> FP32 / BPU Python   | Accuracy mask-large mAP@.50:.95 <br/> FP32 / BPU Python   |
+|----------|-------------|---------------------------------------------------------|-----------------------------------------------------------|------------------------------------------------------------|-----------------------------------------------------------|
+| S600     | YOLO11s Seg | 0.311 / 0.295 (94.9 %)                                  | 0.099 / 0.088 (88.9 %)                                    | 0.350 / 0.327 (93.4 %)                                     | 0.509 / 0.486 (95.5 %)                                    |
+| S600     | YOLO11m Seg | 0.347 / 0.322 (92.8 %)                                  | 0.136 / 0.123 (90.4 %)                                    | 0.396 / 0.362 (91.4 %)                                     | 0.549 / 0.506 (92.2 %)                                    |
+| S600     | YOLO11l Seg | 0.357 / 0.331 (92.7 %)                                  | 0.143 / 0.126 (88.1 %)                                    | 0.409 / 0.377 (92.2 %)                                     | 0.560 / 0.511 (91.3 %)                                    |
+| S600     | YOLO11x Seg | 0.366 / 0.339 (92.6 %)                                  | 0.149 / 0.124 (83.2 %)                                    | 0.420 / 0.384 (91.4 %)                                     | 0.572 / 0.529 (92.5 %)                                    |
+| S600     | YOLOv8s Seg | 0.305 / 0.290 (95.1 %)                                  | 0.096 / 0.085 (88.5 %)                                    | 0.343 / 0.317 (92.4 %)                                     | 0.496 / 0.476 (96.0 %)                                    |
+| S600     | YOLOv8m Seg | 0.337 / 0.319 (94.7 %)                                  | 0.121 / 0.109 (90.1 %)                                    | 0.386 / 0.360 (93.3 %)                                     | 0.533 / 0.506 (94.9 %)                                    |
+| S600     | YOLOv8l Seg | 0.351 / 0.331 (94.3 %)                                  | 0.137 / 0.119 (86.9 %)                                    | 0.398 / 0.374 (94.0 %)                                     | 0.550 / 0.516 (93.8 %)                                    |
+| S600     | YOLOv8x Seg | 0.358 / 0.338 (94.4 %)                                  | 0.139 / 0.122 (87.8 %)                                    | 0.409 / 0.382 (93.4 %)                                     | 0.562 / 0.529 (94.1 %)                                    |
+
+#### Pose Estimation
+| Device   | Model        | Accuracy pose-all mAP@.50:.95 <br/> FP32 / BPU Python   | Accuracy pose-medium mAP@.50:.95 <br/> FP32 / BPU Python   | Accuracy pose-large mAP@.50:.95 <br/> FP32 / BPU Python   |
+|----------|--------------|---------------------------------------------------------|------------------------------------------------------------|-----------------------------------------------------------|
+| S600     | YOLO11n Pose | 0.465 / 0.448 (96.3 %)                                  | 0.386 / 0.374 (96.9 %)                                     | 0.597 / 0.572 (95.8 %)                                    |
+| S600     | YOLO11s Pose | 0.559 / 0.541 (96.8 %)                                  | 0.495 / 0.476 (96.2 %)                                     | 0.672 / 0.648 (96.4 %)                                    |
+| S600     | YOLO11m Pose | 0.627 / 0.605 (96.5 %)                                  | 0.586 / 0.566 (96.6 %)                                     | 0.711 / 0.688 (96.8 %)                                    |
+| S600     | YOLO11l Pose | 0.636 / 0.617 (97.0 %)                                  | 0.592 / 0.568 (95.9 %)                                     | 0.726 / 0.707 (97.4 %)                                    |
+| S600     | YOLO11x Pose | 0.672 / 0.651 (96.9 %)                                  | 0.634 / 0.610 (96.2 %)                                     | 0.750 / 0.731 (97.5 %)                                    |
+| S600     | YOLOv8n Pose | 0.476 / 0.461 (96.8 %)                                  | 0.391 / 0.373 (95.4 %)                                     | 0.610 / 0.593 (97.2 %)                                    |
+| S600     | YOLOv8s Pose | 0.578 / 0.552 (95.5 %)                                  | 0.510 / 0.486 (95.3 %)                                     | 0.692 / 0.667 (96.4 %)                                    |
+| S600     | YOLOv8m Pose | 0.630 / 0.605 (96.0 %)                                  | 0.578 / 0.552 (95.5 %)                                     | 0.724 / 0.703 (97.1 %)                                    |
+| S600     | YOLOv8l Pose | 0.657 / 0.633 (96.3 %)                                  | 0.607 / 0.581 (95.7 %)                                     | 0.747 / 0.719 (96.3 %)                                    |
+| S600     | YOLOv8x Pose | 0.671 / 0.651 (97.0 %)                                  | 0.624 / 0.603 (96.6 %)                                     | 0.757 / 0.739 (97.6 %)                                    |
+
+#### Image Classification
+| Device   | Model       | Accuracy TOP1 <br/> FP32 / BPU Python   | Accuracy TOP5 <br/> FP32 / BPU Python   |
+|----------|-------------|-----------------------------------------|-----------------------------------------|
+| S600     | YOLO11n CLS | 0.700 / 0.556 (79.4 %)                  | 0.894 / 0.794 (88.9 %)                  |
+| S600     | YOLO11s CLS | 0.754 / 0.666 (88.3 %)                  | 0.927 / 0.875 (94.3 %)                  |
+| S600     | YOLO11m CLS | 0.773 / 0.700 (90.5 %)                  | 0.939 / 0.897 (95.5 %)                  |
+| S600     | YOLO11l CLS | 0.783 / 0.718 (91.7 %)                  | 0.942 / 0.908 (96.4 %)                  |
+| S600     | YOLO11x CLS | 0.795 / 0.731 (92.0 %)                  | 0.949 / 0.917 (96.6 %)                  |
+| S600     | YOLOv8n CLS | 0.689 / 0.571 (82.9 %)                  | 0.883 / 0.803 (90.9 %)                  |
+| S600     | YOLOv8s CLS | 0.737 / 0.626 (84.9 %)                  | 0.917 / 0.844 (92.0 %)                  |
+| S600     | YOLOv8m CLS | 0.768 / 0.700 (91.1 %)                  | 0.935 / 0.899 (96.1 %)                  |
+| S600     | YOLOv8l CLS | 0.783 / 0.723 (92.3 %)                  | 0.942 / 0.909 (96.5 %)                  |
+| S600     | YOLOv8x CLS | 0.790 / 0.737 (93.3 %)                  | 0.945 / 0.920 (97.4 %)                  |
+### RDK S100P
 #### Obeject Detection
 | Device   | Model           | Accuracy bbox-all mAP@.50:.95 <br/> FP32 / BPU Python   | Accuracy bbox-small mAP@.50:.95 <br/> FP32 / BPU Python   | Accuracy bbox-medium mAP@.50:.95 <br/> FP32 / BPU Python   | Accuracy bbox-large mAP@.50:.95 <br/> FP32 / BPU Python   |
 |----------|-----------------|---------------------------------------------------------|-----------------------------------------------------------|------------------------------------------------------------|-----------------------------------------------------------|
@@ -216,84 +527,8 @@ hrt_model_exec perf --thread_num 2 --model_file < model.bin / model.hbm >
 | S100P    | YOLOv8m CLS | 0.768 / 0.703 (91.6 %)                  | 0.935 / 0.899 (96.2 %)                  |
 | S100P    | YOLOv8l CLS | 0.783 / 0.723 (92.3 %)                  | 0.942 / 0.910 (96.6 %)                  |
 | S100P    | YOLOv8x CLS | 0.790 / 0.742 (93.9 %)                  | 0.945 / 0.923 (97.6 %)                  |
-## Performance
+
 ### RDK S100
-#### Obeject Detection
-| Device   | Model           | Size(Pixels)   |   Classes | BPU Task Latency  /<br>BPU Throughput (Threads)                          | CPU Latency<br>(Single Core)   | params(M)   | FLOPs(B)   |
-|----------|-----------------|----------------|-----------|--------------------------------------------------------------------------|--------------------------------|-------------|------------|
-| S100     | YOLO12n Detect  | 640×640        |        80 | 2.65 ms / 368.54 FPS (1 thread ) <br/> 4.43 ms / 443.33 FPS (2 threads)  | 2.0 ms                         | 2.6 M       | 7.7 M      |
-| S100     | YOLO12s Detect  | 640×640        |        80 | 4.48 ms / 220.08 FPS (1 thread ) <br/> 8.10 ms / 244.66 FPS (2 threads)  | 2.0 ms                         | 9.3 M       | 21.4 M     |
-| S100     | YOLO12m Detect  | 640×640        |        80 | 9.27 ms / 107.09 FPS (1 thread ) <br/> 17.56 ms / 113.12 FPS (2 threads) | 2.0 ms                         | 20.2 M      | 67.5 M     |
-| S100     | YOLO12l Detect  | 640×640        |        80 | 14.66 ms / 67.85 FPS (1 thread ) <br/> 28.30 ms / 70.28 FPS (2 threads)  | 2.0 ms                         | 26.4 M      | 88.9 M     |
-| S100     | YOLO12x Detect  | 640×640        |        80 | 24.72 ms / 40.33 FPS (1 thread ) <br/> 48.27 ms / 41.26 FPS (2 threads)  | 2.0 ms                         | 59.1 M      | 199.0 M    |
-| S100     | YOLO11n Detect  | 640×640        |        80 | 1.62 ms / 596.53 FPS (1 thread ) <br/> 2.39 ms / 813.87 FPS (2 threads)  | 2.0 ms                         | 2.6 M       | 6.5 M      |
-| S100     | YOLO11s Detect  | 640×640        |        80 | 2.63 ms / 371.42 FPS (1 thread ) <br/> 4.39 ms / 448.18 FPS (2 threads)  | 2.0 ms                         | 9.4 M       | 21.5 M     |
-| S100     | YOLO11m Detect  | 640×640        |        80 | 5.63 ms / 175.69 FPS (1 thread ) <br/> 10.35 ms / 191.62 FPS (2 threads) | 2.0 ms                         | 20.1 M      | 68.0 M     |
-| S100     | YOLO11l Detect  | 640×640        |        80 | 6.96 ms / 142.36 FPS (1 thread ) <br/> 13.02 ms / 152.41 FPS (2 threads) | 2.0 ms                         | 25.3 M      | 86.9 M     |
-| S100     | YOLO11x Detect  | 640×640        |        80 | 13.13 ms / 75.78 FPS (1 thread ) <br/> 25.24 ms / 78.82 FPS (2 threads)  | 2.0 ms                         | 56.9 M      | 194.9 M    |
-| S100     | YOLOv10n Detect | 640×640        |        80 | 1.58 ms / 608.94 FPS (1 thread ) <br/> 2.32 ms / 837.04 FPS (2 threads)  | 2.0 ms                         | 2.3 M       | 6.7 M      |
-| S100     | YOLOv10s Detect | 640×640        |        80 | 2.53 ms / 385.50 FPS (1 thread ) <br/> 4.18 ms / 471.09 FPS (2 threads)  | 2.0 ms                         | 7.2 M       | 21.6 M     |
-| S100     | YOLOv10m Detect | 640×640        |        80 | 4.49 ms / 219.98 FPS (1 thread ) <br/> 8.11 ms / 244.17 FPS (2 threads)  | 2.0 ms                         | 15.4 M      | 59.1 M     |
-| S100     | YOLOv10b Detect | 640×640        |        80 | 6.28 ms / 157.57 FPS (1 thread ) <br/> 11.65 ms / 170.32 FPS (2 threads) | 2.0 ms                         | 19.1 M      | 92.0 M     |
-| S100     | YOLOv10l Detect | 640×640        |        80 | 7.95 ms / 124.70 FPS (1 thread ) <br/> 14.98 ms / 132.53 FPS (2 threads) | 2.0 ms                         | 24.4 M      | 120.3 M    |
-| S100     | YOLOv10x Detect | 640×640        |        80 | 10.83 ms / 91.79 FPS (1 thread ) <br/> 20.66 ms / 96.17 FPS (2 threads)  | 2.0 ms                         | 29.5 M      | 160.4 M    |
-| S100     | YOLOv9t Detect  | 640×640        |        80 | 1.77 ms / 546.03 FPS (1 thread ) <br/> 2.67 ms / 730.68 FPS (2 threads)  | 2.0 ms                         | 2.1 M       | 8.2 M      |
-| S100     | YOLOv9s Detect  | 640×640        |        80 | 2.74 ms / 357.91 FPS (1 thread ) <br/> 4.62 ms / 425.97 FPS (2 threads)  | 2.0 ms                         | 7.2 M       | 26.9 M     |
-| S100     | YOLOv9m Detect  | 640×640        |        80 | 5.52 ms / 179.23 FPS (1 thread ) <br/> 10.13 ms / 195.30 FPS (2 threads) | 2.0 ms                         | 20.1 M      | 76.8 M     |
-| S100     | YOLOv9c Detect  | 640×640        |        80 | 6.98 ms / 142.00 FPS (1 thread ) <br/> 13.05 ms / 151.95 FPS (2 threads) | 2.0 ms                         | 25.3 M      | 102.7 M    |
-| S100     | YOLOv9e Detect  | 640×640        |        80 | 17.75 ms / 56.15 FPS (1 thread ) <br/> 34.41 ms / 57.85 FPS (2 threads)  | 2.0 ms                         | 57.4 M      | 189.5 M    |
-| S100     | YOLOv8n Detect  | 640×640        |        80 | 1.53 ms / 632.06 FPS (1 thread ) <br/> 2.24 ms / 868.87 FPS (2 threads)  | 2.0 ms                         | 3.2 M       | 8.7 M      |
-| S100     | YOLOv8s Detect  | 640×640        |        80 | 2.63 ms / 371.16 FPS (1 thread ) <br/> 4.41 ms / 446.48 FPS (2 threads)  | 2.0 ms                         | 11.2 M      | 28.6 M     |
-| S100     | YOLOv8m Detect  | 640×640        |        80 | 5.18 ms / 190.64 FPS (1 thread ) <br/> 9.45 ms / 209.80 FPS (2 threads)  | 2.0 ms                         | 25.9 M      | 78.9 M     |
-| S100     | YOLOv8l Detect  | 640×640        |        80 | 9.97 ms / 99.68 FPS (1 thread ) <br/> 19.00 ms / 104.65 FPS (2 threads)  | 2.0 ms                         | 43.7 M      | 165.2 M    |
-| S100     | YOLOv8x Detect  | 640×640        |        80 | 15.77 ms / 63.15 FPS (1 thread ) <br/> 30.53 ms / 65.20 FPS (2 threads)  | 2.0 ms                         | 68.2 M      | 257.8 M    |
-| S100     | YOLOv5nu Detect | 640×640        |        80 | 1.42 ms / 674.92 FPS (1 thread ) <br/> 2.02 ms / 959.05 FPS (2 threads)  | 2.0 ms                         | 2.6 M       | 7.7 M      |
-| S100     | YOLOv5su Detect | 640×640        |        80 | 2.31 ms / 420.83 FPS (1 thread ) <br/> 3.79 ms / 519.22 FPS (2 threads)  | 2.0 ms                         | 9.1 M       | 24.0 M     |
-| S100     | YOLOv5mu Detect | 640×640        |        80 | 4.50 ms / 218.77 FPS (1 thread ) <br/> 8.11 ms / 244.06 FPS (2 threads)  | 2.0 ms                         | 25.1 M      | 64.2 M     |
-| S100     | YOLOv5lu Detect | 640×640        |        80 | 8.96 ms / 110.78 FPS (1 thread ) <br/> 16.97 ms / 117.15 FPS (2 threads) | 2.0 ms                         | 53.2 M      | 135.0 M    |
-| S100     | YOLOv5xu Detect | 640×640        |        80 | 15.97 ms / 62.32 FPS (1 thread ) <br/> 30.90 ms / 64.41 FPS (2 threads)  | 2.0 ms                         | 97.2 M      | 246.4 M    |
-#### Instance Segmentation
-| Device   | Model       | Size(Pixels)   |   Classes | BPU Task Latency  /<br>BPU Throughput (Threads)                          | CPU Latency<br>(Single Core)   | params(M)   | FLOPs(B)   |
-|----------|-------------|----------------|-----------|--------------------------------------------------------------------------|--------------------------------|-------------|------------|
-| S100     | YOLO11n Seg | 640×640        |        80 | 2.06 ms / 463.93 FPS (1 thread ) <br/> 3.17 ms / 613.76 FPS (2 threads)  | 5.0 ms                         | 2.9 M       | 10.4 M     |
-| S100     | YOLO11s Seg | 640×640        |        80 | 3.34 ms / 291.16 FPS (1 thread ) <br/> 5.69 ms / 344.91 FPS (2 threads)  | 5.0 ms                         | 10.1 M      | 35.5 M     |
-| S100     | YOLO11m Seg | 640×640        |        80 | 7.86 ms / 125.63 FPS (1 thread ) <br/> 14.67 ms / 135.16 FPS (2 threads) | 5.0 ms                         | 22.4 M      | 123.3 M    |
-| S100     | YOLO11l Seg | 640×640        |        80 | 9.17 ms / 108.00 FPS (1 thread ) <br/> 17.29 ms / 114.67 FPS (2 threads) | 5.0 ms                         | 27.6 M      | 142.2 M    |
-| S100     | YOLO11x Seg | 640×640        |        80 | 17.74 ms / 56.07 FPS (1 thread ) <br/> 34.33 ms / 57.96 FPS (2 threads)  | 5.0 ms                         | 62.1 M      | 319.0 M    |
-| S100     | YOLOv9c Seg | 640×640        |        80 | 9.07 ms / 109.16 FPS (1 thread ) <br/> 17.12 ms / 115.80 FPS (2 threads) | 5.0 ms                         | 27.7 M      | 158.0 M    |
-| S100     | YOLOv9e Seg | 640×640        |        80 | 20.15 ms / 49.38 FPS (1 thread ) <br/> 39.07 ms / 50.91 FPS (2 threads)  | 5.0 ms                         | 59.7 M      | 244.8 M    |
-| S100     | YOLOv8n Seg | 640×640        |        80 | 1.93 ms / 495.35 FPS (1 thread ) <br/> 2.98 ms / 652.21 FPS (2 threads)  | 5.0 ms                         | 3.4 M       | 12.6 M     |
-| S100     | YOLOv8s Seg | 640×640        |        80 | 3.37 ms / 288.70 FPS (1 thread ) <br/> 5.76 ms / 341.12 FPS (2 threads)  | 5.0 ms                         | 11.8 M      | 42.6 M     |
-| S100     | YOLOv8m Seg | 640×640        |        80 | 6.65 ms / 148.28 FPS (1 thread ) <br/> 12.29 ms / 161.07 FPS (2 threads) | 5.0 ms                         | 27.3 M      | 100.2 M    |
-| S100     | YOLOv8l Seg | 640×640        |        80 | 12.21 ms / 81.34 FPS (1 thread ) <br/> 23.32 ms / 85.17 FPS (2 threads)  | 5.0 ms                         | 46.0 M      | 220.5 M    |
-| S100     | YOLOv8x Seg | 640×640        |        80 | 19.51 ms / 51.00 FPS (1 thread ) <br/> 37.80 ms / 52.62 FPS (2 threads)  | 5.0 ms                         | 71.8 M      | 344.1 M    |
-#### Pose Estimation
-| Device   | Model        | Size(Pixels)   |   Classes | BPU Task Latency  /<br>BPU Throughput (Threads)                          | CPU Latency<br>(Single Core)   | params(M)   | FLOPs(B)   |
-|----------|--------------|----------------|-----------|--------------------------------------------------------------------------|--------------------------------|-------------|------------|
-| S100     | YOLO11n Pose | 640×640        |        80 | 1.69 ms / 568.00 FPS (1 thread ) <br/> 2.48 ms / 780.47 FPS (2 threads)  | 1.0 ms                         | 2.9 M       | 7.6 M      |
-| S100     | YOLO11s Pose | 640×640        |        80 | 2.76 ms / 354.06 FPS (1 thread ) <br/> 4.62 ms / 424.92 FPS (2 threads)  | 1.0 ms                         | 9.9 M       | 23.2 M     |
-| S100     | YOLO11m Pose | 640×640        |        80 | 5.89 ms / 167.50 FPS (1 thread ) <br/> 10.79 ms / 183.34 FPS (2 threads) | 1.0 ms                         | 20.9 M      | 71.7 M     |
-| S100     | YOLO11l Pose | 640×640        |        80 | 7.23 ms / 136.91 FPS (1 thread ) <br/> 13.48 ms / 147.21 FPS (2 threads) | 1.0 ms                         | 26.2 M      | 90.7 M     |
-| S100     | YOLO11x Pose | 640×640        |        80 | 13.61 ms / 73.02 FPS (1 thread ) <br/> 26.16 ms / 76.04 FPS (2 threads)  | 1.0 ms                         | 58.8 M      | 203.3 M    |
-| S100     | YOLOv8n Pose | 640×640        |        80 | 1.62 ms / 587.59 FPS (1 thread ) <br/> 2.31 ms / 837.95 FPS (2 threads)  | 1.0 ms                         | 3.3 M       | 9.2 M      |
-| S100     | YOLOv8s Pose | 640×640        |        80 | 2.83 ms / 344.35 FPS (1 thread ) <br/> 4.71 ms / 417.72 FPS (2 threads)  | 1.0 ms                         | 11.6 M      | 30.2 M     |
-| S100     | YOLOv8m Pose | 640×640        |        80 | 5.47 ms / 180.46 FPS (1 thread ) <br/> 9.92 ms / 199.50 FPS (2 threads)  | 1.0 ms                         | 26.4 M      | 81.0 M     |
-| S100     | YOLOv8l Pose | 640×640        |        80 | 10.31 ms / 96.20 FPS (1 thread ) <br/> 19.55 ms / 101.60 FPS (2 threads) | 1.0 ms                         | 44.4 M      | 168.6 M    |
-| S100     | YOLOv8x Pose | 640×640        |        80 | 16.07 ms / 61.88 FPS (1 thread ) <br/> 31.01 ms / 64.14 FPS (2 threads)  | 1.0 ms                         | 69.4 M      | 263.2 M    |
-#### Image Classification
-| Device   | Model       | Size(Pixels)   |   Classes | BPU Task Latency  /<br>BPU Throughput (Threads)                                                                   | CPU Latency<br>(Single Core)   | params(M)   | FLOPs(B)   |
-|----------|-------------|----------------|-----------|-------------------------------------------------------------------------------------------------------------------|--------------------------------|-------------|------------|
-| S100     | YOLO11n CLS | 640×640        |        80 | 0.53 ms / 1827.92 FPS (1 thread ) <br/> 0.62 ms / 3115.65 FPS (2 threads) <br/> 0.70 ms / 4141.22 FPS (3 threads) | 0.5 ms                         | 2.8 M       | 4.2 M      |
-| S100     | YOLO11s CLS | 640×640        |        80 | 0.68 ms / 1415.98 FPS (1 thread ) <br/> 0.76 ms / 2553.99 FPS (2 threads) <br/> 1.05 ms / 2767.63 FPS (3 threads) | 0.5 ms                         | 6.7 M       | 13.0 M     |
-| S100     | YOLO11m CLS | 640×640        |        80 | 1.02 ms / 955.28 FPS (1 thread ) <br/> 1.35 ms / 1445.18 FPS (2 threads)                                          | 0.5 ms                         | 11.6 M      | 40.3 M     |
-| S100     | YOLO11l CLS | 640×640        |        80 | 1.21 ms / 805.52 FPS (1 thread ) <br/> 1.73 ms / 1139.48 FPS (2 threads)                                          | 0.5 ms                         | 14.1 M      | 50.4 M     |
-| S100     | YOLO11x CLS | 640×640        |        80 | 1.97 ms / 501.49 FPS (1 thread ) <br/> 3.23 ms / 612.29 FPS (2 threads)                                           | 0.5 ms                         | 29.6 M      | 111.3 M    |
-| S100     | YOLOv8n CLS | 640×640        |        80 | 0.49 ms / 1928.23 FPS (1 thread ) <br/> 0.57 ms / 3399.86 FPS (2 threads) <br/> 0.66 ms / 4410.92 FPS (3 threads) | 0.5 ms                         | 2.7 M       | 4.3 M      |
-| S100     | YOLOv8s CLS | 640×640        |        80 | 0.62 ms / 1562.83 FPS (1 thread ) <br/> 0.71 ms / 2712.53 FPS (2 threads) <br/> 0.89 ms / 3279.66 FPS (3 threads) | 0.5 ms                         | 6.4 M       | 13.5 M     |
-| S100     | YOLOv8m CLS | 640×640        |        80 | 1.00 ms / 970.04 FPS (1 thread ) <br/> 1.31 ms / 1500.86 FPS (2 threads)                                          | 0.5 ms                         | 17.0 M      | 42.7 M     |
-| S100     | YOLOv8l CLS | 640×640        |        80 | 1.98 ms / 497.58 FPS (1 thread ) <br/> 3.22 ms / 614.92 FPS (2 threads)                                           | 0.5 ms                         | 37.5 M      | 99.7 M     |
-| S100     | YOLOv8x CLS | 640×640        |        80 | 2.77 ms / 357.03 FPS (1 thread ) <br/> 4.81 ms / 412.60 FPS (2 threads)                                           | 0.5 ms                         | 57.4 M      | 154.8 M    |
-## Accuracy
 #### Obeject Detection
 | Device   | Model           | Accuracy bbox-all mAP@.50:.95 <br/> FP32 / BPU Python   | Accuracy bbox-small mAP@.50:.95 <br/> FP32 / BPU Python   | Accuracy bbox-medium mAP@.50:.95 <br/> FP32 / BPU Python   | Accuracy bbox-large mAP@.50:.95 <br/> FP32 / BPU Python   |
 |----------|-----------------|---------------------------------------------------------|-----------------------------------------------------------|------------------------------------------------------------|-----------------------------------------------------------|
@@ -385,84 +620,8 @@ hrt_model_exec perf --thread_num 2 --model_file < model.bin / model.hbm >
 | S100     | YOLOv8m CLS | 0.768 / 0.702 (91.4 %)                  | 0.935 / 0.899 (96.2 %)                  |
 | S100     | YOLOv8l CLS | 0.783 / 0.723 (92.3 %)                  | 0.942 / 0.909 (96.5 %)                  |
 | S100     | YOLOv8x CLS | 0.790 / 0.742 (93.9 %)                  | 0.945 / 0.921 (97.5 %)                  |
-## Performance
+
 ### RDK X5
-#### Obeject Detection
-| Device   | Model           | Size(Pixels)   |   Classes | BPU Task Latency  /<br>BPU Throughput (Threads)                          | CPU Latency<br>(Single Core)   | params(M)   | FLOPs(B)   |
-|----------|-----------------|----------------|-----------|--------------------------------------------------------------------------|--------------------------------|-------------|------------|
-| X5       | YOLO12n Detect  | 640×640        |        80 | 39.70 ms / 25.17 FPS (1 thread ) <br/> 73.19 ms / 27.24 FPS (2 threads)  | 5.0 ms                         | 2.6 M       | 7.7 M      |
-| X5       | YOLO12s Detect  | 640×640        |        80 | 63.74 ms / 15.68 FPS (1 thread ) <br/> 121.24 ms / 16.45 FPS (2 threads) | 5.0 ms                         | 9.3 M       | 21.4 M     |
-| X5       | YOLO12m Detect  | 640×640        |        80 | 103.02 ms / 9.70 FPS (1 thread ) <br/> 199.58 ms / 9.99 FPS (2 threads)  | 5.0 ms                         | 20.2 M      | 67.5 M     |
-| X5       | YOLO12l Detect  | 640×640        |        80 | 183.00 ms / 5.46 FPS (1 thread ) <br/> 359.03 ms / 5.56 FPS (2 threads)  | 5.0 ms                         | 26.4 M      | 88.9 M     |
-| X5       | YOLO12x Detect  | 640×640        |        80 | 315.16 ms / 3.17 FPS (1 thread )                                         | 5.0 ms                         | 59.1 M      | 199.0 M    |
-| X5       | YOLO11n Detect  | 640×640        |        80 | 8.25 ms / 121.05 FPS (1 thread ) <br/> 10.56 ms / 188.57 FPS (2 threads) | 5.0 ms                         | 2.6 M       | 6.5 M      |
-| X5       | YOLO11s Detect  | 640×640        |        80 | 15.81 ms / 63.16 FPS (1 thread ) <br/> 25.74 ms / 77.43 FPS (2 threads)  | 5.0 ms                         | 9.4 M       | 21.5 M     |
-| X5       | YOLO11m Detect  | 640×640        |        80 | 34.68 ms / 28.82 FPS (1 thread ) <br/> 63.30 ms / 31.51 FPS (2 threads)  | 5.0 ms                         | 20.1 M      | 68.0 M     |
-| X5       | YOLO11l Detect  | 640×640        |        80 | 45.23 ms / 22.10 FPS (1 thread ) <br/> 84.30 ms / 23.66 FPS (2 threads)  | 5.0 ms                         | 25.3 M      | 86.9 M     |
-| X5       | YOLO11x Detect  | 640×640        |        80 | 96.70 ms / 10.34 FPS (1 thread ) <br/> 186.76 ms / 10.68 FPS (2 threads) | 5.0 ms                         | 56.9 M      | 194.9 M    |
-| X5       | YOLOv10n Detect | 640×640        |        80 | 8.75 ms / 114.19 FPS (1 thread ) <br/> 11.60 ms / 171.72 FPS (2 threads) | 5.0 ms                         | 2.3 M       | 6.7 M      |
-| X5       | YOLOv10s Detect | 640×640        |        80 | 14.84 ms / 67.32 FPS (1 thread ) <br/> 23.85 ms / 83.58 FPS (2 threads)  | 5.0 ms                         | 7.2 M       | 21.6 M     |
-| X5       | YOLOv10m Detect | 640×640        |        80 | 29.40 ms / 33.99 FPS (1 thread ) <br/> 52.83 ms / 37.75 FPS (2 threads)  | 5.0 ms                         | 15.4 M      | 59.1 M     |
-| X5       | YOLOv10b Detect | 640×640        |        80 | 40.14 ms / 24.90 FPS (1 thread ) <br/> 74.20 ms / 26.88 FPS (2 threads)  | 5.0 ms                         | 19.1 M      | 92.0 M     |
-| X5       | YOLOv10l Detect | 640×640        |        80 | 49.89 ms / 20.04 FPS (1 thread ) <br/> 93.66 ms / 21.30 FPS (2 threads)  | 5.0 ms                         | 24.4 M      | 120.3 M    |
-| X5       | YOLOv10x Detect | 640×640        |        80 | 68.92 ms / 14.51 FPS (1 thread ) <br/> 131.54 ms / 15.16 FPS (2 threads) | 5.0 ms                         | 29.5 M      | 160.4 M    |
-| X5       | YOLOv9t Detect  | 640×640        |        80 | 6.97 ms / 143.14 FPS (1 thread ) <br/> 7.96 ms / 250.11 FPS (2 threads)  | 5.0 ms                         | 2.1 M       | 8.2 M      |
-| X5       | YOLOv9s Detect  | 640×640        |        80 | 13.00 ms / 76.81 FPS (1 thread ) <br/> 20.16 ms / 98.81 FPS (2 threads)  | 5.0 ms                         | 7.2 M       | 26.9 M     |
-| X5       | YOLOv9m Detect  | 640×640        |        80 | 32.63 ms / 30.63 FPS (1 thread ) <br/> 59.31 ms / 33.62 FPS (2 threads)  | 5.0 ms                         | 20.1 M      | 76.8 M     |
-| X5       | YOLOv9c Detect  | 640×640        |        80 | 40.46 ms / 24.71 FPS (1 thread ) <br/> 74.77 ms / 26.67 FPS (2 threads)  | 5.0 ms                         | 25.3 M      | 102.7 M    |
-| X5       | YOLOv9e Detect  | 640×640        |        80 | 119.80 ms / 8.35 FPS (1 thread ) <br/> 233.08 ms / 8.56 FPS (2 threads)  | 5.0 ms                         | 57.4 M      | 189.5 M    |
-| X5       | YOLOv8n Detect  | 640×640        |        80 | 7.00 ms / 142.60 FPS (1 thread ) <br/> 8.06 ms / 246.82 FPS (2 threads)  | 5.0 ms                         | 3.2 M       | 8.7 M      |
-| X5       | YOLOv8s Detect  | 640×640        |        80 | 13.63 ms / 73.30 FPS (1 thread ) <br/> 21.38 ms / 93.20 FPS (2 threads)  | 5.0 ms                         | 11.2 M      | 28.6 M     |
-| X5       | YOLOv8m Detect  | 640×640        |        80 | 30.74 ms / 32.51 FPS (1 thread ) <br/> 55.51 ms / 35.93 FPS (2 threads)  | 5.0 ms                         | 25.9 M      | 78.9 M     |
-| X5       | YOLOv8l Detect  | 640×640        |        80 | 59.51 ms / 16.80 FPS (1 thread ) <br/> 112.80 ms / 17.68 FPS (2 threads) | 5.0 ms                         | 43.7 M      | 165.2 M    |
-| X5       | YOLOv8x Detect  | 640×640        |        80 | 92.72 ms / 10.78 FPS (1 thread ) <br/> 178.95 ms / 11.15 FPS (2 threads) | 5.0 ms                         | 68.2 M      | 257.8 M    |
-| X5       | YOLOv5nu Detect | 640×640        |        80 | 6.33 ms / 157.59 FPS (1 thread ) <br/> 6.80 ms / 291.89 FPS (2 threads)  | 5.0 ms                         | 2.6 M       | 7.7 M      |
-| X5       | YOLOv5su Detect | 640×640        |        80 | 12.33 ms / 81.04 FPS (1 thread ) <br/> 18.88 ms / 105.56 FPS (2 threads) | 5.0 ms                         | 9.1 M       | 24.0 M     |
-| X5       | YOLOv5mu Detect | 640×640        |        80 | 26.57 ms / 37.62 FPS (1 thread ) <br/> 47.20 ms / 42.24 FPS (2 threads)  | 5.0 ms                         | 25.1 M      | 64.2 M     |
-| X5       | YOLOv5lu Detect | 640×640        |        80 | 52.83 ms / 18.92 FPS (1 thread ) <br/> 99.42 ms / 20.06 FPS (2 threads)  | 5.0 ms                         | 53.2 M      | 135.0 M    |
-| X5       | YOLOv5xu Detect | 640×640        |        80 | 91.55 ms / 10.92 FPS (1 thread ) <br/> 176.49 ms / 11.30 FPS (2 threads) | 5.0 ms                         | 97.2 M      | 246.4 M    |
-#### Instance Segmentation
-| Device   | Model       | Size(Pixels)   |   Classes | BPU Task Latency  /<br>BPU Throughput (Threads)                          | CPU Latency<br>(Single Core)   | params(M)   | FLOPs(B)   |
-|----------|-------------|----------------|-----------|--------------------------------------------------------------------------|--------------------------------|-------------|------------|
-| X5       | YOLO11n Seg | 640×640        |        80 | 11.55 ms / 86.39 FPS (1 thread ) <br/> 12.83 ms / 155.10 FPS (2 threads) | 20.0 ms                        | 2.9 M       | 10.4 M     |
-| X5       | YOLO11s Seg | 640×640        |        80 | 21.62 ms / 46.22 FPS (1 thread ) <br/> 33.12 ms / 60.20 FPS (2 threads)  | 20.0 ms                        | 10.1 M      | 35.5 M     |
-| X5       | YOLO11m Seg | 640×640        |        80 | 50.43 ms / 19.82 FPS (1 thread ) <br/> 90.49 ms / 22.04 FPS (2 threads)  | 20.0 ms                        | 22.4 M      | 123.3 M    |
-| X5       | YOLO11l Seg | 640×640        |        80 | 60.60 ms / 16.50 FPS (1 thread ) <br/> 110.99 ms / 17.97 FPS (2 threads) | 20.0 ms                        | 27.6 M      | 142.2 M    |
-| X5       | YOLO11x Seg | 640×640        |        80 | 130.40 ms / 7.67 FPS (1 thread ) <br/> 249.71 ms / 7.99 FPS (2 threads)  | 20.0 ms                        | 62.1 M      | 319.0 M    |
-| X5       | YOLOv9c Seg | 640×640        |        80 | 55.85 ms / 17.90 FPS (1 thread ) <br/> 101.47 ms / 19.65 FPS (2 threads) | 20.0 ms                        | 27.7 M      | 158.0 M    |
-| X5       | YOLOv9e Seg | 640×640        |        80 | 135.34 ms / 7.39 FPS (1 thread ) <br/> 260.08 ms / 7.67 FPS (2 threads)  | 20.0 ms                        | 59.7 M      | 244.8 M    |
-| X5       | YOLOv8n Seg | 640×640        |        80 | 10.40 ms / 96.02 FPS (1 thread ) <br/> 10.75 ms / 185.21 FPS (2 threads) | 20.0 ms                        | 3.4 M       | 12.6 M     |
-| X5       | YOLOv8s Seg | 640×640        |        80 | 19.56 ms / 51.08 FPS (1 thread ) <br/> 28.99 ms / 68.76 FPS (2 threads)  | 20.0 ms                        | 11.8 M      | 42.6 M     |
-| X5       | YOLOv8m Seg | 640×640        |        80 | 40.52 ms / 24.67 FPS (1 thread ) <br/> 70.70 ms / 28.21 FPS (2 threads)  | 20.0 ms                        | 27.3 M      | 100.2 M    |
-| X5       | YOLOv8l Seg | 640×640        |        80 | 75.00 ms / 13.33 FPS (1 thread ) <br/> 139.61 ms / 14.29 FPS (2 threads) | 20.0 ms                        | 46.0 M      | 220.5 M    |
-| X5       | YOLOv8x Seg | 640×640        |        80 | 115.94 ms / 8.62 FPS (1 thread ) <br/> 221.06 ms / 9.02 FPS (2 threads)  | 20.0 ms                        | 71.8 M      | 344.1 M    |
-#### Pose Estimation
-| Device   | Model        | Size(Pixels)   |   Classes | BPU Task Latency  /<br>BPU Throughput (Threads)                          | CPU Latency<br>(Single Core)   | params(M)   | FLOPs(B)   |
-|----------|--------------|----------------|-----------|--------------------------------------------------------------------------|--------------------------------|-------------|------------|
-| X5       | YOLO11n Pose | 640×640        |        80 | 8.36 ms / 119.43 FPS (1 thread ) <br/> 10.97 ms / 181.61 FPS (2 threads) | 10.0 ms                        | 2.9 M       | 7.6 M      |
-| X5       | YOLO11s Pose | 640×640        |        80 | 16.35 ms / 61.11 FPS (1 thread ) <br/> 26.99 ms / 73.85 FPS (2 threads)  | 10.0 ms                        | 9.9 M       | 23.2 M     |
-| X5       | YOLO11m Pose | 640×640        |        80 | 35.74 ms / 27.97 FPS (1 thread ) <br/> 65.60 ms / 30.40 FPS (2 threads)  | 10.0 ms                        | 20.9 M      | 71.7 M     |
-| X5       | YOLO11l Pose | 640×640        |        80 | 46.38 ms / 21.55 FPS (1 thread ) <br/> 86.82 ms / 22.97 FPS (2 threads)  | 10.0 ms                        | 26.2 M      | 90.7 M     |
-| X5       | YOLO11x Pose | 640×640        |        80 | 98.88 ms / 10.11 FPS (1 thread ) <br/> 191.38 ms / 10.42 FPS (2 threads) | 10.0 ms                        | 58.8 M      | 203.3 M    |
-| X5       | YOLOv8n Pose | 640×640        |        80 | 6.95 ms / 143.64 FPS (1 thread ) <br/> 8.23 ms / 241.76 FPS (2 threads)  | 10.0 ms                        | 3.3 M       | 9.2 M      |
-| X5       | YOLOv8s Pose | 640×640        |        80 | 14.16 ms / 70.54 FPS (1 thread ) <br/> 22.62 ms / 88.09 FPS (2 threads)  | 10.0 ms                        | 11.6 M      | 30.2 M     |
-| X5       | YOLOv8m Pose | 640×640        |        80 | 31.60 ms / 31.62 FPS (1 thread ) <br/> 57.34 ms / 34.78 FPS (2 threads)  | 10.0 ms                        | 26.4 M      | 81.0 M     |
-| X5       | YOLOv8l Pose | 640×640        |        80 | 60.37 ms / 16.56 FPS (1 thread ) <br/> 114.73 ms / 17.38 FPS (2 threads) | 10.0 ms                        | 44.4 M      | 168.6 M    |
-| X5       | YOLOv8x Pose | 640×640        |        80 | 94.15 ms / 10.62 FPS (1 thread ) <br/> 182.08 ms / 10.96 FPS (2 threads) | 10.0 ms                        | 69.4 M      | 263.2 M    |
-#### Image Classification
-| Device   | Model       | Size(Pixels)   |   Classes | BPU Task Latency  /<br>BPU Throughput (Threads)                           | CPU Latency<br>(Single Core)   | params(M)   | FLOPs(B)   |
-|----------|-------------|----------------|-----------|---------------------------------------------------------------------------|--------------------------------|-------------|------------|
-| X5       | YOLO11n CLS | 640×640        |        80 | 1.06 ms / 939.95 FPS (1 thread ) <br/> 1.61 ms / 1236.07 FPS (2 threads)  | 0.5 ms                         | 2.8 M       | 4.2 M      |
-| X5       | YOLO11s CLS | 640×640        |        80 | 2.01 ms / 495.14 FPS (1 thread ) <br/> 3.49 ms / 569.44 FPS (2 threads)   | 0.5 ms                         | 6.7 M       | 13.0 M     |
-| X5       | YOLO11m CLS | 640×640        |        80 | 3.82 ms / 261.13 FPS (1 thread ) <br/> 7.09 ms / 280.82 FPS (2 threads)   | 0.5 ms                         | 11.6 M      | 40.3 M     |
-| X5       | YOLO11l CLS | 640×640        |        80 | 5.02 ms / 199.15 FPS (1 thread ) <br/> 9.49 ms / 210.12 FPS (2 threads)   | 0.5 ms                         | 14.1 M      | 50.4 M     |
-| X5       | YOLO11x CLS | 640×640        |        80 | 10.04 ms / 99.49 FPS (1 thread ) <br/> 19.48 ms / 102.39 FPS (2 threads)  | 0.5 ms                         | 29.6 M      | 111.3 M    |
-| X5       | YOLOv8n CLS | 640×640        |        80 | 0.74 ms / 1348.98 FPS (1 thread ) <br/> 0.98 ms / 2018.94 FPS (2 threads) | 0.5 ms                         | 2.7 M       | 4.3 M      |
-| X5       | YOLOv8s CLS | 640×640        |        80 | 1.44 ms / 690.86 FPS (1 thread ) <br/> 2.36 ms / 842.52 FPS (2 threads)   | 0.5 ms                         | 6.4 M       | 13.5 M     |
-| X5       | YOLOv8m CLS | 640×640        |        80 | 3.66 ms / 272.72 FPS (1 thread ) <br/> 6.78 ms / 294.01 FPS (2 threads)   | 0.5 ms                         | 17.0 M      | 42.7 M     |
-| X5       | YOLOv8l CLS | 640×640        |        80 | 7.98 ms / 125.23 FPS (1 thread ) <br/> 15.38 ms / 129.63 FPS (2 threads)  | 0.5 ms                         | 37.5 M      | 99.7 M     |
-| X5       | YOLOv8x CLS | 640×640        |        80 | 13.12 ms / 76.18 FPS (1 thread ) <br/> 25.64 ms / 77.78 FPS (2 threads)   | 0.5 ms                         | 57.4 M      | 154.8 M    |
-## Accuracy
 #### Obeject Detection
 | Device   | Model           | Accuracy bbox-all mAP@.50:.95 <br/> FP32 / BPU Python   | Accuracy bbox-small mAP@.50:.95 <br/> FP32 / BPU Python   | Accuracy bbox-medium mAP@.50:.95 <br/> FP32 / BPU Python   | Accuracy bbox-large mAP@.50:.95 <br/> FP32 / BPU Python   |
 |----------|-----------------|---------------------------------------------------------|-----------------------------------------------------------|------------------------------------------------------------|-----------------------------------------------------------|

--- a/samples/vision/ultralytics_yolo/evaluator/eval_yolo_cls.py
+++ b/samples/vision/ultralytics_yolo/evaluator/eval_yolo_cls.py
@@ -1,0 +1,81 @@
+import os
+import sys
+import json
+import time
+import argparse
+
+import cv2
+
+current_dir = os.path.dirname(os.path.abspath(__file__))
+runtime_path = os.path.abspath(os.path.join(current_dir, "../runtime/python"))
+project_root = os.path.abspath(os.path.join(current_dir, "../../../../"))
+sys.path.append(runtime_path)
+sys.path.append(project_root)
+
+from yolo_cls import YoloCls, YoloClsConfig
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Ultralytics YOLO Classification Evaluation")
+    parser.add_argument("--model-path", required=True)
+    parser.add_argument("--image-dir", required=True)
+    parser.add_argument("--val-txt", required=True)
+    parser.add_argument("--json-save-path", default="results_cls.json")
+    parser.add_argument("--limit", type=int, default=0)
+    parser.add_argument("--topk", type=int, default=5)
+    parser.add_argument("--label-offset", type=int, default=0)
+    parser.add_argument("--log-interval", type=int, default=1000)
+    args = parser.parse_args()
+
+    model = YoloCls(YoloClsConfig(model_path=args.model_path, topk=args.topk))
+    gt_map = {}
+    with open(args.val_txt, "r", encoding="utf-8") as f:
+        for line in f:
+            parts = line.strip().split()
+            if len(parts) >= 2:
+                gt_map[os.path.basename(parts[0])] = int(parts[1]) + args.label_offset
+
+    img_files = sorted([f for f in os.listdir(args.image_dir) if f.lower().endswith((".jpg", ".jpeg", ".png", ".jpeg"))])
+    if args.limit > 0:
+        img_files = img_files[:args.limit]
+
+    top1 = 0
+    top5 = 0
+    total = 0
+    start = time.time()
+    for img_file in img_files:
+        if img_file not in gt_map:
+            continue
+        img = cv2.imread(os.path.join(args.image_dir, img_file))
+        if img is None:
+            continue
+        preds = model(img, topk=args.topk)
+        pred_ids = [p[0] for p in preds]
+        gt = gt_map[img_file]
+        total += 1
+        if pred_ids and pred_ids[0] == gt:
+            top1 += 1
+        if gt in pred_ids[:5]:
+            top5 += 1
+        if args.log_interval > 0 and total % args.log_interval == 0:
+            elapsed = time.time() - start
+            print({
+                "progress": total,
+                "top1": top1 / total if total else 0.0,
+                "top5": top5 / total if total else 0.0,
+                "elapsed_sec": elapsed,
+            }, flush=True)
+
+    summary = {
+        "total": total,
+        "top1": top1 / total if total else 0.0,
+        "top5": top5 / total if total else 0.0,
+        "elapsed_sec": time.time() - start,
+    }
+    with open(args.json_save_path, "w", encoding="utf-8") as f:
+        json.dump(summary, f, indent=2)
+    print(summary)
+
+
+if __name__ == "__main__":
+    main()

--- a/samples/vision/ultralytics_yolo/evaluator/eval_yolo_det.py
+++ b/samples/vision/ultralytics_yolo/evaluator/eval_yolo_det.py
@@ -1,0 +1,83 @@
+import os
+import sys
+import json
+import time
+import argparse
+
+import cv2
+from pycocotools.coco import COCO
+from pycocotools.cocoeval import COCOeval
+
+current_dir = os.path.dirname(os.path.abspath(__file__))
+runtime_path = os.path.abspath(os.path.join(current_dir, "../runtime/python"))
+project_root = os.path.abspath(os.path.join(current_dir, "../../../../"))
+sys.path.append(runtime_path)
+sys.path.append(project_root)
+
+from yolo_detect import YoloDetect, YoloDetectConfig
+from yolo_v10detect import YoloV10Detect, YoloV10DetectConfig
+
+
+def build_model(model_path: str):
+    name = os.path.basename(model_path).lower()
+    if "yolov10" in name:
+        return YoloV10Detect(YoloV10DetectConfig(model_path=model_path)), True
+    return YoloDetect(YoloDetectConfig(model_path=model_path)), False
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Ultralytics YOLO Detection Evaluation")
+    parser.add_argument("--model-path", required=True)
+    parser.add_argument("--image-dir", required=True)
+    parser.add_argument("--annotation", required=True)
+    parser.add_argument("--conf-thres", type=float, default=0.25)
+    parser.add_argument("--nms-thres", type=float, default=0.7)
+    parser.add_argument("--json-save-path", default="results_det.json")
+    parser.add_argument("--limit", type=int, default=0)
+    args = parser.parse_args()
+
+    coco = COCO(args.annotation)
+    image_ids = coco.getImgIds()
+    if args.limit > 0:
+        image_ids = image_ids[:args.limit]
+
+    coco_cat_ids = [cat["id"] for cat in coco.dataset["categories"]]
+
+    model, is_yolov10 = build_model(args.model_path)
+    results = []
+    start = time.time()
+
+    for image_id in image_ids:
+        info = coco.loadImgs([image_id])[0]
+        path = os.path.join(args.image_dir, info["file_name"])
+        img = cv2.imread(path)
+        if img is None:
+            continue
+        if is_yolov10:
+            boxes, scores, cls_ids = model(img, score_thres=args.conf_thres)
+        else:
+            boxes, scores, cls_ids = model(img, score_thres=args.conf_thres, nms_thres=args.nms_thres)
+        for box, score, cls_id in zip(boxes, scores, cls_ids):
+            x1, y1, x2, y2 = [float(v) for v in box]
+            results.append({
+                "image_id": image_id,
+                "category_id": int(coco_cat_ids[int(cls_id)]),
+                "bbox": [x1, y1, x2 - x1, y2 - y1],
+                "score": float(score),
+            })
+
+    with open(args.json_save_path, "w", encoding="utf-8") as f:
+        json.dump(results, f)
+
+    coco_dt = coco.loadRes(args.json_save_path)
+    coco_eval = COCOeval(coco, coco_dt, "bbox")
+    coco_eval.evaluate()
+    coco_eval.accumulate()
+    coco_eval.summarize()
+    print(f"elapsed: {time.time() - start:.3f}s")
+
+
+if __name__ == "__main__":
+    main()
+
+

--- a/samples/vision/ultralytics_yolo/evaluator/eval_yolo_pose.py
+++ b/samples/vision/ultralytics_yolo/evaluator/eval_yolo_pose.py
@@ -1,0 +1,72 @@
+import os
+import sys
+import json
+import time
+import argparse
+
+import cv2
+from pycocotools.coco import COCO
+from pycocotools.cocoeval import COCOeval
+
+current_dir = os.path.dirname(os.path.abspath(__file__))
+runtime_path = os.path.abspath(os.path.join(current_dir, "../runtime/python"))
+project_root = os.path.abspath(os.path.join(current_dir, "../../../../"))
+sys.path.append(runtime_path)
+sys.path.append(project_root)
+
+from yolo_pose import YoloPose, YoloPoseConfig
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Ultralytics YOLO Pose Evaluation")
+    parser.add_argument("--model-path", required=True)
+    parser.add_argument("--image-dir", required=True)
+    parser.add_argument("--annotation", required=True)
+    parser.add_argument("--conf-thres", type=float, default=0.25)
+    parser.add_argument("--nms-thres", type=float, default=0.7)
+    parser.add_argument("--json-save-path", default="results_pose.json")
+    parser.add_argument("--limit", type=int, default=0)
+    args = parser.parse_args()
+
+    coco = COCO(args.annotation)
+    image_ids = coco.getImgIds()
+    if args.limit > 0:
+        image_ids = image_ids[:args.limit]
+
+    model = YoloPose(YoloPoseConfig(model_path=args.model_path))
+    results = []
+    start = time.time()
+    for image_id in image_ids:
+        info = coco.loadImgs([image_id])[0]
+        img = cv2.imread(os.path.join(args.image_dir, info["file_name"]))
+        if img is None:
+            continue
+        boxes, scores, cls_ids, kpts_xy, kpts_score = model(img, score_thres=args.conf_thres, nms_thres=args.nms_thres)
+        for box, score, kxy, kscore in zip(boxes, scores, kpts_xy, kpts_score):
+            x1, y1, x2, y2 = [float(v) for v in box]
+            flat_kpts = []
+            for (x, y), ks in zip(kxy, kscore):
+                ks_value = ks.item() if hasattr(ks, "item") else float(ks)
+                flat_kpts.extend([float(x), float(y), 1 if ks_value > 0 else 0])
+            results.append({
+                "image_id": image_id,
+                "category_id": 1,
+                "bbox": [x1, y1, x2 - x1, y2 - y1],
+                "score": float(score),
+                "keypoints": flat_kpts,
+            })
+
+    with open(args.json_save_path, "w", encoding="utf-8") as f:
+        json.dump(results, f)
+
+    coco_dt = coco.loadRes(args.json_save_path)
+    coco_eval = COCOeval(coco, coco_dt, "keypoints")
+    coco_eval.evaluate()
+    coco_eval.accumulate()
+    coco_eval.summarize()
+    print(f"elapsed: {time.time() - start:.3f}s")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/samples/vision/ultralytics_yolo/evaluator/eval_yolo_seg.py
+++ b/samples/vision/ultralytics_yolo/evaluator/eval_yolo_seg.py
@@ -1,0 +1,85 @@
+import os
+import sys
+import json
+import time
+import argparse
+
+import cv2
+import numpy as np
+from pycocotools.coco import COCO
+from pycocotools.cocoeval import COCOeval
+from pycocotools import mask as mask_utils
+
+current_dir = os.path.dirname(os.path.abspath(__file__))
+runtime_path = os.path.abspath(os.path.join(current_dir, "../runtime/python"))
+project_root = os.path.abspath(os.path.join(current_dir, "../../../../"))
+sys.path.append(runtime_path)
+sys.path.append(project_root)
+
+from yolo_seg import YoloSeg, YoloSegConfig
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Ultralytics YOLO Segmentation Evaluation")
+    parser.add_argument("--model-path", required=True)
+    parser.add_argument("--image-dir", required=True)
+    parser.add_argument("--annotation", required=True)
+    parser.add_argument("--conf-thres", type=float, default=0.25)
+    parser.add_argument("--nms-thres", type=float, default=0.7)
+    parser.add_argument("--json-save-path", default="results_seg.json")
+    parser.add_argument("--limit", type=int, default=0)
+    args = parser.parse_args()
+
+    coco = COCO(args.annotation)
+    image_ids = coco.getImgIds()
+    if args.limit > 0:
+        image_ids = image_ids[:args.limit]
+
+    coco_cat_ids = [cat["id"] for cat in coco.dataset["categories"]]
+
+    model = YoloSeg(YoloSegConfig(model_path=args.model_path))
+    results = []
+    start = time.time()
+    for image_id in image_ids:
+        info = coco.loadImgs([image_id])[0]
+        img = cv2.imread(os.path.join(args.image_dir, info["file_name"]))
+        if img is None:
+            continue
+        img_h, img_w = img.shape[:2]
+        boxes, scores, cls_ids, masks = model(img, score_thres=args.conf_thres, nms_thres=args.nms_thres)
+        for box, score, cls_id, mask in zip(boxes, scores, cls_ids, masks):
+            x1, y1, x2, y2 = [float(v) for v in box]
+            ix1, iy1 = max(int(x1), 0), max(int(y1), 0)
+            ix2, iy2 = min(int(x2), img_w), min(int(y2), img_h)
+            full_mask = np.zeros((img_h, img_w), dtype=np.uint8)
+            if mask is not None and getattr(mask, 'size', 0) > 0 and ix2 > ix1 and iy2 > iy1:
+                mh, mw = mask.shape[:2]
+                th, tw = iy2 - iy1, ix2 - ix1
+                if mh != th or mw != tw:
+                    mask = cv2.resize(mask, (tw, th), interpolation=cv2.INTER_NEAREST)
+                full_mask[iy1:iy2, ix1:ix2] = (mask > 0).astype(np.uint8)
+            encoded = mask_utils.encode(np.asfortranarray(full_mask))
+            encoded["counts"] = encoded["counts"].decode("utf-8")
+            results.append({
+                "image_id": image_id,
+                "category_id": int(coco_cat_ids[int(cls_id)]),
+                "bbox": [x1, y1, x2 - x1, y2 - y1],
+                "score": float(score),
+                "segmentation": encoded,
+            })
+
+    with open(args.json_save_path, "w", encoding="utf-8") as f:
+        json.dump(results, f)
+
+    coco_dt = coco.loadRes(args.json_save_path)
+    for iou_type in ["bbox", "segm"]:
+        coco_eval = COCOeval(coco, coco_dt, iou_type)
+        coco_eval.evaluate()
+        coco_eval.accumulate()
+        coco_eval.summarize()
+    print(f"elapsed: {time.time() - start:.3f}s")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/samples/vision/ultralytics_yolo/model/README.md
+++ b/samples/vision/ultralytics_yolo/model/README.md
@@ -2,7 +2,7 @@ English | [简体中文](./README_cn.md)
 
 # Model Files
 
-This directory contains pre-compiled YOLO model files in HBM format and download scripts for RDK S100/S100P.
+This directory contains pre-compiled YOLO model files in HBM format and download scripts for RDK S100, RDK S100P, and RDK S600.
 
 ## Directory Structure
 
@@ -26,37 +26,44 @@ bash download_model.sh s100p yolov8 seg
 bash download_model.sh s100 yolov8 pose
 bash download_model.sh s100p yolo11 cls
 bash download_model.sh s100p yolov5u detect x
+bash download_model.sh s600 yolo11 detect x
+bash download_model.sh s600 yolov9 detect s
 ```
 
 ## Notes
 
-- The RDK S100/S100P inference model format is `.hbm`.
+- The RDK S series inference model format is `.hbm`.
 - All models use NV12 input (Y + UV as two separate tensors).
-- The model suffix differs by platform: `nashe` for S100, `nashm` for S100P.
-- Main download URL base path: `https://archive.d-robotics.cc/downloads/rdk_model_zoo/rdk_s100/Ultralytics_YOLO_OE_3.7.0/{nash-e|nash-m}/`
+- The model suffix differs by platform: `nashe` for S100, `nashm` for S100P, and `nashp` for S600.
+- Main download URL base path: `https://archive.d-robotics.cc/downloads/rdk_model_zoo/{rdk_s100|rdk_s600}/Ultralytics_YOLO_OE_3.7.0/{nash-e|nash-m|nash-p}/`
 - `model_size` supports `n/s/m/l/x`; YOLOv10 also supports `b`.
 
 ## Published Models
 
 ### Detection
 
-- `yolov5{n|s|m|l|x}u_detect_{nashe|nashm}_640x640_nv12.hbm`
-- `yolov8{n|s|m|l|x}_detect_{nashe|nashm}_640x640_nv12.hbm`
-- `yolov10{n|s|m|b|l|x}_detect_{nashe|nashm}_640x640_nv12.hbm`
-- `yolo11{n|s|m|l|x}_detect_{nashe|nashm}_640x640_nv12.hbm`
-- `yolo12{n|s|m|l|x}_detect_{nashe|nashm}_640x640_nv12.hbm`
+- `yolov5{n|s|m|l|x}u_detect_{nashe|nashm|nashp}_640x640_nv12.hbm`
+- `yolov8{n|s|m|l|x}_detect_{nashe|nashm|nashp}_640x640_nv12.hbm`
+- `yolov9{s|m|c|e}_{detect|seg}_{nashe|nashm}_640x640_nv12.hbm` (`seg` currently published on S100/S100P only)
+- `yolov9{s|m|c|e}_detect_nashp_640x640_nv12.hbm` (public S600 models)
+- `yolov9t_detect_{nashe|nashm}_640x640_nv12.hbm` (public S100/S100P models)
+- `yolov10{n|s|m|b|l|x}_detect_{nashe|nashm|nashp}_640x640_nv12.hbm`
+- `yolo11{n|s|m|l|x}_detect_{nashe|nashm|nashp}_640x640_nv12.hbm`
+- `yolo12{n|s|m|l|x}_detect_{nashe|nashm|nashp}_640x640_nv12.hbm`
 
 ### Instance Segmentation
 
-- `yolov8{n|s|m|l|x}_seg_{nashe|nashm}_640x640_nv12.hbm`
-- `yolo11{n|s|m|l|x}_seg_{nashe|nashm}_640x640_nv12.hbm`
+- `yolov8{n|s|m|l|x}_seg_{nashe|nashm|nashp}_640x640_nv12.hbm`
+- `yolo11{n|s|m|l|x}_seg_{nashe|nashm|nashp}_640x640_nv12.hbm`
 
 ### Pose Estimation
 
-- `yolov8{n|s|m|l|x}_pose_{nashe|nashm}_640x640_nv12.hbm`
-- `yolo11{n|s|m|l|x}_pose_{nashe|nashm}_640x640_nv12.hbm`
+- `yolov8{n|s|m|l|x}_pose_{nashe|nashm|nashp}_640x640_nv12.hbm`
+- `yolo11{n|s|m|l|x}_pose_{nashe|nashm|nashp}_640x640_nv12.hbm`
 
 ### Classification
 
-- `yolov8{n|s|m|l|x}_cls_{nashe|nashm}_640x640_nv12.hbm`
-- `yolo11{n|s|m|l|x}_cls_{nashe|nashm}_640x640_nv12.hbm`
+- `yolov8{n|s|m|l|x}_cls_{nashe|nashm}_224x224_nv12.hbm`
+- `yolo11{n|s|m|l|x}_cls_{nashe|nashm}_224x224_nv12.hbm`
+- `yolov8{n|s|m|l|x}_cls_nashp_224x224_nv12.hbm`
+- `yolo11{n|s|m|l|x}_cls_nashp_224x224_nv12.hbm`

--- a/samples/vision/ultralytics_yolo/model/README_cn.md
+++ b/samples/vision/ultralytics_yolo/model/README_cn.md
@@ -2,7 +2,7 @@
 
 # 模型文件
 
-本目录包含 RDK S100/S100P 的预编译 YOLO 模型文件和下载脚本。
+本目录包含 RDK S100、RDK S100P 和 RDK S600 的预编译 YOLO 模型文件与下载脚本。
 
 ## 目录结构
 
@@ -25,6 +25,8 @@ bash download_model.sh s100p yolov8 seg
 bash download_model.sh s100 yolov8 pose
 bash download_model.sh s100p yolo11 cls
 bash download_model.sh s100p yolov5u detect x
+bash download_model.sh s600 yolo11 detect x
+bash download_model.sh s600 yolov9 detect s
 ```
 
 ## 说明
@@ -39,23 +41,28 @@ bash download_model.sh s100p yolov5u detect x
 
 ### 目标检测
 
-- `yolov5{n|s|m|l|x}u_detect_{nashe|nashm}_640x640_nv12.hbm`
-- `yolov8{n|s|m|l|x}_detect_{nashe|nashm}_640x640_nv12.hbm`
-- `yolov10{n|s|m|b|l|x}_detect_{nashe|nashm}_640x640_nv12.hbm`
-- `yolo11{n|s|m|l|x}_detect_{nashe|nashm}_640x640_nv12.hbm`
-- `yolo12{n|s|m|l|x}_detect_{nashe|nashm}_640x640_nv12.hbm`
+- `yolov5{n|s|m|l|x}u_detect_{nashe|nashm|nashp}_640x640_nv12.hbm`
+- `yolov8{n|s|m|l|x}_detect_{nashe|nashm|nashp}_640x640_nv12.hbm`
+- `yolov9{s|m|c|e}_{detect|seg}_{nashe|nashm}_640x640_nv12.hbm`（其中 `seg` 当前仅公开发布于 S100/S100P）
+- `yolov9{s|m|c|e}_detect_nashp_640x640_nv12.hbm`（S600 公开模型）
+- `yolov9t_detect_{nashe|nashm}_640x640_nv12.hbm`（S100/S100P 公开模型）
+- `yolov10{n|s|m|b|l|x}_detect_{nashe|nashm|nashp}_640x640_nv12.hbm`
+- `yolo11{n|s|m|l|x}_detect_{nashe|nashm|nashp}_640x640_nv12.hbm`
+- `yolo12{n|s|m|l|x}_detect_{nashe|nashm|nashp}_640x640_nv12.hbm`
 
 ### 实例分割
 
-- `yolov8{n|s|m|l|x}_seg_{nashe|nashm}_640x640_nv12.hbm`
-- `yolo11{n|s|m|l|x}_seg_{nashe|nashm}_640x640_nv12.hbm`
+- `yolov8{n|s|m|l|x}_seg_{nashe|nashm|nashp}_640x640_nv12.hbm`
+- `yolo11{n|s|m|l|x}_seg_{nashe|nashm|nashp}_640x640_nv12.hbm`
 
 ### 姿态估计
 
-- `yolov8{n|s|m|l|x}_pose_{nashe|nashm}_640x640_nv12.hbm`
-- `yolo11{n|s|m|l|x}_pose_{nashe|nashm}_640x640_nv12.hbm`
+- `yolov8{n|s|m|l|x}_pose_{nashe|nashm|nashp}_640x640_nv12.hbm`
+- `yolo11{n|s|m|l|x}_pose_{nashe|nashm|nashp}_640x640_nv12.hbm`
 
 ### 图像分类
 
-- `yolov8{n|s|m|l|x}_cls_{nashe|nashm}_640x640_nv12.hbm`
-- `yolo11{n|s|m|l|x}_cls_{nashe|nashm}_640x640_nv12.hbm`
+- `yolov8{n|s|m|l|x}_cls_{nashe|nashm}_224x224_nv12.hbm`
+- `yolo11{n|s|m|l|x}_cls_{nashe|nashm}_224x224_nv12.hbm`
+- `yolov8{n|s|m|l|x}_cls_nashp_224x224_nv12.hbm`
+- `yolo11{n|s|m|l|x}_cls_nashp_224x224_nv12.hbm`

--- a/samples/vision/ultralytics_yolo/model/download_model.sh
+++ b/samples/vision/ultralytics_yolo/model/download_model.sh
@@ -5,14 +5,15 @@
 #   bash download_model.sh [soc] [yolo_type] [task] [model_size]
 #
 # Arguments:
-#   soc       - Target SoC: s100 (default) or s100p
-#   yolo_type - Model variant: yolov5u, yolov8, yolov10, yolo11, yolo12
+#   soc       - Target SoC: s100 (default), s100p, or s600
+#   yolo_type - Model variant: yolov5u, yolov8, yolov9, yolov10, yolo11, yolo12
 #   task      - Task type: detect, seg, pose, cls
 #   model_size - Model scale: n, s, m, l, x (default: n); yolov10 also supports b
 #
 # Examples:
 #   bash download_model.sh s100 yolo11 detect
 #   bash download_model.sh s100p yolov5u detect s
+#   bash download_model.sh s600 yolo11 detect x
 
 set -e
 
@@ -38,10 +39,15 @@ else
   BOARD_TYPE="$SOC"
 fi
 
-# Model suffix differs by platform: S100 uses nashe; S100P uses nashm.
+# Model suffix differs by platform: S100 uses nashe; S100P uses nashm; S600 uses nashp.
 MODEL_MARCH="nash-e"
 MODEL_SUFFIX="nashe"
-if [[ "$SOC" == "s100p" || "$BOARD_TYPE" == *"p"* ]]; then
+SOC_DIR="rdk_s100"
+if [[ "$SOC" == "s600" ]]; then
+  MODEL_MARCH="nash-p"
+  MODEL_SUFFIX="nashp"
+  SOC_DIR="rdk_s600"
+elif [[ "$SOC" == "s100p" || "$BOARD_TYPE" == *"p"* ]]; then
   MODEL_MARCH="nash-m"
   MODEL_SUFFIX="nashm"
 fi
@@ -72,6 +78,13 @@ case "$YOLO_TYPE" in
       *)      echo "YOLOv10 only supports detect task"; exit 1 ;;
     esac
     ;;
+  yolov9)
+    URL_BASE="Ultralytics_YOLO_OE_3.7.0/${MODEL_MARCH}"
+    case "$TASK" in
+      detect) MODEL_FILE="yolov9${MODEL_SIZE}_detect_${MODEL_SUFFIX}_640x640_nv12.hbm" ;;
+      *)      echo "YOLOv9 public models in this sample only support detect task"; exit 1 ;;
+    esac
+    ;;
   yolo11)
     URL_BASE="Ultralytics_YOLO_OE_3.7.0/${MODEL_MARCH}"
     case "$TASK" in
@@ -95,7 +108,7 @@ case "$YOLO_TYPE" in
     ;;
 esac
 
-MODEL_URL="https://archive.d-robotics.cc/downloads/rdk_model_zoo/rdk_s100/${URL_BASE}/${MODEL_FILE}"
+MODEL_URL="https://archive.d-robotics.cc/downloads/rdk_model_zoo/${SOC_DIR}/${URL_BASE}/${MODEL_FILE}"
 OUTPUT_DIR="$(dirname "$0")"
 OUTPUT_DIR="${OUTPUT_DIR}/${MODEL_MARCH}"
 OUTPUT_PATH="${OUTPUT_DIR}/${MODEL_FILE}"

--- a/samples/vision/ultralytics_yolo/runtime/python/README.md
+++ b/samples/vision/ultralytics_yolo/runtime/python/README.md
@@ -2,11 +2,11 @@ English | [简体中文](./README_cn.md)
 
 # Ultralytics YOLO Python Runtime
 
-This sample demonstrates how to run Ultralytics YOLO task models on RDK S100/S100P with `hbm_runtime`.
+This sample demonstrates how to run Ultralytics YOLO task models on RDK S100/S100P/S600 with `hbm_runtime`.
 
 ## Environment Dependencies
 
-This sample has no special extra dependencies. Make sure the RDK S100/S100P Python environment is ready.
+This sample has no special extra dependencies. Make sure the RDK S Python environment is ready.
 
 ```bash
 pip install numpy opencv-python hbm-runtime scipy
@@ -17,7 +17,7 @@ pip install numpy opencv-python hbm-runtime scipy
 ```text
 .
 ├── main.py                # Inference entry script
-├── yolo_detect.py         # DFL-based detection wrapper (v5u/v8/v11/v12)
+├── yolo_detect.py         # DFL-based detection wrapper (v5u/v8/v9/v11/v12)
 ├── yolo_seg.py            # Instance segmentation wrapper
 ├── yolo_pose.py           # Pose estimation wrapper
 ├── yolo_cls.py            # Classification wrapper
@@ -42,8 +42,8 @@ pip install numpy opencv-python hbm-runtime scipy
 | `--topk` | Top-K results for classification | `5` |
 | `--kpt-conf-thres` | Keypoint confidence threshold for pose | `0.50` |
 
-> **Note**: The default `--model-path` is determined automatically based on `--task` and the detected SoC. S100 uses the `nashe` suffix; S100P uses the `nashm` suffix. Model family and scale are selected by `--model-path`.
-> Public S100P models are available for `yolov5u detect`, `yolov8 detect/seg/pose/cls`, `yolov10 detect`, `yolo11 detect/seg/pose/cls`, and `yolo12 detect`.
+> **Note**: The default `--model-path` is determined automatically based on `--task` and the detected SoC. S100 uses the `nashe` suffix, S100P uses `nashm`, and S600 uses `nashp`. Model family and scale are selected by `--model-path`.
+> Public RDK S archives currently provide `yolov5u detect`, `yolov8 detect/seg/pose/cls`, `yolov9 detect`, `yolov10 detect`, `yolo11 detect/seg/pose/cls`, and `yolo12 detect`. `YOLOv9 seg` is currently published on S100/S100P only.
 
 ## Quick Run
 
@@ -71,6 +71,13 @@ pip install numpy opencv-python hbm-runtime scipy
         --model-path ../../model/nash-m/yolo11n_detect_nashm_640x640_nv12.hbm \
         --test-img ../../test_data/bus.jpg
     ```
+  - Run detection explicitly on RDK S600
+    ```bash
+    python3 main.py \
+        --task detect \
+        --model-path ../../model/nash-p/yolo11n_detect_nashp_640x640_nv12.hbm \
+        --test-img ../../test_data/bus.jpg
+    ```
 
 ## Task Examples
 
@@ -89,6 +96,15 @@ python3 main.py \
 python3 main.py \
     --task detect \
     --model-path ../../model/nash-e/yolov10n_detect_nashe_640x640_nv12.hbm \
+    --test-img ../../test_data/bus.jpg
+```
+
+### YOLOv9 Detection
+
+```bash
+python3 main.py \
+    --task detect \
+    --model-path ../../model/nash-e/yolov9s_detect_nashe_640x640_nv12.hbm \
     --test-img ../../test_data/bus.jpg
 ```
 

--- a/samples/vision/ultralytics_yolo/runtime/python/README_cn.md
+++ b/samples/vision/ultralytics_yolo/runtime/python/README_cn.md
@@ -2,11 +2,11 @@
 
 # Ultralytics YOLO Python 运行时
 
-本示例演示如何在 RDK S100/S100P 上使用 `hbm_runtime` 运行 Ultralytics YOLO 任务模型。
+本示例演示如何在 RDK S100/S100P/S600 上使用 `hbm_runtime` 运行 Ultralytics YOLO 任务模型。
 
 ## 环境依赖
 
-本示例无额外依赖。请确保 RDK S100/S100P Python 环境已就绪。
+本示例无额外依赖。请确保 RDK S 系列 Python 环境已就绪。
 
 ```bash
 pip install numpy opencv-python hbm-runtime scipy
@@ -42,8 +42,8 @@ pip install numpy opencv-python hbm-runtime scipy
 | `--topk` | 分类 Top-K 结果数 | `5` |
 | `--kpt-conf-thres` | 姿态关键点置信度阈值 | `0.50` |
 
-> **注意**：`--model-path` 默认值根据 `--task` 和检测到的 SoC 自动确定。S100 使用 `nashe` 后缀，S100P 使用 `nashm` 后缀。具体模型家族和尺寸由 `--model-path` 选择。
-> 公开归档中 S100P 模型覆盖 `yolov5u detect`、`yolov8 detect/seg/pose/cls`、`yolov10 detect`、`yolo11 detect/seg/pose/cls`、`yolo12 detect`。
+> **注意**：`--model-path` 默认值根据 `--task` 和检测到的 SoC 自动确定。S100 使用 `nashe` 后缀，S100P 使用 `nashm` 后缀，S600 使用 `nashp` 后缀。具体模型家族和尺寸由 `--model-path` 选择。
+> 当前 RDK S 公共归档覆盖 `yolov5u detect`、`yolov8 detect/seg/pose/cls`、`yolov9 detect`、`yolov10 detect`、`yolo11 detect/seg/pose/cls`、`yolo12 detect`。其中 `YOLOv9 seg` 当前仅公开发布于 S100/S100P。
 
 ## 快速运行
 
@@ -69,6 +69,13 @@ pip install numpy opencv-python hbm-runtime scipy
     python3 main.py \
         --task detect \
         --model-path ../../model/nash-m/yolo11n_detect_nashm_640x640_nv12.hbm \
+        --test-img ../../test_data/bus.jpg
+    ```
+  - 在 RDK S600 上显式运行检测
+    ```bash
+    python3 main.py \
+        --task detect \
+        --model-path ../../model/nash-p/yolo11n_detect_nashp_640x640_nv12.hbm \
         --test-img ../../test_data/bus.jpg
     ```
 
@@ -101,6 +108,15 @@ python3 main.py \
     --test-img ../../test_data/bus.jpg
 ```
 
+### YOLOv9 目标检测
+
+```bash
+python3 main.py \
+    --task detect \
+    --model-path ../../model/nash-e/yolov9s_detect_nashe_640x640_nv12.hbm \
+    --test-img ../../test_data/bus.jpg
+```
+
 ### 姿态估计
 
 ```bash
@@ -115,7 +131,7 @@ python3 main.py \
 ```bash
 python3 main.py \
     --task cls \
-    --model-path ../../model/nash-e/yolo11n_cls_nashe_640x640_nv12.hbm \
+    --model-path ../../model/nash-e/yolo11n_cls_nashe_224x224_nv12.hbm \
     --test-img ../../test_data/bus.jpg
 ```
 

--- a/samples/vision/ultralytics_yolo/runtime/python/main.py
+++ b/samples/vision/ultralytics_yolo/runtime/python/main.py
@@ -22,6 +22,7 @@ Supported model variants:
     - yolov5u: YOLOv5u (anchor-free DFL head, detect)
     - yolov8:  YOLOv8
     - yolov10: YOLOv10 (NMS-free detection)
+    - yolov9:  YOLOv9
     - yolo11:  YOLO11
     - yolo12:  YOLO12
 
@@ -36,6 +37,7 @@ Example:
     python main.py --task seg --model-path ../../model/nash-m/yolov8n_seg_nashm_640x640_nv12.hbm
     python main.py --task detect --model-path ../../model/nash-m/yolo12n_detect_nashm_640x640_nv12.hbm
     python main.py --task cls --model-path ../../model/nash-m/yolo11n_cls_nashm_640x640_nv12.hbm
+    python main.py --task detect --model-path ../../model/nash-p/yolo11n_detect_nashp_640x640_nv12.hbm
 """
 
 import argparse
@@ -58,7 +60,7 @@ import utils.py_utils.inspect as inspect
 
 
 # Model file naming conventions per variant and task.
-# These names match the public S100 model archive; unsupported task/model
+# These names match the public RDK S model archives; unsupported task/model
 # combinations are intentionally omitted instead of guessed.
 MODEL_FILE_PATTERNS = {
     "yolov5u": {
@@ -72,6 +74,9 @@ MODEL_FILE_PATTERNS = {
     },
     "yolov10": {
         "detect": "yolov10n_detect_{suffix}_640x640_nv12.hbm",
+    },
+    "yolov9": {
+        "detect": "yolov9s_detect_{suffix}_640x640_nv12.hbm",
     },
     "yolo11": {
         "detect": "yolo11n_detect_{suffix}_640x640_nv12.hbm",
@@ -89,17 +94,20 @@ DOWNLOAD_URL_BASE = {
     "yolov5u": "Ultralytics_YOLO_OE_3.7.0",
     "yolov8":  "Ultralytics_YOLO_OE_3.7.0",
     "yolov10": "Ultralytics_YOLO_OE_3.7.0",
+    "yolov9":  "Ultralytics_YOLO_OE_3.7.0",
     "yolo11":  "Ultralytics_YOLO_OE_3.7.0",
     "yolo12":  "Ultralytics_YOLO_OE_3.7.0",
 }
 
 def get_model_march_and_suffix(soc: str) -> tuple[str, str]:
-    """Return S100 model architecture directory and filename suffix."""
+    """Return model architecture directory and filename suffix for the SoC."""
     try:
         with open("/sys/class/boardinfo/board_type", "r", encoding="utf-8") as f:
             board_type = f.read().strip().lower()
     except Exception:
         board_type = soc
+    if soc == "s600":
+        return "nash-p", "nashp"
     if soc == "s100p" or "p" in board_type:
         return "nash-m", "nashm"
     return "nash-e", "nashe"
@@ -147,8 +155,9 @@ def get_download_url(task: str, model_march: str, suffix: str) -> str:
 
     model_file = MODEL_FILE_PATTERNS[default_yolo_type][task].format(suffix=suffix)
     url_base = DOWNLOAD_URL_BASE[default_yolo_type]
+    soc_dir = "rdk_s600" if suffix == "nashp" else "rdk_s100"
     return ("https://archive.d-robotics.cc/downloads/rdk_model_zoo/"
-            f"rdk_s100/{url_base}/{model_march}/{model_file}")
+            f"{soc_dir}/{url_base}/{model_march}/{model_file}")
 
 
 def main() -> None:

--- a/samples/vision/ultralytics_yolo/runtime/python/run.sh
+++ b/samples/vision/ultralytics_yolo/runtime/python/run.sh
@@ -21,7 +21,10 @@ fi
 
 MODEL_MARCH="nash-e"
 MODEL_SUFFIX="nashe"
-if [[ "${SOC}" == "s100p" || "${BOARD_TYPE}" == *"p"* ]]; then
+if [[ "${SOC}" == "s600" ]]; then
+  MODEL_MARCH="nash-p"
+  MODEL_SUFFIX="nashp"
+elif [[ "${SOC}" == "s100p" || "${BOARD_TYPE}" == *"p"* ]]; then
   MODEL_MARCH="nash-m"
   MODEL_SUFFIX="nashm"
 fi

--- a/samples/vision/ultralytics_yolo26/evaluator/README.md
+++ b/samples/vision/ultralytics_yolo26/evaluator/README.md
@@ -93,7 +93,7 @@ python3 eval_yolo26_obb.py \
 
 ## Benchmark Results
 
-### RDK S100/S100P Performance Data (Performance @ NV12)
+### RDK S100 Performance Data (Performance @ NV12)
 
 | Device | Model | Size <br> (Pixels) | Classes | BPU Task Latency / <br> BPU Throughput (Threads) | CPU Latency | Params <br> (M) | FLOPs <br> (G) |
 | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
@@ -122,11 +122,46 @@ python3 eval_yolo26_obb.py \
 | S100 | YOLO26m Obb | 640x640 | 15 | 6.16 ms / 157.61 FPS (1 thread) <br> 11.27 ms / 175.02 FPS (2 threads) | - | 23.49 | 82.2 |
 | S100 | YOLO26l Obb | 640x640 | 15 | 7.46 ms / 130.74 FPS (1 thread) <br> 13.79 ms / 143.34 FPS (2 threads) | - | 27.90 | 100.6 |
 | S100 | YOLO26x Obb | 640x640 | 15 | 13.81 ms / 71.33 FPS (1 thread) <br> 26.95 ms / 73.69 FPS (2 threads) | - | 62.66 | 225.3 |
+
+### RDK S100 Performance Data (Performance @ NV12)
+
+| Device | Model | Size <br> (Pixels) | Classes | BPU Task Latency / <br> BPU Throughput (Threads) | CPU Latency | Params <br> (M) | FLOPs <br> (G) |
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
 | S100P | YOLO26n Detect | 640x640 | 80 | - | - | 2.57 | 6.1 |
 | S100P | YOLO26s Detect | 640x640 | 80 | - | - | 10.01 | 22.8 |
 | S100P | YOLO26m Detect | 640x640 | 80 | - | - | 21.90 | 75.4 |
 | S100P | YOLO26l Detect | 640x640 | 80 | - | - | 26.30 | 93.8 |
 | S100P | YOLO26x Detect | 640x640 | 80 | - | - | 58.99 | 209.5 |
+
+### RDK S600 Performance Data (Performance @ NV12)
+
+| Device | Model | Size <br> (Pixels) | Classes | BPU Task Latency / <br> BPU Throughput (Threads) | CPU Latency | Params <br> (M) | FLOPs <br> (G) |
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+| S600 | YOLO26n Detect | 640x640 | 80 | 0.83 ms / 1170.57 FPS (1 thread) <br> 1.85 ms / 6023.19 FPS (12 threads) | - | 2.57 | 6.1 |
+| S600 | YOLO26s Detect | 640x640 | 80 | 1.27 ms / 780.57 FPS (1 thread) <br> 3.17 ms / 3576.09 FPS (12 threads) | - | 10.01 | 22.8 |
+| S600 | YOLO26m Detect | 640x640 | 80 | 2.61 ms / 380.65 FPS (1 thread) <br> 7.19 ms / 1612.92 FPS (12 threads) | - | 21.90 | 75.4 |
+| S600 | YOLO26l Detect | 640x640 | 80 | 3.21 ms / 309.74 FPS (1 thread) <br> 9.02 ms / 1291.03 FPS (12 threads) | - | 26.30 | 93.8 |
+| S600 | YOLO26x Detect | 640x640 | 80 | 6.57 ms / 151.87 FPS (1 thread) <br> 19.20 ms / 609.19 FPS (12 threads) | - | 58.99 | 209.5 |
+| S600 | YOLO26n Seg | 640x640 | 80 | 1.02 ms / 966.75 FPS (1 thread) <br> 2.54 ms / 4353.03 FPS (12 threads) | - | 3.13 | 10.5 |
+| S600 | YOLO26s Seg | 640x640 | 80 | 1.70 ms / 579.68 FPS (1 thread) <br> 4.38 ms / 2585.38 FPS (12 threads) | - | 11.51 | 37.4 |
+| S600 | YOLO26m Seg | 640x640 | 80 | 3.91 ms / 254.03 FPS (1 thread) <br> 10.87 ms / 1069.46 FPS (12 threads) | - | 27.11 | 132.5 |
+| S600 | YOLO26l Seg | 640x640 | 80 | 4.58 ms / 217.11 FPS (1 thread) <br> 13.00 ms / 895.80 FPS (12 threads) | - | 31.52 | 150.9 |
+| S600 | YOLO26x Seg | 640x640 | 80 | 9.32 ms / 107.13 FPS (1 thread) <br> 26.92 ms / 434.77 FPS (12 threads) | - | 70.69 | 337.7 |
+| S600 | YOLO26n Pose | 640x640 | 1 | 0.86 ms / 1129.76 FPS (1 thread) <br> 1.93 ms / 5634.91 FPS (12 threads) | - | 3.68 | 10.3 |
+| S600 | YOLO26s Pose | 640x640 | 1 | 1.36 ms / 725.97 FPS (1 thread) <br> 3.33 ms / 3384.84 FPS (12 threads) | - | 11.81 | 29.2 |
+| S600 | YOLO26m Pose | 640x640 | 1 | 2.73 ms / 363.75 FPS (1 thread) <br> 7.41 ms / 1550.53 FPS (12 threads) | - | 24.22 | 85.2 |
+| S600 | YOLO26l Pose | 640x640 | 1 | 3.31 ms / 299.85 FPS (1 thread) <br> 9.26 ms / 1252.19 FPS (12 threads) | - | 28.63 | 103.6 |
+| S600 | YOLO26x Pose | 640x640 | 1 | 6.80 ms / 146.52 FPS (1 thread) <br> 19.60 ms / 596.04 FPS (12 threads) | - | 62.73 | 225.3 |
+| S600 | YOLO26n Cls | 224x224 | 1000 | 0.34 ms / 2890.55 FPS (1 thread) <br> 0.68 ms / 15743.07 FPS (12 threads) | - | 2.81 | 0.5 |
+| S600 | YOLO26s Cls | 224x224 | 1000 | 0.40 ms / 2459.18 FPS (1 thread) <br> 0.78 ms / 13540.05 FPS (12 threads) | - | 6.72 | 1.6 |
+| S600 | YOLO26m Cls | 224x224 | 1000 | 0.54 ms / 1825.63 FPS (1 thread) <br> 1.06 ms / 10526.32 FPS (12 threads) | - | 11.63 | 5.0 |
+| S600 | YOLO26l Cls | 224x224 | 1000 | 0.65 ms / 1516.99 FPS (1 thread) <br> 1.43 ms / 7924.24 FPS (12 threads) | - | 14.12 | 6.2 |
+| S600 | YOLO26x Cls | 224x224 | 1000 | 0.99 ms / 998.72 FPS (1 thread) <br> 2.57 ms / 4463.59 FPS (12 threads) | - | 29.64 | 13.7 |
+| S600 | YOLO26n Obb | 640x640 | 15 | 0.79 ms / 1230.91 FPS (1 thread) <br> 1.65 ms / 6496.46 FPS (12 threads) | - | 2.65 | 6.3 |
+| S600 | YOLO26s Obb | 640x640 | 15 | 1.26 ms / 784.60 FPS (1 thread) <br> 3.11 ms / 3610.24 FPS (12 threads) | - | 10.53 | 24.5 |
+| S600 | YOLO26m Obb | 640x640 | 15 | 2.66 ms / 372.64 FPS (1 thread) <br> 7.21 ms / 1601.00 FPS (12 threads) | - | 23.49 | 82.2 |
+| S600 | YOLO26l Obb | 640x640 | 15 | 3.27 ms / 304.08 FPS (1 thread) <br> 9.15 ms / 1266.96 FPS (12 threads) | - | 27.90 | 100.6 |
+| S600 | YOLO26x Obb | 640x640 | 15 | 6.73 ms / 148.08 FPS (1 thread) <br> 19.31 ms / 604.86 FPS (12 threads) | - | 62.66 | 225.3 |
 
 ### RDK S100 Accuracy Data (Accuracy @ NV12 - Detection)
 

--- a/samples/vision/ultralytics_yolo26/evaluator/README_cn.md
+++ b/samples/vision/ultralytics_yolo26/evaluator/README_cn.md
@@ -93,7 +93,7 @@ python3 eval_yolo26_obb.py \
 
 ## 基准测试结果 (Benchmark Results)
 
-### RDK S100/S100P 性能数据 (Performance @ NV12)
+### RDK S100 性能数据 (Performance @ NV12)
 
 | 设备 | 模型 | 尺寸 <br> (Pixels) | 类别数 | BPU 任务延迟 / <br> BPU 吞吐量 (线程) | CPU 延迟 | 参数量 <br> (M) | 计算量 <br> (G) |
 | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
@@ -122,11 +122,46 @@ python3 eval_yolo26_obb.py \
 | S100 | YOLO26m Obb | 640x640 | 15 | 6.16 ms / 157.61 FPS (1 thread) <br> 11.27 ms / 175.02 FPS (2 threads) | - | 23.49 | 82.2 |
 | S100 | YOLO26l Obb | 640x640 | 15 | 7.46 ms / 130.74 FPS (1 thread) <br> 13.79 ms / 143.34 FPS (2 threads) | - | 27.90 | 100.6 |
 | S100 | YOLO26x Obb | 640x640 | 15 | 13.81 ms / 71.33 FPS (1 thread) <br> 26.95 ms / 73.69 FPS (2 threads) | - | 62.66 | 225.3 |
+
+### RDK S100P 性能数据 (Performance @ NV12)
+
+| 设备 | 模型 | 尺寸 <br> (Pixels) | 类别数 | BPU 任务延迟 / <br> BPU 吞吐量 (线程) | CPU 延迟 | 参数量 <br> (M) | 计算量 <br> (G) |
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
 | S100P | YOLO26n Detect | 640x640 | 80 | - | - | 2.57 | 6.1 |
 | S100P | YOLO26s Detect | 640x640 | 80 | - | - | 10.01 | 22.8 |
 | S100P | YOLO26m Detect | 640x640 | 80 | - | - | 21.90 | 75.4 |
 | S100P | YOLO26l Detect | 640x640 | 80 | - | - | 26.30 | 93.8 |
 | S100P | YOLO26x Detect | 640x640 | 80 | - | - | 58.99 | 209.5 |
+
+### RDK S600 性能数据 (Performance @ NV12)
+
+| 设备 | 模型 | 尺寸 <br> (Pixels) | 类别数 | BPU 任务延迟 / <br> BPU 吞吐量 (线程) | CPU 延迟 | 参数量 <br> (M) | 计算量 <br> (G) |
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+| S600 | YOLO26n Detect | 640x640 | 80 | 0.83 ms / 1170.57 FPS (1 thread) <br> 1.85 ms / 6023.19 FPS (12 threads) | - | 2.57 | 6.1 |
+| S600 | YOLO26s Detect | 640x640 | 80 | 1.27 ms / 780.57 FPS (1 thread) <br> 3.17 ms / 3576.09 FPS (12 threads) | - | 10.01 | 22.8 |
+| S600 | YOLO26m Detect | 640x640 | 80 | 2.61 ms / 380.65 FPS (1 thread) <br> 7.19 ms / 1612.92 FPS (12 threads) | - | 21.90 | 75.4 |
+| S600 | YOLO26l Detect | 640x640 | 80 | 3.21 ms / 309.74 FPS (1 thread) <br> 9.02 ms / 1291.03 FPS (12 threads) | - | 26.30 | 93.8 |
+| S600 | YOLO26x Detect | 640x640 | 80 | 6.57 ms / 151.87 FPS (1 thread) <br> 19.20 ms / 609.19 FPS (12 threads) | - | 58.99 | 209.5 |
+| S600 | YOLO26n Seg | 640x640 | 80 | 1.02 ms / 966.75 FPS (1 thread) <br> 2.54 ms / 4353.03 FPS (12 threads) | - | 3.13 | 10.5 |
+| S600 | YOLO26s Seg | 640x640 | 80 | 1.70 ms / 579.68 FPS (1 thread) <br> 4.38 ms / 2585.38 FPS (12 threads) | - | 11.51 | 37.4 |
+| S600 | YOLO26m Seg | 640x640 | 80 | 3.91 ms / 254.03 FPS (1 thread) <br> 10.87 ms / 1069.46 FPS (12 threads) | - | 27.11 | 132.5 |
+| S600 | YOLO26l Seg | 640x640 | 80 | 4.58 ms / 217.11 FPS (1 thread) <br> 13.00 ms / 895.80 FPS (12 threads) | - | 31.52 | 150.9 |
+| S600 | YOLO26x Seg | 640x640 | 80 | 9.32 ms / 107.13 FPS (1 thread) <br> 26.92 ms / 434.77 FPS (12 threads) | - | 70.69 | 337.7 |
+| S600 | YOLO26n Pose | 640x640 | 1 | 0.86 ms / 1129.76 FPS (1 thread) <br> 1.93 ms / 5634.91 FPS (12 threads) | - | 3.68 | 10.3 |
+| S600 | YOLO26s Pose | 640x640 | 1 | 1.36 ms / 725.97 FPS (1 thread) <br> 3.33 ms / 3384.84 FPS (12 threads) | - | 11.81 | 29.2 |
+| S600 | YOLO26m Pose | 640x640 | 1 | 2.73 ms / 363.75 FPS (1 thread) <br> 7.41 ms / 1550.53 FPS (12 threads) | - | 24.22 | 85.2 |
+| S600 | YOLO26l Pose | 640x640 | 1 | 3.31 ms / 299.85 FPS (1 thread) <br> 9.26 ms / 1252.19 FPS (12 threads) | - | 28.63 | 103.6 |
+| S600 | YOLO26x Pose | 640x640 | 1 | 6.80 ms / 146.52 FPS (1 thread) <br> 19.60 ms / 596.04 FPS (12 threads) | - | 62.73 | 225.3 |
+| S600 | YOLO26n Cls | 224x224 | 1000 | 0.34 ms / 2890.55 FPS (1 thread) <br> 0.68 ms / 15743.07 FPS (12 threads) | - | 2.81 | 0.5 |
+| S600 | YOLO26s Cls | 224x224 | 1000 | 0.40 ms / 2459.18 FPS (1 thread) <br> 0.78 ms / 13540.05 FPS (12 threads) | - | 6.72 | 1.6 |
+| S600 | YOLO26m Cls | 224x224 | 1000 | 0.54 ms / 1825.63 FPS (1 thread) <br> 1.06 ms / 10526.32 FPS (12 threads) | - | 11.63 | 5.0 |
+| S600 | YOLO26l Cls | 224x224 | 1000 | 0.65 ms / 1516.99 FPS (1 thread) <br> 1.43 ms / 7924.24 FPS (12 threads) | - | 14.12 | 6.2 |
+| S600 | YOLO26x Cls | 224x224 | 1000 | 0.99 ms / 998.72 FPS (1 thread) <br> 2.57 ms / 4463.59 FPS (12 threads) | - | 29.64 | 13.7 |
+| S600 | YOLO26n Obb | 640x640 | 15 | 0.79 ms / 1230.91 FPS (1 thread) <br> 1.65 ms / 6496.46 FPS (12 threads) | - | 2.65 | 6.3 |
+| S600 | YOLO26s Obb | 640x640 | 15 | 1.26 ms / 784.60 FPS (1 thread) <br> 3.11 ms / 3610.24 FPS (12 threads) | - | 10.53 | 24.5 |
+| S600 | YOLO26m Obb | 640x640 | 15 | 2.66 ms / 372.64 FPS (1 thread) <br> 7.21 ms / 1601.00 FPS (12 threads) | - | 23.49 | 82.2 |
+| S600 | YOLO26l Obb | 640x640 | 15 | 3.27 ms / 304.08 FPS (1 thread) <br> 9.15 ms / 1266.96 FPS (12 threads) | - | 27.90 | 100.6 |
+| S600 | YOLO26x Obb | 640x640 | 15 | 6.73 ms / 148.08 FPS (1 thread) <br> 19.31 ms / 604.86 FPS (12 threads) | - | 62.66 | 225.3 |
 
 ### RDK S100 精度数据 (Accuracy @ NV12 - Detection)
 

--- a/utils/py_utils/postprocess.py
+++ b/utils/py_utils/postprocess.py
@@ -673,24 +673,24 @@ def resize_masks_to_boxes(masks: list[np.ndarray],
     """
     resized_masks = []
     for mask, (x1, y1, x2, y2) in zip(masks, boxes):
-        # Clamp coordinates to image bounds
         x1, y1 = max(int(x1), 0), max(int(y1), 0)
         x2, y2 = min(int(x2), img_w), min(int(y2), img_h)
 
         target_w = max(x2 - x1, 1)
         target_h = max(y2 - y1, 1)
 
+        if mask is None or getattr(mask, "size", 0) == 0:
+            resized_masks.append(np.zeros((target_h, target_w), dtype=np.uint8))
+            continue
+
         resized = cv2.resize(mask, (target_w, target_h), interpolation=interpolation)
 
-        if do_morph:
-            # Apply morphological filtering
+        if do_morph and resized.size > 0:
             resized = cv2.morphologyEx(resized, cv2.MORPH_OPEN, np.ones((5, 5), np.uint8))
 
         resized_masks.append(resized)
 
     return resized_masks
-
-
 def scale_keypoints_to_original_image(kpts_xy: np.ndarray,
                                       kpts_score: np.ndarray,
                                       img_w: int, img_h: int,
@@ -1025,3 +1025,4 @@ def decode_pose_layer(box_feat: np.ndarray, cls_feat: np.ndarray,
 
     out = np.stack([x1, y1, x2, y2, valid_score, valid_cls_id], axis=-1)
     return np.concatenate([out, decoded_kpt_flat], axis=-1)
+


### PR DESCRIPTION
Refresh ultralytics_yolo evaluator documentation for rdk_s
Add evaluator scripts for detect / seg / pose / cls
Update ultralytics_yolo26 evaluator READMEs
Sync shared postprocess utility changes used by evaluator flow
Exclude local S600 benchmark/accuracy result markdown files from repo changes
