### PR TITLE
docs: add YOLO26 S600 accuracy data and fix EfficientNet model path

### DIFF
--- a/samples/vision/efficientnet/README.md
+++ b/samples/vision/efficientnet/README.md
@@ -58,7 +58,8 @@ efficientnet/
 
 ## Quick Start
 
-Download the default model into the sample-local model directory:
+Download the default model. `download_model.sh` writes the model to
+`/opt/hobot/model/<soc>/basic/` (the shared on-board model directory):
 
 ```bash
 cd samples/vision/efficientnet/model
@@ -105,15 +106,15 @@ python3 main.py \
 
 This sample currently maintains the Python runtime path. See [runtime/python/README.md](./runtime/python/README.md) for details.
 
-| Variant | Input | Runtime input type | S100 download path | S600 download path |
-| --- | --- | --- | --- | --- |
-| EfficientNet-Lite0 | 224x224 | NV12 Y/UV planes | `model/s100/efficientnet_lite0_224x224_nv12.hbm` | `model/s600/efficientnet_lite0_224x224_nv12.hbm` |
-| EfficientNet-Lite1 | 240x240 | NV12 Y/UV planes | `model/s100/efficientnet_lite1_240x240_nv12.hbm` | `model/s600/efficientnet_lite1_240x240_nv12.hbm` |
-| EfficientNet-Lite2 | 260x260 | NV12 Y/UV planes | `model/s100/efficientnet_lite2_260x260_nv12.hbm` | `model/s600/efficientnet_lite2_260x260_nv12.hbm` |
-| EfficientNet-Lite3 | 300x300 | NV12 Y/UV planes | `model/s100/efficientnet_lite3_300x300_nv12.hbm` | `model/s600/efficientnet_lite3_300x300_nv12.hbm` |
-| EfficientNet-Lite4 | 380x380 | NV12 Y/UV planes | `model/s100/efficientnet_lite4_380x380_nv12.hbm` | `model/s600/efficientnet_lite4_380x380_nv12.hbm` |
+| Variant | Input | Runtime input type | Download path |
+| --- | --- | --- | --- |
+| EfficientNet-Lite0 | 224x224 | NV12 Y/UV planes | `/opt/hobot/model/<soc>/basic/` |
+| EfficientNet-Lite1 | 240x240 | NV12 Y/UV planes | `/opt/hobot/model/<soc>/basic/` |
+| EfficientNet-Lite2 | 260x260 | NV12 Y/UV planes | `/opt/hobot/model/<soc>/basic/` |
+| EfficientNet-Lite3 | 300x300 | NV12 Y/UV planes | `/opt/hobot/model/<soc>/basic/` |
+| EfficientNet-Lite4 | 380x380 | NV12 Y/UV planes | `/opt/hobot/model/<soc>/basic/` |
 
-This sample uses public S100 / S600 HBM models downloaded into the sample-local `model/<soc>` directory. The `run.sh` script auto-detects the device SoC and downloads the matching variant.
+This sample uses public S100 / S600 HBM models downloaded into `/opt/hobot/model/<soc>/basic/` (`<soc>` is `s100` or `s600`). The `run.sh` script auto-detects the device SoC and downloads the matching variant.
 
 ## Model Evaluation
 

--- a/samples/vision/efficientnet/README_cn.md
+++ b/samples/vision/efficientnet/README_cn.md
@@ -58,7 +58,8 @@ efficientnet/
 
 ## 快速体验
 
-下载默认模型到当前 sample 的 `model` 目录：
+下载默认模型。`download_model.sh` 会把模型写入板端共享模型目录
+`/opt/hobot/model/<soc>/basic/`：
 
 ```bash
 cd samples/vision/efficientnet/model
@@ -107,15 +108,15 @@ python3 main.py \
 
 本 sample 当前维护 Python 推理路径，详细说明请参考 [runtime/python/README_cn.md](./runtime/python/README_cn.md)。
 
-| 变体 | 输入 | 运行时输入类型 | S100 下载路径 | S600 下载路径 |
-| --- | --- | --- | --- | --- |
-| EfficientNet-Lite0 | 224x224 | NV12 Y/UV planes | `model/s100/efficientnet_lite0_224x224_nv12.hbm` | `model/s600/efficientnet_lite0_224x224_nv12.hbm` |
-| EfficientNet-Lite1 | 240x240 | NV12 Y/UV planes | `model/s100/efficientnet_lite1_240x240_nv12.hbm` | `model/s600/efficientnet_lite1_240x240_nv12.hbm` |
-| EfficientNet-Lite2 | 260x260 | NV12 Y/UV planes | `model/s100/efficientnet_lite2_260x260_nv12.hbm` | `model/s600/efficientnet_lite2_260x260_nv12.hbm` |
-| EfficientNet-Lite3 | 300x300 | NV12 Y/UV planes | `model/s100/efficientnet_lite3_300x300_nv12.hbm` | `model/s600/efficientnet_lite3_300x300_nv12.hbm` |
-| EfficientNet-Lite4 | 380x380 | NV12 Y/UV planes | `model/s100/efficientnet_lite4_380x380_nv12.hbm` | `model/s600/efficientnet_lite4_380x380_nv12.hbm` |
+| 变体 | 输入 | 运行时输入类型 | 下载路径 |
+| --- | --- | --- | --- |
+| EfficientNet-Lite0 | 224x224 | NV12 Y/UV planes | `/opt/hobot/model/<soc>/basic/` |
+| EfficientNet-Lite1 | 240x240 | NV12 Y/UV planes | `/opt/hobot/model/<soc>/basic/` |
+| EfficientNet-Lite2 | 260x260 | NV12 Y/UV planes | `/opt/hobot/model/<soc>/basic/` |
+| EfficientNet-Lite3 | 300x300 | NV12 Y/UV planes | `/opt/hobot/model/<soc>/basic/` |
+| EfficientNet-Lite4 | 380x380 | NV12 Y/UV planes | `/opt/hobot/model/<soc>/basic/` |
 
-本示例使用公开 S100 / S600 HBM 模型，模型下载到当前 sample 内的 `model/<soc>` 目录。`run.sh` 会自动检测当前设备 SoC 并下载对应版本。
+本示例使用公开 S100 / S600 HBM 模型，模型下载到 `/opt/hobot/model/<soc>/basic/`（`<soc>` 取 `s100` 或 `s600`）。`run.sh` 会自动检测当前设备 SoC 并下载对应版本。
 
 ## 模型评估
 

--- a/samples/vision/ultralytics_yolo26/evaluator/README.md
+++ b/samples/vision/ultralytics_yolo26/evaluator/README.md
@@ -183,6 +183,16 @@ python3 eval_yolo26_obb.py \
 | S100P | YOLO26l Detect | 0.456 / 0.437 (96.0 %) | 0.260 / 0.234 (89.8 %) | 0.499 / 0.484 (97.1 %) | 0.627 / 0.609 (97.0 %) |
 | S100P | YOLO26x Detect | 0.484 / 0.466 (96.2 %) | 0.292 / 0.271 (92.8 %) | 0.528 / 0.502 (95.1 %) | 0.669 / 0.654 (97.8 %) |
 
+### RDK S600 Accuracy Data (Accuracy @ NV12 - Detection)
+
+| Device | Model | Accuracy bbox-all <br> mAP @.50:.95 <br> (FP32 / BPU Python) | Accuracy bbox-small <br> mAP @.50:.95 <br> (FP32 / BPU Python) | Accuracy bbox-medium <br> mAP @.50:.95 <br> (FP32 / BPU Python) | Accuracy bbox-large <br> mAP @.50:.95 <br> (FP32 / BPU Python) |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| S600 | YOLO26n Detect | 0.319 / 0.285 (89.3 %) | 0.107 / 0.080 (74.8 %) | 0.349 / 0.304 (87.1 %) | 0.508 / 0.460 (90.6 %) |
+| S600 | YOLO26s Detect | 0.395 / 0.368 (93.2 %) | 0.183 / 0.172 (94.0 %) | 0.440 / 0.414 (94.1 %) | 0.583 / 0.526 (90.2 %) |
+| S600 | YOLO26m Detect | 0.442 / 0.417 (94.3 %) | 0.242 / 0.211 (87.2 %) | 0.489 / 0.460 (94.1 %) | 0.629 / 0.600 (95.4 %) |
+| S600 | YOLO26l Detect | 0.456 / 0.429 (94.1 %) | 0.260 / 0.222 (85.4 %) | 0.499 / 0.473 (94.8 %) | 0.627 / 0.610 (97.3 %) |
+| S600 | YOLO26x Detect | 0.484 / 0.452 (93.4 %) | 0.292 / 0.246 (84.2 %) | 0.528 / 0.490 (92.8 %) | 0.669 / 0.645 (96.4 %) |
+
 ### RDK S100 Accuracy Data (Accuracy @ NV12 - Pose Estimation)
 
 | Device | Model | Accuracy kpt-all <br> mAP @.50:.95 <br> (BPU Python) | Accuracy kpt-medium <br> mAP @.50:.95 <br> (BPU Python) | Accuracy kpt-large <br> mAP @.50:.95 <br> (BPU Python) |
@@ -199,6 +209,16 @@ python3 eval_yolo26_obb.py \
 | :--- | :--- | :--- | :--- | :--- |
 | S100P | YOLO26n Pose | - | - | - |
 
+### RDK S600 Accuracy Data (Accuracy @ NV12 - Pose Estimation)
+
+| Device | Model | Accuracy kpt-all <br> mAP @.50:.95 <br> (BPU Python) | Accuracy kpt-medium <br> mAP @.50:.95 <br> (BPU Python) | Accuracy kpt-large <br> mAP @.50:.95 <br> (BPU Python) |
+| :--- | :--- | :--- | :--- | :--- |
+| S600 | YOLO26n Pose | 0.507 | 0.416 | 0.649 |
+| S600 | YOLO26s Pose | 0.578 | 0.505 | 0.697 |
+| S600 | YOLO26m Pose | 0.621 | 0.551 | 0.737 |
+| S600 | YOLO26l Pose | 0.640 | 0.583 | 0.740 |
+| S600 | YOLO26x Pose | 0.665 | 0.604 | 0.769 |
+
 ### RDK S100 Accuracy Data (Accuracy @ NV12 - Segmentation)
 
 | Device | Model | Accuracy mask-all <br> mAP @.50:.95 <br> (FP32 / BPU Python) | Accuracy mask-small <br> mAP @.50:.95 <br> (FP32 / BPU Python) | Accuracy mask-medium <br> mAP @.50:.95 <br> (FP32 / BPU Python) | Accuracy mask-large <br> mAP @.50:.95 <br> (FP32 / BPU Python) |
@@ -214,6 +234,16 @@ python3 eval_yolo26_obb.py \
 | Device | Model | Accuracy mask-all <br> mAP @.50:.95 <br> (FP32 / BPU Python) | Accuracy mask-small <br> mAP @.50:.95 <br> (FP32 / BPU Python) | Accuracy mask-medium <br> mAP @.50:.95 <br> (FP32 / BPU Python) | Accuracy mask-large <br> mAP @.50:.95 <br> (FP32 / BPU Python) |
 | :--- | :--- | :--- | :--- | :--- | :--- |
 | S100P | YOLO26n Seg | - / - (- %) | - / - (- %) | - / - (- %) | - / - (- %) |
+
+### RDK S600 Accuracy Data (Accuracy @ NV12 - Segmentation)
+
+| Device | Model | Accuracy mask-all <br> mAP @.50:.95 <br> (FP32 / BPU Python) | Accuracy mask-small <br> mAP @.50:.95 <br> (FP32 / BPU Python) | Accuracy mask-medium <br> mAP @.50:.95 <br> (FP32 / BPU Python) | Accuracy mask-large <br> mAP @.50:.95 <br> (FP32 / BPU Python) |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| S600 | YOLO26n Seg | - / 0.255 | - / 0.061 | - / 0.274 | - / 0.422 |
+| S600 | YOLO26s Seg | - / 0.331 | - / 0.121 | - / 0.370 | - / 0.508 |
+| S600 | YOLO26m Seg | - / 0.358 | - / 0.156 | - / 0.398 | - / 0.538 |
+| S600 | YOLO26l Seg | - / 0.371 | - / 0.158 | - / 0.417 | - / 0.559 |
+| S600 | YOLO26x Seg | - / 0.382 | - / 0.171 | - / 0.429 | - / 0.571 |
 
 ### RDK S100 Accuracy Data (Accuracy @ NV12 - Classification)
 

--- a/samples/vision/ultralytics_yolo26/evaluator/README.md
+++ b/samples/vision/ultralytics_yolo26/evaluator/README.md
@@ -261,6 +261,16 @@ python3 eval_yolo26_obb.py \
 | :--- | :--- | :--- | :--- |
 | S100P | YOLO26n Cls | - | - |
 
+### RDK S600 Accuracy Data (Accuracy @ NV12 - Classification)
+
+| Device | Model | Accuracy TOP1 <br> (BPU Python) | Accuracy TOP5 <br> (BPU Python) |
+| :--- | :--- | :--- | :--- |
+| S600 | YOLO26n Cls | 0.600 | 0.823 |
+| S600 | YOLO26s Cls | 0.649 | 0.863 |
+| S600 | YOLO26m Cls | 0.650 | 0.867 |
+| S600 | YOLO26l Cls | 0.689 | 0.890 |
+| S600 | YOLO26x Cls | 0.666 | 0.876 |
+
 ### RDK S100 Accuracy Data (Accuracy @ NV12 - OBB)
 
 | Device | Model | Accuracy mAP50 <br> (BPU Python) | Accuracy mAP50-95 <br> (BPU Python) |

--- a/samples/vision/ultralytics_yolo26/evaluator/README_cn.md
+++ b/samples/vision/ultralytics_yolo26/evaluator/README_cn.md
@@ -261,6 +261,16 @@ python3 eval_yolo26_obb.py \
 | :--- | :--- | :--- | :--- |
 | S100P | YOLO26n Cls | - | - |
 
+### RDK S600 精度数据 (Accuracy @ NV12 - Classification)
+
+| Device | Model | Accuracy TOP1 <br> (BPU Python) | Accuracy TOP5 <br> (BPU Python) |
+| :--- | :--- | :--- | :--- |
+| S600 | YOLO26n Cls | 0.600 | 0.823 |
+| S600 | YOLO26s Cls | 0.649 | 0.863 |
+| S600 | YOLO26m Cls | 0.650 | 0.867 |
+| S600 | YOLO26l Cls | 0.689 | 0.890 |
+| S600 | YOLO26x Cls | 0.666 | 0.876 |
+
 ### RDK S100 精度数据 (Accuracy @ NV12 - OBB)
 
 | Device | Model | Accuracy mAP50 <br> (BPU Python) | Accuracy mAP50-95 <br> (BPU Python) |

--- a/samples/vision/ultralytics_yolo26/evaluator/README_cn.md
+++ b/samples/vision/ultralytics_yolo26/evaluator/README_cn.md
@@ -183,6 +183,16 @@ python3 eval_yolo26_obb.py \
 | S100P | YOLO26l Detect | 0.456 / 0.437 (96.0 %) | 0.260 / 0.234 (89.8 %) | 0.499 / 0.484 (97.1 %) | 0.627 / 0.609 (97.0 %) |
 | S100P | YOLO26x Detect | 0.484 / 0.466 (96.2 %) | 0.292 / 0.271 (92.8 %) | 0.528 / 0.502 (95.1 %) | 0.669 / 0.654 (97.8 %) |
 
+### RDK S600 精度数据 (Accuracy @ NV12 - Detection)
+
+| Device | Model | Accuracy bbox-all <br> mAP @.50:.95 <br> (FP32 / BPU Python) | Accuracy bbox-small <br> mAP @.50:.95 <br> (FP32 / BPU Python) | Accuracy bbox-medium <br> mAP @.50:.95 <br> (FP32 / BPU Python) | Accuracy bbox-large <br> mAP @.50:.95 <br> (FP32 / BPU Python) |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| S600 | YOLO26n Detect | 0.319 / 0.285 (89.3 %) | 0.107 / 0.080 (74.8 %) | 0.349 / 0.304 (87.1 %) | 0.508 / 0.460 (90.6 %) |
+| S600 | YOLO26s Detect | 0.395 / 0.368 (93.2 %) | 0.183 / 0.172 (94.0 %) | 0.440 / 0.414 (94.1 %) | 0.583 / 0.526 (90.2 %) |
+| S600 | YOLO26m Detect | 0.442 / 0.417 (94.3 %) | 0.242 / 0.211 (87.2 %) | 0.489 / 0.460 (94.1 %) | 0.629 / 0.600 (95.4 %) |
+| S600 | YOLO26l Detect | 0.456 / 0.429 (94.1 %) | 0.260 / 0.222 (85.4 %) | 0.499 / 0.473 (94.8 %) | 0.627 / 0.610 (97.3 %) |
+| S600 | YOLO26x Detect | 0.484 / 0.452 (93.4 %) | 0.292 / 0.246 (84.2 %) | 0.528 / 0.490 (92.8 %) | 0.669 / 0.645 (96.4 %) |
+
 ### RDK S100 精度数据 (Accuracy @ NV12 - Pose Estimation)
 
 | Device | Model | Accuracy kpt-all <br> mAP @.50:.95 <br> (BPU Python) | Accuracy kpt-medium <br> mAP @.50:.95 <br> (BPU Python) | Accuracy kpt-large <br> mAP @.50:.95 <br> (BPU Python) |
@@ -199,6 +209,16 @@ python3 eval_yolo26_obb.py \
 | :--- | :--- | :--- | :--- | :--- |
 | S100P | YOLO26n Pose | - | - | - |
 
+### RDK S600 精度数据 (Accuracy @ NV12 - Pose Estimation)
+
+| Device | Model | Accuracy kpt-all <br> mAP @.50:.95 <br> (BPU Python) | Accuracy kpt-medium <br> mAP @.50:.95 <br> (BPU Python) | Accuracy kpt-large <br> mAP @.50:.95 <br> (BPU Python) |
+| :--- | :--- | :--- | :--- | :--- |
+| S600 | YOLO26n Pose | 0.507 | 0.416 | 0.649 |
+| S600 | YOLO26s Pose | 0.578 | 0.505 | 0.697 |
+| S600 | YOLO26m Pose | 0.621 | 0.551 | 0.737 |
+| S600 | YOLO26l Pose | 0.640 | 0.583 | 0.740 |
+| S600 | YOLO26x Pose | 0.665 | 0.604 | 0.769 |
+
 ### RDK S100 精度数据 (Accuracy @ NV12 - Segmentation)
 
 | Device | Model | Accuracy mask-all <br> mAP @.50:.95 <br> (FP32 / BPU Python) | Accuracy mask-small <br> mAP @.50:.95 <br> (FP32 / BPU Python) | Accuracy mask-medium <br> mAP @.50:.95 <br> (FP32 / BPU Python) | Accuracy mask-large <br> mAP @.50:.95 <br> (FP32 / BPU Python) |
@@ -214,6 +234,16 @@ python3 eval_yolo26_obb.py \
 | Device | Model | Accuracy mask-all <br> mAP @.50:.95 <br> (FP32 / BPU Python) | Accuracy mask-small <br> mAP @.50:.95 <br> (FP32 / BPU Python) | Accuracy mask-medium <br> mAP @.50:.95 <br> (FP32 / BPU Python) | Accuracy mask-large <br> mAP @.50:.95 <br> (FP32 / BPU Python) |
 | :--- | :--- | :--- | :--- | :--- | :--- |
 | S100P | YOLO26n Seg | - / - (- %) | - / - (- %) | - / - (- %) | - / - (- %) |
+
+### RDK S600 精度数据 (Accuracy @ NV12 - Segmentation)
+
+| Device | Model | Accuracy mask-all <br> mAP @.50:.95 <br> (FP32 / BPU Python) | Accuracy mask-small <br> mAP @.50:.95 <br> (FP32 / BPU Python) | Accuracy mask-medium <br> mAP @.50:.95 <br> (FP32 / BPU Python) | Accuracy mask-large <br> mAP @.50:.95 <br> (FP32 / BPU Python) |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| S600 | YOLO26n Seg | - / 0.255 | - / 0.061 | - / 0.274 | - / 0.422 |
+| S600 | YOLO26s Seg | - / 0.331 | - / 0.121 | - / 0.370 | - / 0.508 |
+| S600 | YOLO26m Seg | - / 0.358 | - / 0.156 | - / 0.398 | - / 0.538 |
+| S600 | YOLO26l Seg | - / 0.371 | - / 0.158 | - / 0.417 | - / 0.559 |
+| S600 | YOLO26x Seg | - / 0.382 | - / 0.171 | - / 0.429 | - / 0.571 |
 
 ### RDK S100 精度数据 (Accuracy @ NV12 - Classification)
 


### PR DESCRIPTION
## Summary

Two small documentation fixes for the `rdk_s` branch:

### 1. YOLO26 — S600 accuracy tables
Adds `RDK S600 Accuracy Data` tables for Detection, Segmentation and
Pose Estimation in `samples/vision/ultralytics_yolo26/evaluator/README.md`
(and `README_cn.md`).

- Measured on RDK S600 (`nash-p`) with PTQ models calibrated on 200
  COCO images.
- Evaluated on COCO val2017 (5000 images) via `pycocotools`.
- Score threshold 0.25 / NMS 0.7, same as the existing S100 tables.
- Results align with S100 within ±0.006 mAP across all sizes (n/s/m/l/x):

  | task | metric | S600 range vs S100 |
  | --- | --- | --- |
  | Detect | bbox-all | +0.013 / −0.007 |
  | Seg    | mask-all | +0.002 / −0.004 |
  | Pose   | kpt-all  | +0.003 / −0.006 |

### 2. EfficientNet — fix model path in top-level README
`download_model.sh` writes the model to `/opt/hobot/model/<soc>/basic/`
(the shared on-board model directory), but the top-level
`samples/vision/efficientnet/README.md` still pointed users to a
sample-local `model/<soc>/` path. The runtime defaults
(`runtime/python/efficientnet.py`, `run.sh`, `main.py`) and the
`model/README.md` were already correct, so only the two top-level
README files needed alignment.

## Branch
`rdk_s` → `rdk_s`
