### PR TITLE
feat(gemma4): add S600 quantization and runtime support

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ The `run.sh` script automatically downloads the model, installs dependencies, an
 | Speech Recognition | ASR (Wav2Vec2) | `samples/speech/asr` | S100 / S600 | [Details](./samples/speech/asr) |
 | Speech Recognition | Paraformer (Chinese ASR, WAV input, three-stage INT16 HBM) | `samples/speech/paraformer` | S100 | [Details](./samples/speech/paraformer) |
 | Keyword Spotting | KWS (MDTC) | `samples/speech/kws` | S100 | [Details](./samples/speech/kws) |
-| Vision-Language Model | Gemma4-E2B VLM | `samples/llm/gemma4-e2b` | S100P | [Details](./samples/llm/gemma4-e2b) |
+| Vision-Language Model | Gemma4-E2B VLM | `samples/llm/gemma4-e2b` | S100P / S600 | [Details](./samples/llm/gemma4-e2b) |
 | Embodied AI / Robot Policy | ACT (Action Chunking Transformer) | `samples/vla/act` | S100 / S600 | [Details](https://github.com/D-Robotics/rdk_LeRobot_tools) |
 
 ---

--- a/README_cn.md
+++ b/README_cn.md
@@ -153,7 +153,7 @@ bash run.sh
 | 语音识别 | ASR（Wav2Vec2） | `samples/speech/asr` | S100 / S600 | [详情](./samples/speech/asr) |
 | 语音识别 | Paraformer（中文 ASR，WAV 输入，三段 INT16 HBM） | `samples/speech/paraformer` | S100 | [详情](./samples/speech/paraformer) |
 | 关键词唤醒 | KWS（MDTC） | `samples/speech/kws` | S100 | [详情](./samples/speech/kws) |
-| 视觉语言模型 | Gemma4-E2B VLM | `samples/llm/gemma4-e2b` | S100P | [详情](./samples/llm/gemma4-e2b) |
+| 视觉语言模型 | Gemma4-E2B VLM | `samples/llm/gemma4-e2b` | S100P / S600 | [详情](./samples/llm/gemma4-e2b) |
 | 具身智能 / 机器人策略 | ACT（Action Chunking Transformer） | `samples/vla/act` | S100 / S600 | [详情](https://github.com/D-Robotics/rdk_LeRobot_tools) |
 
 ---

--- a/samples/llm/gemma4-e2b/.gitignore
+++ b/samples/llm/gemma4-e2b/.gitignore
@@ -9,12 +9,14 @@ __pycache__/
 *.hbo
 *.bin
 
-# Calibration data (download via scripts)
-calibration_data/images/
-calibration_data/text/*.json
+# Calibration data (download or provide locally; do not commit datasets)
+conversion/calibration_data/images/
+conversion/calibration_data/images_coco_manifest.json
+conversion/calibration_data/text/*.json
+conversion/calibration_data/text/*.txt
 
 # Build output
-output/
+conversion/output/
 runtime/cpp/build/
 
 # tokenizers-cpp: downloaded at build time by install_tokenizers_cpp.sh,

--- a/samples/llm/gemma4-e2b/README.md
+++ b/samples/llm/gemma4-e2b/README.md
@@ -6,7 +6,7 @@
   <img src="./test_data/results/image.jpg" alt="Gemma4-E2B on RDK S100P" width="960">
 </p>
 
-Real-time **Vision-Language Model** inference for Google **Gemma4-E2B** on **D-Robotics RDK S100P** (`march=nash-m`). Runs fully on-device via the BPU — text chat and image+text (VLM) in one interactive runtime.
+Real-time **Vision-Language Model** inference for Google **Gemma4-E2B** on **D-Robotics RDK S100P and S600**. It runs fully on-device via the BPU and provides multi-turn text chat plus image+text VLM chat in one interactive runtime.
 
 ![Text chat demo](./test_data/results/test3.jpg)
 
@@ -16,7 +16,7 @@ Real-time **Vision-Language Model** inference for Google **Gemma4-E2B** on **D-R
 
 *VLM chat: load an image, ask in Chinese, stream the reply (86% BPU utilization).*
 
-> Supported platform: **RDK S100P** (community sample; upstream: [gemma4-e2b-rdk-s100p](https://github.com/shockley6668/gemma4-e2b-rdk-s100p))
+> Supported platforms: **RDK S100P / S600**. Both use the same C++ runtime, but each board requires HBM files compiled for its SoC.
 
 ---
 
@@ -31,6 +31,7 @@ Gemma4-E2B is a lightweight multimodal model from Google, combining a Vision ViT
 
 - Multimodal understanding: image + text → text
 - Multi-turn text chat with KV cache reuse
+- Automatic budgeting across the full 4096-token context, with `/context` reporting and complete-turn history trimming
 - Streaming token output on BPU
 
 ### Algorithm Features
@@ -47,7 +48,12 @@ Gemma4-E2B is a lightweight multimodal model from Google, combining a Vision ViT
 | Platform | Support | Notes |
 | --- | --- | --- |
 | RDK S100P | ✅ | Primary target (`nash-m`, `core_num=1`) |
-| RDK S100 / S600 | ❌ | Not validated in this sample |
+| RDK S600 | ✅ | `nash-p`; matching public S600 HBMs, with Vision and Text loaded once at startup and kept resident |
+| RDK S100 | ⚠️ | SoC runtime branch retained, but board validation is not complete |
+
+On-board regression for this update was run only on RDK S600. S100/S100P
+coverage is limited to shared-source target-matrix and compatibility checks;
+no S100 board connection is required or claimed.
 
 ---
 
@@ -86,25 +92,30 @@ Each sample provides a `run.sh` for one-click experience on board:
 
 ```bash
 cd samples/llm/gemma4-e2b/runtime/cpp
-./run.sh
+./run.sh                              # interactive VLM chat
+./run.sh server --port=8000           # OpenAI / ChatBox API
+./run.sh --max_tokens=512             # pass gflags to main
 ```
 
 The script will:
 
-1. Install build dependencies (`cmake`, `g++`, `libopencv-dev`, `libgflags-dev`, `nlohmann-json3-dev`, `cargo`, `wget`)
-2. Download pre-compiled runtime model files from the D-Robotics model archive if missing (`~/gemma4_e2b` by default)
+1. Install build dependencies (`cmake`, `g++`, `libopencv-dev`, `libgflags-dev`, `nlohmann-json3-dev`, `cargo`, `wget`, `git`, `curl`)
+2. Resolve the SoC-specific model files under `~/gemma4_e2b`: S100P and S600 download matching HBMs from the public archive; S100 uses pre-placed HBMs or `GEMMA4_MODEL_BASE_URL`
 3. Download `tokenizers-cpp` source (pinned commit)
-4. Build `main` (first build compiles `tokenizers-cpp`, ~few minutes)
-5. Launch interactive VLM chat
+4. Build all five runtime targets (the first build compiles `tokenizers-cpp`)
+5. Launch the selected entry; zero arguments still start interactive `main`
 
 Example session:
 
 ```
 gemma4> /image ../../test_data/image1.jpg
 gemma4> Describe this image
+gemma4> /context
 gemma4> /reset
 gemma4> /quit
 ```
+
+`main` defaults to `--max_tokens=0`, which uses all KV capacity remaining after the current prompt while keeping `prompt + output <= 4096`. On S600, `download_model.sh` selects the public `nash-p` Vision/Text HBMs automatically.
 
 For step-by-step details see [runtime/cpp/README.md](./runtime/cpp/README.md).
 
@@ -112,9 +123,10 @@ For step-by-step details see [runtime/cpp/README.md](./runtime/cpp/README.md).
 
 ## Model Conversion
 
-ModelZoo already provides pre-compiled HBM models. Users can download them
-directly via `model/download_model.sh` and **skip this section** if they
-only want to run inference.
+Pre-compiled HBM models can be used directly, so users who only need
+inference may **skip this section**. The download helper selects the public
+S100P and S600 assets automatically; S100 requires matching HBMs supplied locally
+or through `GEMMA4_MODEL_BASE_URL`.
 
 For custom re-quantization (requires a PC with 128 GB RAM + OE-LLM SDK),
 see [conversion/README.md](./conversion/README.md) and the full guide:
@@ -128,7 +140,7 @@ see [conversion/README.md](./conversion/README.md) and the full guide:
 
 This sample provides a **C++** board-side runtime only (LLM inference is
 C++-native; no Python path is provided). For build, parameters, and
-detailed usage, see [runtime/cpp/README.md](./runtime/cpp/README.md).
+interactive / OpenAI-compatible chat usage, see [runtime/cpp/README.md](./runtime/cpp/README.md).
 
 ---
 

--- a/samples/llm/gemma4-e2b/README_cn.md
+++ b/samples/llm/gemma4-e2b/README_cn.md
@@ -6,7 +6,7 @@
   <img src="./test_data/results/image.jpg" alt="Gemma4-E2B on RDK S100P" width="960">
 </p>
 
-Google **Gemma4-E2B** 视觉语言模型在 **地瓜 RDK S100P**（`march=nash-m`）上的实时 VLM 推理示例。完全在 BPU 上运行，支持纯文本对话和图文多模态对话。
+Google **Gemma4-E2B** 视觉语言模型在 **地瓜 RDK S100P / S600** 上的实时 VLM 推理示例。完全在 BPU 上运行，支持纯文本多轮对话和图文多模态对话。
 
 ![纯文本对话演示](./test_data/results/test3.jpg)
 
@@ -16,7 +16,7 @@ Google **Gemma4-E2B** 视觉语言模型在 **地瓜 RDK S100P**（`march=nash-m
 
 *VLM 对话：加载图片、中文提问、BPU 流式输出（BPU 利用率 86%）。*
 
-> 支持平台：**RDK S100P**（社区示例；上游项目：[gemma4-e2b-rdk-s100p](https://github.com/shockley6668/gemma4-e2b-rdk-s100p)）
+> 支持平台：**RDK S100P / S600**。运行时共用同一套 C++ 代码，但必须使用与板端 SoC 匹配的 HBM。
 
 ---
 
@@ -31,6 +31,7 @@ Gemma4-E2B 是 Google 推出的轻量多模态模型，由 Vision ViT 编码器�
 
 - 多模态理解：图片 + 文本 → 文本
 - 多轮文本对话，复用 KV cache
+- 4096-token 总上下文自动预算，支持 `/context` 查看容量并按完整轮次裁剪旧历史
 - BPU 上流式 token 输出
 
 ### 算法特性
@@ -47,7 +48,11 @@ Gemma4-E2B 是 Google 推出的轻量多模态模型，由 Vision ViT 编码器�
 | 平台 | 支持 | 说明 |
 | --- | --- | --- |
 | RDK S100P | ✅ | 主要目标平台（`nash-m`，`core_num=1`） |
-| RDK S100 / S600 | ❌ | 本示例未验证 |
+| RDK S600 | ✅ | `nash-p`；使用公开的 S600 HBM，Vision 与 Text 在启动时各加载一次并常驻 |
+| RDK S100 | ⚠️ | Runtime 保留 SoC 分支，本示例未完成板端验证 |
+
+本次更新只在 RDK S600 上执行板端回归。S100/S100P 仅检查同源代码的目标矩阵
+与兼容性逻辑，不需要连接 S100，也不声明完成了 S100 板端实测。
 
 ---
 
@@ -86,25 +91,30 @@ samples/llm/gemma4-e2b/
 
 ```bash
 cd samples/llm/gemma4-e2b/runtime/cpp
-./run.sh
+./run.sh                              # 交互式 VLM 对话
+./run.sh server --port=8000           # OpenAI / ChatBox 接口
+./run.sh --max_tokens=512             # 向 main 传递 gflags 参数
 ```
 
 脚本会自动：
 
-1. 安装编译依赖（`cmake`、`g++`、`libopencv-dev`、`libgflags-dev`、`nlohmann-json3-dev`、`cargo`、`wget`）
-2. 若本地无模型，从地瓜机器人模型服务器下载预编译运行模型文件（默认 `~/gemma4_e2b`）
+1. 安装编译依赖（`cmake`、`g++`、`libopencv-dev`、`libgflags-dev`、`nlohmann-json3-dev`、`cargo`、`wget`、`git`、`curl`）
+2. 在 `~/gemma4_e2b` 下准备与 SoC 匹配的模型：S100P 与 S600 从公共归档下载对应 HBM；S100 使用预置 HBM 或 `GEMMA4_MODEL_BASE_URL`
 3. 下载 `tokenizers-cpp` 源码（固定 commit）
-4. 编译 `main`（首次编译 `tokenizers-cpp`，耗时数分钟）
-5. 启动交互式 VLM 对话
+4. 编译全部 5 个 runtime 目标（首次会编译 `tokenizers-cpp`）
+5. 启动指定入口；零参数仍默认进入交互式 `main`
 
 交互示例：
 
 ```
 gemma4> /image ../../test_data/image1.jpg
 gemma4> 描述这张图片
+gemma4> /context
 gemma4> /reset
 gemma4> /quit
 ```
+
+`main` 默认使用 `--max_tokens=0`，即每轮自动使用 prompt 后的全部剩余 KV 容量；`prompt + output` 总计不会超过 4096 tokens。S600 会由 `download_model.sh` 自动选择公开的 `nash-p` Vision/Text HBM。
 
 详细步骤见 [runtime/cpp/README_cn.md](./runtime/cpp/README_cn.md)。
 
@@ -112,7 +122,7 @@ gemma4> /quit
 
 ## 模型转换（Model Conversion）
 
-ModelZoo 已提供适配完成的 HBM 模型，用户可直接运行 `model/download_model.sh` 下载使用，如不关心模型转换流程，**可跳过本小节**。
+已有预编译 HBM 时可直接运行，因此仅做推理的用户可以**跳过本小节**。下载脚本会自动选择 S100P 与 S600 的公开模型；S100 必须预置匹配 HBM，或通过 `GEMMA4_MODEL_BASE_URL` 指定模型目录。
 
 如需自定义重新量化（需要 128 GB 内存的 PC + OE-LLM SDK），请参考 [conversion/README.md](./conversion/README.md) 及完整教程：
 
@@ -123,7 +133,7 @@ ModelZoo 已提供适配完成的 HBM 模型，用户可直接运行 `model/down
 
 ## 模型推理（Runtime）
 
-本示例仅提供 **C++** 板端推理（LLM 推理为 C++ 原生，不提供 Python 路径）。编译、参数及详细用法请参考 [runtime/cpp/README_cn.md](./runtime/cpp/README_cn.md)。
+本示例仅提供 **C++** 板端推理（LLM 推理为 C++ 原生，不提供 Python 路径）。编译、参数、交互式对话和 OpenAI 兼容接口用法请参考 [runtime/cpp/README_cn.md](./runtime/cpp/README_cn.md)。
 
 ---
 

--- a/samples/llm/gemma4-e2b/conversion/QUANTIZATION_TUTORIAL.md
+++ b/samples/llm/gemma4-e2b/conversion/QUANTIZATION_TUTORIAL.md
@@ -1,10 +1,11 @@
-# Gemma4-E2B Quantization & Deployment on RDK S100P
+# Gemma4-E2B Quantization & Deployment on RDK S100/S100P/S600
 
 [中文](./QUANTIZATION_TUTORIAL_zh.md) | **English**
 
-> A complete guide from zero to working on-board VLM inference.  
-> Based on Google Gemma4-E2B (Vision + Text, no Audio) + D-Robotics OE-LLM 1.0.0 + RDK S100P (`march=nash-m`).  
-> Last updated: 2026-06-25
+> A complete guide from zero to working on-board VLM inference.
+> Based on Google Gemma4-E2B (Vision + Text, no Audio) and D-Robotics OE-LLM 1.0.0.
+> One source tree targets S100 (`nash-e`), S100P (`nash-m`) and S600 (`nash-p`).
+> Last updated: 2026-07-30
 
 ---
 
@@ -22,7 +23,9 @@
 
 ## 0. Introduction
 
-This document walks through quantizing and deploying the Gemma4-E2B multimodal model on the RDK S100P — environment setup, model analysis, calibration data, compilation, accuracy verification, packaging, and on-board deployment — including pitfalls we hit and how we fixed them.
+This document walks through quantizing and deploying Gemma4-E2B on RDK S100,
+S100P and S600: environment setup, model analysis, calibration data,
+compilation, accuracy verification, packaging and on-board deployment.
 
 **Audience**: developers comfortable with Linux/Python who have some familiarity with the D-Robotics RDK platform.
 
@@ -32,7 +35,7 @@ This document walks through quantizing and deploying the Gemma4-E2B multimodal m
 - Run PTQ quantization compilation on your own PC
 - Know how calibration data affects accuracy
 - Verify quantized accuracy (including end-to-end fusion checks)
-- Produce an HBM model package ready for S100P deployment
+- Produce an HBM model package matched to S100, S100P or S600
 
 ---
 
@@ -52,15 +55,20 @@ Google Gemma4 is a multimodal model family released on March 31, 2026. E2B is th
 
 E2B Vision and Text are **defined separately** (`Gemma4Config`), unlike the unified 12B architecture (`Gemma4UnifiedConfig`). Adaptation differs accordingly.
 
-### 1.2 RDK S100P Hardware Constraints
+### 1.2 RDK Target Matrix
 
-Quantization and on-board deployment in this guide target the **RDK S100P** with `--march nash-m`.
+The conversion scripts select the correct march and core counts through
+`TARGET_SOC`:
 
-| Item | Value | Quantization impact |
-| --- | --- | --- |
-| RAM | 12 GB LPDDR5 | Model + KV + system should stay under ~10 GB |
-| BPU | Nash-M, 80 TOPS | `march=nash-m` |
-| BPU cores | **1** | `core_num=1`, `vit_core_num=1` |
+| Target | HBDK march | Vision cores | Text prefill / decode | Board-memory note |
+| --- | --- | ---: | ---: | --- |
+| S100 | `nash-e` | 1 | 1 / 1 | Compile or provide matching S100 HBMs |
+| S100P | `nash-m` | 1 | 1 / 1 | Original sample behavior |
+| S600 | `nash-p` | 4 | 2 / 2 | 23 GiB usable (24 GB nominal), not 64 GB |
+
+S600-only compiler options (dynamic quantization, `opt=1`, HPC and decode
+no-padding) are isolated behind `nash-p`; they do not alter S100/S100P
+compilation.
 
 ### 1.3 OE-LLM Toolchain
 
@@ -325,17 +333,21 @@ If calibration distribution diverges from inference (e.g. solid color blocks vs 
 
 ### 4.2 Vision Calibration
 
-Vision calibration uses **50 real COCO val2017 images** in `calibration_data/images/`. Download script:
+Vision calibration uses **50 real COCO val2017 images** in `calibration_data/images/`. Run the downloader from the sample root:
 
 ```bash
-python download_coco_calib_images.py
+python3 conversion/scripts/calibration/download_coco_images.py
 ```
 
-You can also add your own images (jpg/png/bmp/webp) to `calibration_data/images/`.
+The compile wrapper verifies the generated provenance manifest, COCO source URLs,
+SHA256 hashes, and the exact 50-file set. It rejects extra, missing, synthetic, or
+otherwise untracked images; do not mix custom images into this directory unless
+you intentionally replace the verification workflow.
 
 ### 4.3 Text Calibration
 
-Text calibration needs diverse prompts in OELLM JSON format:
+Text calibration must be a user-supplied, reviewed corpus in OELLM JSON format.
+This sample does not generate replacement prompts:
 
 ```json
 [
@@ -345,17 +357,20 @@ Text calibration needs diverse prompts in OELLM JSON format:
 ]
 ```
 
-Prepare 100–200 entries covering languages, lengths, and topics. We used 150 entries.
+Use a stable corpus covering representative languages, lengths, and topics. The
+validated reference corpus contained 234 entries. The S600 resume flow reused
+existing quantized BC and did not generate or recalibrate from fresh text.
 
 ### 4.4 Calibration Directory Layout
 
 ```
 calibration_data/
-├── images/              # Vision calibration (50 COCO images)
+├── images_coco_manifest.json  # COCO provenance and per-image SHA256
+├── images/              # Vision calibration (exactly 50 COCO images)
 │   ├── coco_00_000000000802.jpg
 │   ├── coco_01_000000280325.jpg
 │   └── ...
-├── text/                # Text calibration (150 prompts)
+├── text/                # Reviewed text corpus (234 entries in reference run)
 │   └── calibration.json
 └── text_verify/         # Text accuracy check (2 short prompts)
     └── calibration.json
@@ -371,29 +386,23 @@ calibration_data/
 cd ~/gemma
 conda activate oellm
 
-# Increase stack size (required by hbdk4 compile_hbo; otherwise segfault)
-ulimit -s unlimited
+# Downloads a deterministic category-diverse set and writes its provenance
+# manifest. The compile script refuses synthetic or untracked images.
+python3 conversion/scripts/calibration/download_coco_images.py
 
-python -u $(python -c "import leap_llm; import os; print(os.path.dirname(leap_llm.__file__))")/apis/oellm_build.py \
-    --model_name gemma4-e2b-vision \
-    --march nash-m \
-    --input_model_path ./gemma4-e2b \
-    --output_model_path ./output/gemma4_e2b_vision \
-    --calib_image_path ./calibration_data/images \
-    --device cuda:0 \
-    --vit_core_num 1 \
-    2>&1 | tee output/vision_compile.log
+# Replace s600 with s100 or s100p for the other targets.
+TARGET_SOC=s600 bash conversion/scripts/compile/run_vision_compile.sh
 ```
 
 | Parameter | Value | Notes |
 | --- | --- | --- |
 | `--model_name` | `gemma4-e2b-vision` | Registered in model_factory.py |
-| `--march` | `nash-m` | S100P march |
+| `TARGET_SOC` | `s100` / `s100p` / `s600` | Selects march and core defaults |
 | `--input_model_path` | HuggingFace weights dir | config.json + model.safetensors |
-| `--output_model_path` | Output directory | Compile artifacts |
-| `--calib_image_path` | COCO image dir | 50 real images |
+| `OUTPUT_DIR` | Per-target output directory | Compile artifacts do not overwrite another SoC |
+| `CALIB_IMAGE_DIR` | COCO image dir | Exactly 50 manifest-backed real images |
 | `--device` | `cuda:0` | GPU for calibration forward (CPU works, slower) |
-| `--vit_core_num` | `1` | Single core in this guide |
+| `VIT_CORE_NUM` | Matrix default | Optional explicit override |
 
 **Do not use `--verifier` here**: post-compile verifier reports `gemma4-e2b-vision does not support LLM` (it applies LLM verification to VLM). The HBM is valid — run `verifier_cli.py` separately.
 
@@ -422,7 +431,7 @@ Function 'convert_mlir' done in 19.3s
 Function 'compile_hbo' done in 6620.3s     ← ~110 min
 [Gemma4Vision] Linking HBM...
 Function 'link_models' done in 10.5s
-[Gemma4Vision] Done: ./output/gemma4_e2b_vision/gemma4-e2b_vit_ptq.hbm
+[Gemma4Vision] Done: ./output/gemma4_e2b_vision_s600/gemma4-e2b_vit_ptq.hbm
 ```
 
 `compile_hbo` is CPU single-threaded for ViT; `HBDK_JOBS` has little effect.
@@ -430,7 +439,7 @@ Function 'link_models' done in 10.5s
 ### 5.3 Artifacts
 
 ```
-output/gemma4_e2b_vision/
+output/gemma4_e2b_vision_s600/
 ├── gemma4-e2b_vit_ptq.bc              # 620 MB  exported BC
 ├── gemma4-e2b_vit_ptq.convert.bc      # 202 MB  after MLIR convert
 ├── gemma4-e2b_vit_ptq.hbo             # 363 MB  HBO binary
@@ -471,7 +480,7 @@ Inspect with:
 
 ```python
 from hbdk4.compiler import load
-bc = load("output/gemma4_e2b_vision/gemma4-e2b_vit_ptq.bc")
+bc = load("output/gemma4_e2b_vision_s600/gemma4-e2b_vit_ptq.bc")
 for inp in bc.functions[0].inputs:
     print(inp.name, list(inp.type.shape), inp.type.np_dtype)
 for out in bc.functions[0].outputs:
@@ -488,19 +497,9 @@ Text has prefill and decode phases; OELLM compiles both and links one `.hbm`:
 
 ```bash
 conda activate oellm
-ulimit -s unlimited
 
-python -u $(python -c "import leap_llm; import os; print(os.path.dirname(leap_llm.__file__))")/apis/oellm_build.py \
-    --model_name gemma4-e2b-text \
-    --march nash-m \
-    --input_model_path ./gemma4-e2b \
-    --output_model_path ./output/gemma4_e2b_text \
-    --calib_text_path ./calibration_data/text \
-    --chunk_size 256 \
-    --cache_len 4096 \
-    --device cpu \
-    --core_num 1 \
-    2>&1 | tee output/text_compile.log
+# Uses the existing text calibration corpus; it does not synthesize prompts.
+TARGET_SOC=s600 bash conversion/scripts/compile/run_text_compile.sh
 ```
 
 | Parameter | Value | Notes |
@@ -509,20 +508,21 @@ python -u $(python -c "import leap_llm; import os; print(os.path.dirname(leap_ll
 | `--chunk_size` | `256` | Prefill processes 256 tokens per step |
 | `cache_len` | `4096` | Max KV cache length |
 | `--device` | `cpu` | Text calibration has little GPU benefit |
-| `--core_num` | `1` | Single core in this guide |
+| `PREFILL_CORE_NUM` | Matrix default | S600 uses 2; S100/S100P use 1 |
+| `DECODE_CORE_NUM` | Matrix default | S600 uses 2; S100/S100P use 1 |
 
 `tok_embeddings.bin` is exported automatically:
 
 ```python
 # Runs in Gemma4TextApi.__init__
 tok_embs = model.embed_tokens.weight.data * model.embed_tokens.embed_scale
-tok_embs.detach().cpu().numpy().tofile("output/gemma4_e2b_text/tok_embeddings.bin")
+tok_embs.detach().cpu().numpy().tofile("output/gemma4_e2b_text_s600/tok_embeddings.bin")
 ```
 
 ### 6.2 Artifacts
 
 ```
-output/gemma4_e2b_text/
+output/gemma4_e2b_text_s600/
 ├── gemma4-e2b_lm_chunk_256_cache_4096_ptq.prefill.bc          # 18.5 GB
 ├── gemma4-e2b_lm_chunk_256_cache_4096_ptq.prefill_convert.bc  # 4.7 GB
 ├── gemma4-e2b_lm_chunk_256_cache_4096_ptq.prefill.hbo          # 4.8 GB
@@ -567,25 +567,21 @@ Key Text HBM parameters are **fixed at compile time** and define on-board contex
 | KV cache length | env `CACHE_LEN` | 4096 | Shared budget for input + output tokens. Larger → more DDR, longer compile. |
 | Prefill chunk size | env `CHUNK_SIZE` | 256 | Tokens per prefill step. Larger → fewer steps, higher peak memory. |
 
-These map to `kCacheLen` / `kChunkSize` in `runtime/cpp/gemma4_config.h`. After recompiling HBM, update the runtime config or inference will misalign.
+These map to `kCacheLen` / `kChunkSize` in
+`runtime/cpp/inc/gemma4_config.hpp`. After recompiling HBM, update the runtime
+config or inference will misalign.
 
-**Example: extend context from 4096 to 8192**
+**Current deliverable: use the complete 4096-token KV budget**
 
-```bash
-# 1. Recompile Text HBM on PC (hours)
-CHUNK_SIZE=512 CACHE_LEN=8192 bash conversion/scripts/compile/run_text_compile.sh
-```
-
-```cpp
-// 2. Update board runtime (runtime/cpp/gemma4_config.h)
-constexpr int kChunkSize = 512;   // must match CHUNK_SIZE above
-constexpr int kCacheLen  = 8192;  // must match CACHE_LEN above
-```
+The provided Text HBM is fixed at `CHUNK_SIZE=256` and `CACHE_LEN=4096`.
+No 8K/16K HBM is included in this deliverable. Run the interactive entry with
+its default `--max_tokens=0`; each turn then receives all capacity remaining
+after the encoded prompt. When later turns need more room, `main` removes the
+oldest complete user/assistant turns and continues within the same 4096-token
+limit.
 
 ```bash
-# 3. Rebuild runtime
-cd runtime/cpp && mkdir build && cd build
-cmake .. && make -j$(nproc)
+./main --max_tokens=0
 ```
 
 **Runtime-only parameters** (no HBM recompile):
@@ -593,7 +589,7 @@ cmake .. && make -j$(nproc)
 | Parameter | Where | Default | Notes |
 | --- | --- | --- | --- |
 | Sliding window | `kSlidingWindow` | 512 | Decode sliding-attention window; must be ≤ `kCacheLen`. |
-| Max output tokens | `--max-tokens N` | `kCacheLen` | Per-turn generation limit at runtime. |
+| Max output tokens | `--max_tokens N` | `0` | `0` uses all KV capacity remaining after the prompt. |
 
 > **Memory cost**: doubling `CACHE_LEN` doubles KV cache DDR usage. Confirm free board memory before increasing.  
 > HBM filename `gemma4-e2b_lm_chunk_256_cache_4096_ptq.hbm` keeps the old naming pattern; contents reflect whatever `CHUNK_SIZE` / `CACHE_LEN` you used.
@@ -618,26 +614,29 @@ Separate checks for Vision and Text vs float outputs.
 **Vision BC**
 
 ```bash
-cd ~/gemma && conda activate oellm
+cd samples/llm/gemma4-e2b/conversion
+conda activate oellm
+export TARGET_SOC=s600  # replace with s100 or s100p when needed
 
-python -u leap_llm/apis/verifier_cli.py \
+python -m leap_llm.apis.verifier_cli \
     --model_name gemma4-e2b-vision \
     --model_dir ./gemma4-e2b \
-    --quant_vlm_model_path ./output/gemma4_e2b_vision/gemma4-e2b_vit_ptq.bc \
+    --quant_vlm_model_path ./output/gemma4_e2b_vision_${TARGET_SOC}/gemma4-e2b_vit_ptq.bc \
     --input_image_path ./calibration_data/images/coco_00_000000000802.jpg
 ```
 
 **Text BC** (text only, no vision)
 
 ```bash
-python -u quick_text_verify.py
-# Output: output/e2b_text_verify_quick.json
+python -u scripts/verify/quick_text_verify.py --target-soc "$TARGET_SOC"
+# Output: output/e2b_text_verify_quick_${TARGET_SOC}.json
 ```
 
 If dev machine and board share a network, you can also run HBM verification on BPU:
 
 ```bash
-bash run_remote_hbm_verify.sh   # pass --remote_ip for board IP
+BOARD_IP=<board-ip> TARGET_SOC="$TARGET_SOC" \
+  bash scripts/verify/run_remote_hbm_verify.sh
 ```
 
 ---
@@ -650,13 +649,13 @@ bash run_remote_hbm_verify.sh   # pass --remote_ip for board IP
 mkdir -p gemma4_e2b_deploy/{model,tokenizer}
 
 # Model files (3 large files)
-cp output/gemma4_e2b_vision/gemma4-e2b_vit_ptq.hbm \
+cp output/gemma4_e2b_vision_s600/gemma4-e2b_vit_ptq.hbm \
    gemma4_e2b_deploy/model/
 
-cp output/gemma4_e2b_text/gemma4-e2b_lm_chunk_256_cache_4096_ptq.hbm \
+cp output/gemma4_e2b_text_s600/gemma4-e2b_lm_chunk_256_cache_4096_ptq.hbm \
    gemma4_e2b_deploy/model/
 
-cp output/gemma4_e2b_text/tok_embeddings.bin \
+cp output/gemma4_e2b_text_s600/tok_embeddings.bin \
    gemma4_e2b_deploy/model/
 
 # Tokenizer files
@@ -700,7 +699,8 @@ Packed size ~**4.3 GB** (gzip); unpacked ~**6.3 GB**.
 
 ## 9. On-Board Deployment & VLM Inference
 
-How to deploy compiled HBM models on S100P and run Gemma4-E2B VLM inference.
+How to deploy the HBM files matching the detected SoC and run Gemma4-E2B VLM
+inference with the same C++ runtime.
 
 ### 9.1 Two Paths: Run Prebuilt vs Compile Yourself
 
@@ -716,25 +716,28 @@ How to deploy compiled HBM models on S100P and run Gemma4-E2B VLM inference.
 
 #### Step 1: Download Prebuilt Models
 
-On S100P:
+On S100P, the script downloads the validated public `nash-m` HBM archive.
+On S600, it downloads the validated public `nash-p` HBMs from the S600 model directory.
+For S100, place matching HBMs in `$GEMMA4_HOME/model` first or set
+`GEMMA4_MODEL_BASE_URL`; the script never substitutes another target's HBM.
 
 ```bash
 export GEMMA4_HOME=~/gemma4_e2b
+export GEMMA4_SOC=s600  # optional when /sys/class/boardinfo/soc_name is present
 bash model/download_model.sh
 ```
 
-The script downloads the three runtime model files and the two required
-tokenizer files from the D-Robotics model archive.
+Shared token embeddings and tokenizer files are downloaded from the public
+archive when missing.
 
 Verify integrity (optional):
 
 ```bash
 sha256sum ~/gemma4_e2b/model/*.hbm
-
-# Expected:
-# 470791849d21cffadb388cc61c8f4b1452078c1722d302fd8a8ac775ee9769f1  ...vit_ptq.hbm
-# 3e4d4940051e4e8dc0cb434e972e7aae75d49504da3fac435e303f68af73a25f  ...lm_..._ptq.hbm
 ```
+
+Hashes are SoC-specific; use the values distributed with the selected model
+package rather than comparing an S600 file against an S100 checksum.
 
 #### Step 2: Build C++ Runtime
 

--- a/samples/llm/gemma4-e2b/conversion/QUANTIZATION_TUTORIAL_zh.md
+++ b/samples/llm/gemma4-e2b/conversion/QUANTIZATION_TUTORIAL_zh.md
@@ -1,10 +1,11 @@
-# Gemma4-E2B 在 RDK S100P 上的量化部署实战教程
+# Gemma4-E2B 在 RDK S100/S100P/S600 上的量化部署教程
 
 [English](./QUANTIZATION_TUTORIAL.md) | **中文**
 
-> 从零到板端 VLM 推理通过的完整指南。  
-> 基于 Google Gemma4-E2B（Vision + Text，不含 Audio）+ 地瓜 OE-LLM 1.0.0 + RDK S100P（`march=nash-m`）。  
-> 最后更新：2026-06-25
+> 从零到板端 VLM 推理通过的完整指南。
+> 基于 Google Gemma4-E2B（Vision + Text，不含 Audio）与地瓜 OE-LLM 1.0.0。
+> 同一套代码支持 S100（`nash-e`）、S100P（`nash-m`）和 S600（`nash-p`）。
+> 最后更新：2026-07-30
 
 ---
 
@@ -22,7 +23,8 @@
 
 ## 0. 前言
 
-本文记录将 Gemma4-E2B 多模态模型量化编译并部署到 RDK S100P 的完整过程，包含环境搭建、模型分析、校准数据准备、编译、精度验证、打包交付等所有步骤，以及我们在实践中踩过的坑和解决方案。
+本文记录将 Gemma4-E2B 多模态模型量化编译并部署到 RDK S100、S100P、S600
+的完整过程，包含环境搭建、模型分析、校准数据准备、编译、精度验证与打包交付。
 
 **目标读者**：有 Linux/Python 基础、对地瓜 RDK 平台有一定了解的开发者。
 
@@ -32,7 +34,7 @@
 - 能够在自己的 PC 上完成 PTQ 量化编译
 - 掌握校准数据选择对精度的影响
 - 知道如何验证量化精度（包括端到端融合验证）
-- 产出可直接部署到 S100P 的 HBM 模型包
+- 产出与 S100、S100P 或 S600 匹配的 HBM 模型包
 
 ---
 
@@ -54,16 +56,18 @@ Google Gemma4 是 2026 年3月31日发布的多模态模型家族，E2B 是其�
 
 E2B 的 Vision 和 Text 是**独立定义**的（`Gemma4Config`），这与 12B 的统一架构（`Gemma4UnifiedConfig`）不同，适配方式也不同。
 
-### 1.2 RDK S100P 硬件约束
+### 1.2 RDK 目标平台矩阵
 
-本文量化与板端部署均在 **RDK S100P** 上完成，编译参数 `--march nash-m`。
+转换脚本通过 `TARGET_SOC` 自动选择 march 和核数：
 
+| 目标平台 | HBDK march | Vision 核数 | Text prefill / decode | 板端内存说明 |
+| --- | --- | ---: | ---: | --- |
+| S100 | `nash-e` | 1 | 1 / 1 | 编译或提供匹配的 S100 HBM |
+| S100P | `nash-m` | 1 | 1 / 1 | 保持原样例行为 |
+| S600 | `nash-p` | 4 | 2 / 2 | 实测可用 23 GiB（标称 24 GB），不是 64 GB |
 
-| 项      | 值              | 量化影响                          |
-| ------ | -------------- | ----------------------------- |
-| RAM    | 12 GB LPDDR5   | 模型+KV+系统需控制在 ~10GB            |
-| BPU    | Nash-M，80 TOPS | `march=nash-m`                |
-| BPU 核数 | **1**          | `core_num=1`、`vit_core_num=1` |
+动态量化、`opt=1`、HPC 与 decode no-padding 仅在 `nash-p` 启用，不会改变
+S100/S100P 的原单核编译行为。
 
 
 ### 1.3 OE-LLM 工具链
@@ -340,17 +344,20 @@ PTQ 的工作原理：
 
 ### 4.2 Vision 校准
 
-Vision 校准使用 **50 张 COCO val2017 真实图像**，保存到 `calibration_data/images/`。下载脚本：
+Vision 校准使用 **50 张 COCO val2017 真实图像**，保存到 `calibration_data/images/`。在样例根目录执行：
 
 ```bash
-python download_coco_calib_images.py
+python3 conversion/scripts/calibration/download_coco_images.py
 ```
 
-也可以手动准备自己的图像，放入 `calibration_data/images/` 目录，支持 jpg/png/bmp/webp。
+编译脚本会校验来源清单、COCO 下载地址、每张图片的 SHA256，以及完整的
+50 张图片集合；多余、缺失、合成或未登记图片都会被拒绝。除非明确替换整套
+来源校验流程，否则不要向该目录混入自定义图片。
 
 ### 4.3 Text 校准
 
-Text 校准需要多样化的 prompt 文本，OELLM 的格式是 JSON：
+Text 校准必须使用人工确认过的自备语料，OELLM 的格式是 JSON。本样例不会
+自动生成替代 prompt：
 
 ```json
 [
@@ -360,17 +367,20 @@ Text 校准需要多样化的 prompt 文本，OELLM 的格式是 JSON：
 ]
 ```
 
-建议准备 100-200 条，覆盖不同语言、不同长度、不同话题。我们使用了 150 条（703 行 JSON 文件中每条一个 `text` 字段）。
+应使用固定语料，覆盖实际业务中的语言、长度和主题。已验证的参考语料包含
+234 条；S600 本次续编译复用了已有量化 BC，没有生成新文本，也没有重新执行
+Text 校准。
 
 ### 4.4 校准数据目录结构
 
 ```
 calibration_data/
-├── images/              # Vision 校准图像（50 张 COCO）
+├── images_coco_manifest.json  # COCO 来源与每张图片的 SHA256
+├── images/              # Vision 校准图像（固定 50 张 COCO）
 │   ├── coco_00_000000000802.jpg
 │   ├── coco_01_000000280325.jpg
 │   └── ...
-├── text/                # Text 校准文本（150 条）
+├── text/                # 已审核文本语料（参考运行使用 234 条）
 │   └── calibration.json
 └── text_verify/         # Text 精度验证（2 条短 prompt）
     └── calibration.json
@@ -386,18 +396,12 @@ calibration_data/
 cd ~/gemma
 conda activate oellm
 
-# 增大栈大小（hbdk4 compile_hbo 需要，否则可能 segfault）
-ulimit -s unlimited
+# 下载固定、类别多样的 50 张真实 COCO val2017 图片并生成来源清单。
+# 编译脚本会拒绝合成图或未登记图片。
+python3 conversion/scripts/calibration/download_coco_images.py
 
-python -u $(python -c "import leap_llm; import os; print(os.path.dirname(leap_llm.__file__))")/apis/oellm_build.py \
-    --model_name gemma4-e2b-vision \
-    --march nash-m \
-    --input_model_path ./gemma4-e2b \
-    --output_model_path ./output/gemma4_e2b_vision \
-    --calib_image_path ./calibration_data/images \
-    --device cuda:0 \
-    --vit_core_num 1 \
-    2>&1 | tee output/vision_compile.log
+# 其他平台将 s600 改成 s100 或 s100p。
+TARGET_SOC=s600 bash conversion/scripts/compile/run_vision_compile.sh
 ```
 
 参数说明：
@@ -406,12 +410,12 @@ python -u $(python -c "import leap_llm; import os; print(os.path.dirname(leap_ll
 | 参数                    | 值                   | 说明                                |
 | --------------------- | ------------------- | --------------------------------- |
 | `--model_name`        | `gemma4-e2b-vision` | 已在 model_factory.py 注册            |
-| `--march`             | `nash-m`            | S100P 对应 march                    |
+| `TARGET_SOC`          | `s100` / `s100p` / `s600` | 选择 march 与默认核数 |
 | `--input_model_path`  | HuggingFace 权重目录    | 含 config.json + model.safetensors |
-| `--output_model_path` | 输出目录                | 编译产出会写到这里                         |
-| `--calib_image_path`  | COCO 图目录            | 50 张真实图像                          |
+| `OUTPUT_DIR`          | 按平台区分的输出目录       | 避免不同 SoC 产物互相覆盖 |
+| `CALIB_IMAGE_DIR`     | COCO 图目录            | 固定 50 张有 manifest 的真实图像 |
 | `--device`            | `cuda:0`            | GPU 加速校准 forward（CPU 也可，更慢）       |
-| `--vit_core_num`      | `1`                 | 本文编译使用 1 核                        |
+| `VIT_CORE_NUM`        | 平台矩阵默认值           | 可显式覆盖 |
 
 
 **不要加 `--verifier`**：编译后 verifier 会报 `gemma4-e2b-vision does not support LLM`（它试图用 LLM 验证逻辑验证 VLM），HBM 本身是有效的，单独跑 verifier_cli.py 即可。
@@ -441,7 +445,7 @@ Function 'convert_mlir' done in 19.3s
 Function 'compile_hbo' done in 6620.3s     ← 约 110 分钟
 [Gemma4Vision] Linking HBM...
 Function 'link_models' done in 10.5s
-[Gemma4Vision] Done: ./output/gemma4_e2b_vision/gemma4-e2b_vit_ptq.hbm
+[Gemma4Vision] Done: ./output/gemma4_e2b_vision_s600/gemma4-e2b_vit_ptq.hbm
 ```
 
 `compile_hbo` 是纯 CPU 单核运算（ViT 模型特性），`HBDK_JOBS` 参数对它基本无影响。
@@ -449,7 +453,7 @@ Function 'link_models' done in 10.5s
 ### 5.3 编译产出
 
 ```
-output/gemma4_e2b_vision/
+output/gemma4_e2b_vision_s600/
 ├── gemma4-e2b_vit_ptq.bc              # 620 MB  导出的 BC 计算图
 ├── gemma4-e2b_vit_ptq.convert.bc      # 202 MB  MLIR 转换后
 ├── gemma4-e2b_vit_ptq.hbo             # 363 MB  HBO 二进制
@@ -490,7 +494,7 @@ PYTHONUNBUFFERED=1 python -u ... | tee output/vision_compile.log
 
 ```python
 from hbdk4.compiler import load
-bc = load("output/gemma4_e2b_vision/gemma4-e2b_vit_ptq.bc")
+bc = load("output/gemma4_e2b_vision_s600/gemma4-e2b_vit_ptq.bc")
 for inp in bc.functions[0].inputs:
     print(inp.name, list(inp.type.shape), inp.type.np_dtype)
 for out in bc.functions[0].outputs:
@@ -507,19 +511,9 @@ Text 分 prefill 和 decode 两个阶段，OELLM 会自动编译两阶段并 lin
 
 ```bash
 conda activate oellm
-ulimit -s unlimited
 
-python -u $(python -c "import leap_llm; import os; print(os.path.dirname(leap_llm.__file__))")/apis/oellm_build.py \
-    --model_name gemma4-e2b-text \
-    --march nash-m \
-    --input_model_path ./gemma4-e2b \
-    --output_model_path ./output/gemma4_e2b_text \
-    --calib_text_path ./calibration_data/text \
-    --chunk_size 256 \
-    --cache_len 4096 \
-    --device cpu \
-    --core_num 1 \
-    2>&1 | tee output/text_compile.log
+# 沿用已有文本校准语料，不自行生成替代 prompt。
+TARGET_SOC=s600 bash conversion/scripts/compile/run_text_compile.sh
 ```
 
 参数说明：
@@ -531,7 +525,8 @@ python -u $(python -c "import leap_llm; import os; print(os.path.dirname(leap_ll
 | `--chunk_size` | `256`             | prefill 每次处理 256 tokens  |
 | `cache_len`    | `4096`            | KV cache 最大长度            |
 | `--device`     | `cpu`             | Text 校准无 GPU 加速优势，CPU 即可 |
-| `--core_num`   | `1`               | 本文编译使用 1 核               |
+| `PREFILL_CORE_NUM` | 平台矩阵默认值 | S600 为 2，S100/S100P 为 1 |
+| `DECODE_CORE_NUM` | 平台矩阵默认值 | S600 为 2，S100/S100P 为 1 |
 
 
 编译会自动导出 `tok_embeddings.bin`：
@@ -539,13 +534,13 @@ python -u $(python -c "import leap_llm; import os; print(os.path.dirname(leap_ll
 ```python
 # 在 Gemma4TextApi.__init__ 中自动执行
 tok_embs = model.embed_tokens.weight.data * model.embed_tokens.embed_scale
-tok_embs.detach().cpu().numpy().tofile("output/gemma4_e2b_text/tok_embeddings.bin")
+tok_embs.detach().cpu().numpy().tofile("output/gemma4_e2b_text_s600/tok_embeddings.bin")
 ```
 
 ### 6.2 编译产出
 
 ```
-output/gemma4_e2b_text/
+output/gemma4_e2b_text_s600/
 ├── gemma4-e2b_lm_chunk_256_cache_4096_ptq.prefill.bc          # 18.5 GB
 ├── gemma4-e2b_lm_chunk_256_cache_4096_ptq.prefill_convert.bc  # 4.7 GB
 ├── gemma4-e2b_lm_chunk_256_cache_4096_ptq.prefill.hbo          # 4.8 GB
@@ -592,25 +587,19 @@ Text HBM 的几个关键参数是**编译时固定**的，决定了板端推理�
 | Prefill 分块大小 | 环境变量 `CHUNK_SIZE` | 256  | 每次 prefill 处理的 token 数。越大步数越少、峰值显存越高。 |
 
 
-这两个参数对应板端的 `gemma4_config.h` 里的 `kCacheLen` / `kChunkSize`，改了 HBM 编译参数后必须同步改源码配置，否则推理会错位。
+这两个参数对应板端 `runtime/cpp/inc/gemma4_config.hpp` 里的
+`kCacheLen` / `kChunkSize`，改了 HBM 编译参数后必须同步改源码配置，否则
+推理会错位。
 
-**示例：把上下文从 4096 扩到 8192**
+**当前交付：用满现有 4096-token KV 预算**
 
-```bash
-# 1. 重新编译 Text HBM（PC 上，耗时数小时）
-CHUNK_SIZE=512 CACHE_LEN=8192 bash conversion/scripts/compile/run_text_compile.sh
-```
-
-```cpp
-// 2. 更新板端 runtime 配置（runtime/cpp/gemma4_config.h）
-constexpr int kChunkSize = 512;   // 必须和上面的 CHUNK_SIZE 一致
-constexpr int kCacheLen  = 8192;  // 必须和上面的 CACHE_LEN 一致
-```
+当前提供的 Text HBM 固定为 `CHUNK_SIZE=256`、`CACHE_LEN=4096`，本次交付
+不包含 8K/16K HBM。交互入口使用默认参数 `--max_tokens=0` 时，每轮都会把
+编码后的 prompt 之外全部剩余 KV 容量用于输出；后续轮次空间不足时，`main`
+会按完整 user/assistant 对裁剪最旧历史，并继续在同一个 4096-token 上限内聊天。
 
 ```bash
-# 3. 重新编译 runtime
-cd runtime/cpp && mkdir build && cd build
-cmake .. && make -j$(nproc)
+./main --max_tokens=0
 ```
 
 **仅 runtime 可调的参数**（无需重编 HBM）：
@@ -619,7 +608,7 @@ cmake .. && make -j$(nproc)
 | 参数         | 在哪改                   | 默认值         | 说明                                   |
 | ---------- | --------------------- | ----------- | ------------------------------------ |
 | 滑动窗口       | `kSlidingWindow`      | 512         | decode 时滑动注意力的窗口大小，必须 ≤ `kCacheLen`。 |
-| 最大输出 token | `--max-tokens N` 启动参数 | `kCacheLen` | 限制每轮生成长度，运行时传入即可。                    |
+| 最大输出 token | `--max_tokens N` 启动参数 | `0` | `0` 表示使用 prompt 之后全部剩余 KV 容量。 |
 
 
 > **内存代价**：`CACHE_LEN` 翻倍，KV cache 占用的 DDR 也会翻倍。请先确认板端空闲内存足够再加大。
@@ -647,26 +636,29 @@ cmake .. && make -j$(nproc)
 **Vision BC**
 
 ```bash
-cd ~/gemma && conda activate oellm
+cd samples/llm/gemma4-e2b/conversion
+conda activate oellm
+export TARGET_SOC=s600  # 需要时替换为 s100 或 s100p
 
-python -u leap_llm/apis/verifier_cli.py \
+python -m leap_llm.apis.verifier_cli \
     --model_name gemma4-e2b-vision \
     --model_dir ./gemma4-e2b \
-    --quant_vlm_model_path ./output/gemma4_e2b_vision/gemma4-e2b_vit_ptq.bc \
+    --quant_vlm_model_path ./output/gemma4_e2b_vision_${TARGET_SOC}/gemma4-e2b_vit_ptq.bc \
     --input_image_path ./calibration_data/images/coco_00_000000000802.jpg
 ```
 
 **Text BC**（纯文本，不含 Vision）
 
 ```bash
-python -u quick_text_verify.py
-# 结果：output/e2b_text_verify_quick.json
+python -u scripts/verify/quick_text_verify.py --target-soc "$TARGET_SOC"
+# 结果：output/e2b_text_verify_quick_${TARGET_SOC}.json
 ```
 
 若开发机与板端同网段，还可在板端 BPU 上跑 HBM 对比：
 
 ```bash
-bash run_remote_hbm_verify.sh   # 需 --remote_ip 指定板子 IP
+BOARD_IP=<板端IP> TARGET_SOC="$TARGET_SOC" \
+  bash scripts/verify/run_remote_hbm_verify.sh
 ```
 
 ---
@@ -679,13 +671,13 @@ bash run_remote_hbm_verify.sh   # 需 --remote_ip 指定板子 IP
 mkdir -p gemma4_e2b_deploy/{model,tokenizer}
 
 # 模型文件（3 个大文件）
-cp output/gemma4_e2b_vision/gemma4-e2b_vit_ptq.hbm \
+cp output/gemma4_e2b_vision_s600/gemma4-e2b_vit_ptq.hbm \
    gemma4_e2b_deploy/model/
 
-cp output/gemma4_e2b_text/gemma4-e2b_lm_chunk_256_cache_4096_ptq.hbm \
+cp output/gemma4_e2b_text_s600/gemma4-e2b_lm_chunk_256_cache_4096_ptq.hbm \
    gemma4_e2b_deploy/model/
 
-cp output/gemma4_e2b_text/tok_embeddings.bin \
+cp output/gemma4_e2b_text_s600/tok_embeddings.bin \
    gemma4_e2b_deploy/model/
 
 # Tokenizer 文件
@@ -731,7 +723,8 @@ gemma4_e2b_deploy/
 
 ## 9. 板端部署与 VLM 推理
 
-本节介绍如何将编译好的 HBM 模型部署到 S100P 板端，并运行 Gemma4-E2B VLM 推理。
+本节介绍如何把与目标 SoC 匹配的 HBM 部署到板端，并使用同一套 C++ runtime
+运行 Gemma4-E2B VLM 推理。
 
 ### 9.1 两条路径：直接跑 vs 自己编译
 
@@ -749,25 +742,28 @@ gemma4_e2b_deploy/
 
 #### Step 1：下载预编译模型
 
-在 S100P 板端执行：
+S100P 可直接下载已验证的公共 `nash-m` HBM；S600 会从 S600 模型目录
+自动下载已验证的公共 `nash-p` HBM。S100 需要先把匹配的 HBM 放入
+`$GEMMA4_HOME/model`，或设置 `GEMMA4_MODEL_BASE_URL`；脚本不会用其他
+目标平台的 HBM 替代当前平台模型。
 
 ```bash
 export GEMMA4_HOME=~/gemma4_e2b
+export GEMMA4_SOC=s600  # 板端可从 /sys/class/boardinfo/soc_name 自动识别
 bash model/download_model.sh
 ```
 
-该脚本从地瓜机器人模型服务器下载 3 个运行模型文件和 2 个必需的 tokenizer 文件。
+缺少共享的 token embedding 或 tokenizer 文件时，脚本会从公开归档补齐。
 
 下载完成后检查文件完整性：
 
 ```bash
 # 验证 SHA256（可选）
 sha256sum ~/gemma4_e2b/model/*.hbm
-
-# 预期输出：
-# 470791849d21cffadb388cc61c8f4b1452078c1722d302fd8a8ac775ee9769f1  ...vit_ptq.hbm
-# 3e4d4940051e4e8dc0cb434e972e7aae75d49504da3fac435e303f68af73a25f  ...lm_..._ptq.hbm
 ```
+
+不同 SoC 的 HBM 哈希不同，应使用对应模型包提供的校验值，不能拿 S100 哈希
+校验 S600 文件。
 
 #### Step 2：编译 C++ runtime
 

--- a/samples/llm/gemma4-e2b/conversion/README.md
+++ b/samples/llm/gemma4-e2b/conversion/README.md
@@ -13,6 +13,22 @@ PTQ quantization and HBM compilation run on a **development PC**, not on the boa
 | SDK | OE-LLM 1.0.0 | D-Robotics official channel |
 | GPU | Optional | CUDA for Vision calibration |
 
+## Target SoCs
+
+The same conversion entry points support all three RDK S targets. `TARGET_SOC`
+defaults to `s100p` for backward compatibility.
+
+| `TARGET_SOC` | HBDK march | Vision cores | Text prefill / decode cores |
+| --- | --- | ---: | ---: |
+| `s100` | `nash-e` | 1 | 1 / 1 |
+| `s100p` | `nash-m` | 1 | 1 / 1 |
+| `s600` | `nash-p` | 4 | 2 / 2 |
+
+S600-specific dynamic quantization, `opt=1`, HPC and decode no-padding options
+are enabled only for `nash-p`; S100/S100P retain the original single-core
+behavior. The tested S600 board has 23 GiB usable RAM (24 GB nominal), not
+64 GB.
+
 ## Contents
 
 ```bash
@@ -29,17 +45,27 @@ conversion/
 ## Quick Reference
 
 ```bash
-# Vision compile (GPU recommended)
-bash conversion/scripts/compile/run_vision_compile.sh
+# Prepare exactly 50 deterministic real COCO val2017 images.
+python3 conversion/scripts/calibration/download_coco_images.py
 
-# Text compile (CPU, ~100 GB RAM peak)
-bash conversion/scripts/compile/run_text_compile.sh
-
-# Adjust context at compile time
-CHUNK_SIZE=512 CACHE_LEN=8192 bash conversion/scripts/compile/run_text_compile.sh
+# Select one target; use s100 or s100p for the other boards.
+TARGET_SOC=s600 bash conversion/scripts/compile/run_vision_compile.sh
+TARGET_SOC=s600 bash conversion/scripts/compile/run_text_compile.sh
 ```
 
-Then sync `kChunkSize` / `kCacheLen` in `runtime/cpp/gemma4_config.h` and rebuild the board runtime.
+The Vision script refuses synthetic or untracked images: the calibration
+directory must match `images_coco_manifest.json`. Text compilation uses the
+existing text calibration corpus and does not generate replacement prompts.
+
+The released Text HBM is compiled with `CHUNK_SIZE=256` and
+`CACHE_LEN=4096`. This deliverable does not include an 8K/16K HBM. The
+interactive `main` binary uses all KV capacity left after the prompt when
+`--max_tokens=0` (the default), so no HBM rebuild is needed to maximize the
+current 4096-token budget.
+
+If a different HBM is compiled later, keep `kChunkSize` / `kCacheLen` in
+`runtime/cpp/inc/gemma4_config.hpp` exactly synchronized with its compile-time
+settings before rebuilding the board runtime.
 
 ## Full Tutorial
 

--- a/samples/llm/gemma4-e2b/conversion/README_cn.md
+++ b/samples/llm/gemma4-e2b/conversion/README_cn.md
@@ -13,6 +13,21 @@ PTQ 量化与 HBM 编译在**开发 PC**上完成，不在板端执行。
 | SDK | OE-LLM 1.0.0 | 地瓜官方渠道 |
 | GPU | 可选 | CUDA 加速 Vision 校准 |
 
+## 目标 SoC
+
+同一套转换入口支持三种 RDK S 平台。为了兼容原 S100P 样例，`TARGET_SOC`
+默认值为 `s100p`。
+
+| `TARGET_SOC` | HBDK march | Vision 核数 | Text prefill / decode 核数 |
+| --- | --- | ---: | ---: |
+| `s100` | `nash-e` | 1 | 1 / 1 |
+| `s100p` | `nash-m` | 1 | 1 / 1 |
+| `s600` | `nash-p` | 4 | 2 / 2 |
+
+动态量化、`opt=1`、HPC 和 decode no-padding 只在 `nash-p` 启用，S100/S100P
+继续保持原来的单核行为。实测 S600 板端可用内存为 23 GiB（标称 24 GB），
+不是 64 GB。
+
 ## 目录内容
 
 ```bash
@@ -29,17 +44,25 @@ conversion/
 ## 常用命令
 
 ```bash
-# Vision 编译（建议 GPU）
-bash conversion/scripts/compile/run_vision_compile.sh
+# 准备固定的 50 张真实 COCO val2017 图像
+python3 conversion/scripts/calibration/download_coco_images.py
 
-# Text 编译（CPU，内存峰值 ~100 GB）
-bash conversion/scripts/compile/run_text_compile.sh
-
-# 调整上下文长度
-CHUNK_SIZE=512 CACHE_LEN=8192 bash conversion/scripts/compile/run_text_compile.sh
+# 选择目标平台；S100/S100P 分别改为 s100/s100p
+TARGET_SOC=s600 bash conversion/scripts/compile/run_vision_compile.sh
+TARGET_SOC=s600 bash conversion/scripts/compile/run_text_compile.sh
 ```
 
-编译后需同步修改 `runtime/cpp/gemma4_config.h` 中的 `kChunkSize` / `kCacheLen`，并重新编译板端 runtime。
+Vision 脚本会校验 `images_coco_manifest.json`，拒绝合成图或未登记图片；Text
+编译沿用已有文本校准语料，不会自行生成替代 prompt。
+
+当前发布的 Text HBM 使用 `CHUNK_SIZE=256`、`CACHE_LEN=4096` 编译，本次
+交付不包含 8K/16K HBM。交互入口 `main` 的 `--max_tokens=0`（默认值）会
+自动使用 prompt 之后剩余的全部 KV 容量，因此无需重新编译 HBM，即可用满
+现有 4096-token 预算。
+
+后续若重新编译不同规格的 HBM，必须同步修改
+`runtime/cpp/inc/gemma4_config.hpp` 中的 `kChunkSize` / `kCacheLen`，再
+重新编译板端 runtime。
 
 ## 完整教程
 

--- a/samples/llm/gemma4-e2b/conversion/leap_llm_gemma4/apis/model/gemma4.py
+++ b/samples/llm/gemma4-e2b/conversion/leap_llm_gemma4/apis/model/gemma4.py
@@ -14,6 +14,11 @@ from leap_llm.apis.calibration.data_loader import load_text_data
 from leap_llm.models.gemma4.model import Gemma4Text, Gemma4Vision, Gemma4VisionConfig
 
 
+def _first_device(device):
+    """Return the first device when OE-LLM supplies a parsed device list."""
+    return device[0] if isinstance(device, (list, tuple)) else device
+
+
 def _patchify_image(image_tensor, patch_size=16):
     """Convert image tensor [1, 3, H, W] -> [1, num_patches, 3*patch_size^2].
 
@@ -84,7 +89,7 @@ class Gemma4VisionApi:
         self.input_model_path = input_model_path
         self.output_model_path = output_model_path
         self.calib_image_path = calib_image_path
-        self.device = device
+        self.device = _first_device(device)
         self.model_type = model_type
         self.core_num = core_num
 
@@ -108,9 +113,11 @@ class Gemma4VisionApi:
         )
         print(f"[Gemma4VisionApi] Loaded {len(self.calib_images)} calibration images")
 
-    def compile(self, **kwargs):
+    def compile(self, vit_kwargs=None, llm_kwargs=None, **kwargs):
         device = self.device if torch.cuda.is_available() else "cpu"
         dtype = torch.float32
+        compile_kwargs = dict(kwargs)
+        compile_kwargs.update(vit_kwargs or {})
 
         vit = self.vit_model
 
@@ -129,7 +136,7 @@ class Gemma4VisionApi:
             dtype=leap.float16,
             output_model_path=self.vit_file_name,
             vit_core_num=self.core_num,
-            **kwargs,
+            **compile_kwargs,
         )
 
     def get_hbm_path(self):
@@ -151,7 +158,7 @@ class Gemma4TextCalibrationDataPreparer:
         self.chunk_size = chunk_size
         self.cache_len = cache_len
         self.sliding_window = sliding_window
-        self.device = device
+        self.device = _first_device(device)
         self.mask_value = mask_value
         self.pad_token_id = self.tokenizer.pad_token_id
         if self.pad_token_id is None:
@@ -267,7 +274,7 @@ class Gemma4TextApi:
         self.calib_text_data = list(load_text_data(calib_text_path))
         self.chunk_size = chunk_size
         self.cache_len = cache_len
-        self.device = device
+        self.device = _first_device(device)
         self.model_type = model_type
         self.prefill_core_num = prefill_core_num
         self.decode_core_num = decode_core_num
@@ -299,9 +306,11 @@ class Gemma4TextApi:
             os.path.join(output_model_path, "tok_embeddings.bin")
         )
 
-    def compile(self, **kwargs):
+    def compile(self, vit_kwargs=None, llm_kwargs=None, **kwargs):
         device = self.device if torch.cuda.is_available() else "cpu"
         dtype = torch.float32
+        compile_kwargs = dict(kwargs)
+        compile_kwargs.update(llm_kwargs or {})
 
         text = self.text_model
         text.set_model_device(device, dtype=dtype)
@@ -345,7 +354,7 @@ class Gemma4TextApi:
             output_model_path=self.lm_file_name,
             prefill_core_num=self.prefill_core_num,
             decode_core_num=self.decode_core_num,
-            **kwargs,
+            **compile_kwargs,
         )
 
     def get_hbm_path(self):

--- a/samples/llm/gemma4-e2b/conversion/leap_llm_gemma4/install.sh
+++ b/samples/llm/gemma4-e2b/conversion/leap_llm_gemma4/install.sh
@@ -9,8 +9,22 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+PY_BIN=""
+for candidate in python python3; do
+  if "$candidate" -c "import leap_llm" >/dev/null 2>&1; then
+    PY_BIN="$candidate"
+    break
+  fi
+done
+if [[ -z "$PY_BIN" ]]; then
+  echo "ERROR: leap_llm is not importable by python or python3."
+  echo "Activate the OE-LLM environment before running this installer."
+  exit 1
+fi
+echo "[install] using interpreter: $PY_BIN"
+
 # Locate leap_llm package
-LEAP_LLM_PATH=$(python -c "import leap_llm, os; print(os.path.dirname(leap_llm.__file__))")
+LEAP_LLM_PATH=$("$PY_BIN" -c "import leap_llm, os; print(os.path.dirname(leap_llm.__file__))")
 if [ -z "$LEAP_LLM_PATH" ]; then
     echo "ERROR: leap_llm not found. Activate the oellm conda env first."
     exit 1
@@ -41,7 +55,7 @@ fi
 
 # 4. Verify
 echo "[install] Verifying ..."
-python -c "
+"$PY_BIN" -c "
 from leap_llm.apis.model.model_factory import get_marches_with_model
 for m in ['gemma4-e2b-vision', 'gemma4-e2b-text', 'gemma4-e4b-vision', 'gemma4-e4b-text']:
     print(f'  {m}: {get_marches_with_model(m)}')

--- a/samples/llm/gemma4-e2b/conversion/leap_llm_gemma4/models/gemma4/model.py
+++ b/samples/llm/gemma4-e2b/conversion/leap_llm_gemma4/models/gemma4/model.py
@@ -579,9 +579,19 @@ class Gemma4Vision:
         model = self.model
         assert model.is_compiled, "Model must be in compile mode before compiling."
 
+        if isinstance(vit_core_num, (list, tuple)):
+            vit_core_num = vit_core_num[0]
+
+        is_nash_p = kwargs.get("march") == "nash-p"
+        dynamic_quant = kwargs.pop("dynamic_quant", None)
         kwargs["core_num"] = vit_core_num
         if vit_core_num > 1:
-            kwargs["max_l2m_size"] = 25165824
+            kwargs.setdefault(
+                "max_l2m_size",
+                int(os.environ.get("GEMMA4_MAX_L2M_SIZE", "25165824")),
+            )
+        if is_nash_p:
+            kwargs.setdefault("opt", 1)
 
         inputs = self.get_leap_inputs(dtype)
 
@@ -593,10 +603,13 @@ class Gemma4Vision:
         # Step 2: Convert MLIR
         convert_bc_path = str(Path(output_model_path).with_suffix(".convert.bc"))
         print("[Gemma4Vision] Converting MLIR...")
+        convert_kwargs = {"march": kwargs["march"]}
+        if dynamic_quant is not None:
+            convert_kwargs["dynamic_quant"] = dynamic_quant
+        elif is_nash_p:
+            convert_kwargs["dynamic_quant"] = True
         mlir_module = model.convert_mlir(
-            bc_module,
-            save_path=convert_bc_path,
-            march=kwargs["march"],
+            bc_module, save_path=convert_bc_path, **convert_kwargs
         )
         statistics(mlir_module)
 
@@ -1280,6 +1293,19 @@ class Gemma4Text:
     ):
         assert self.model.is_compiled, "Model must be compiled before compiling."
 
+        if isinstance(prefill_core_num, (list, tuple)):
+            prefill_core_num = prefill_core_num[0]
+        if isinstance(decode_core_num, (list, tuple)):
+            decode_core_num = decode_core_num[0]
+
+        is_nash_p = kwargs.get("march") == "nash-p"
+        dynamic_quant = kwargs.pop("dynamic_quant", None)
+        stop_after = os.environ.get("GEMMA4_STOP_AFTER", "link").lower()
+        if stop_after not in {"export", "convert", "compile", "link"}:
+            raise ValueError(
+                "GEMMA4_STOP_AFTER must be export, convert, compile, or link"
+            )
+
         model_list = []
         stages = []
         if stage in {"prefill", "all"}:
@@ -1298,17 +1324,27 @@ class Gemma4Text:
             bc_module = self.model.export_module(inputs, stage_name, bc_path)
             model_list.append(bc_module)
 
+        if stop_after == "export":
+            print("[Gemma4Text] Stopped after BC export (GEMMA4_STOP_AFTER=export).")
+            return model_list
+
+        converted_models = []
         hbos = []
         for bc_module in model_list:
             func_name = bc_module.functions[0].name
             convert_bc_path = str(
                 Path(output_model_path).with_suffix(f".{func_name}_convert.bc")
             )
+            convert_kwargs = {
+                "enable_vpu": enable_vpu,
+                "march": kwargs["march"],
+            }
+            if dynamic_quant is not None:
+                convert_kwargs["dynamic_quant"] = dynamic_quant
+            elif is_nash_p:
+                convert_kwargs["dynamic_quant"] = True
             mlir_module = self.model.convert_mlir(
-                bc_module,
-                convert_bc_path,
-                enable_vpu=enable_vpu,
-                march=kwargs["march"],
+                bc_module, convert_bc_path, **convert_kwargs
             )
 
             func = mlir_module.functions[0]
@@ -1317,15 +1353,36 @@ class Gemma4Text:
                 Path(output_model_path).with_suffix(f".{func_name}_convert_removed.bc")
             )
             save(mlir_module, convert_removed_bc_path)
+            converted_models.append(mlir_module)
+
+            if stop_after == "convert":
+                continue
 
             hbo_path = str(Path(output_model_path).with_suffix(f".{func_name}.hbo"))
             compile_kwargs = kwargs.copy()
             compile_kwargs["core_num"] = (
                 prefill_core_num if "prefill" in func_name else decode_core_num
             )
+            is_decode = "decode" in func_name
+            if is_nash_p:
+                compile_kwargs.setdefault("enable_hpc", True)
+                compile_kwargs.setdefault("input_no_padding", is_decode)
+                compile_kwargs.setdefault("output_no_padding", is_decode)
             if compile_kwargs["core_num"] > 1:
-                compile_kwargs["max_l2m_size"] = 25165824
+                compile_kwargs.setdefault(
+                    "max_l2m_size",
+                    int(os.environ.get("GEMMA4_MAX_L2M_SIZE", "25165824")),
+                )
+            if is_nash_p:
+                compile_kwargs.setdefault("opt", 1)
             hbo_model = self.model.compile_hbo(mlir_module, hbo_path, **compile_kwargs)
             hbos.append(hbo_model)
+
+        if stop_after == "convert":
+            print("[Gemma4Text] Stopped after MLIR conversion.")
+            return converted_models
+        if stop_after == "compile":
+            print("[Gemma4Text] Stopped after HBO compilation.")
+            return hbos
 
         return self.model.link_models(hbos, output_model_path)

--- a/samples/llm/gemma4-e2b/conversion/scripts/calibration/download_coco_images.py
+++ b/samples/llm/gemma4-e2b/conversion/scripts/calibration/download_coco_images.py
@@ -1,16 +1,12 @@
 #!/usr/bin/env python3
-"""Download 50 diverse real COCO val2017 images for Gemma4 Vision calibration.
+"""Prepare and verify 50 deterministic real COCO val2017 calibration images."""
 
-Usage:
-    python download_coco_images.py [--output-dir ../../calibration_data/images]
-"""
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
-import os
 import random
-import shutil
 import sys
 import zipfile
 from collections import defaultdict
@@ -20,129 +16,327 @@ from urllib.request import urlretrieve
 DEFAULT_OUT = Path(__file__).resolve().parent.parent.parent / "calibration_data" / "images"
 ANN_ZIP = Path("/tmp/coco_annotations_trainval2017.zip")
 ANN_JSON = Path("/tmp/instances_val2017.json")
-COCO_IMG_BASE = "http://images.cocodataset.org/val2017"
+COCO_IMG_BASE = "https://images.cocodataset.org/val2017"
 TARGET_COUNT = 50
 SEED = 42
+IMAGE_SUFFIXES = {".jpg", ".jpeg", ".png", ".webp"}
+
+
+def sha256_file(path: Path) -> str:
+    """Return a file's SHA256 digest."""
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def is_sha256(value: object) -> bool:
+    """Return whether value is a lowercase or uppercase SHA256 digest."""
+    return (
+        isinstance(value, str)
+        and len(value) == 64
+        and all(character in "0123456789abcdefABCDEF" for character in value)
+    )
+
+
+def looks_like_jpeg(path: Path) -> bool:
+    """Check the JPEG signature used by all COCO val2017 image files."""
+    try:
+        with path.open("rb") as stream:
+            return stream.read(2) == b"\xff\xd8"
+    except OSError:
+        return False
+
+
+def load_manifest(manifest_path: Path) -> dict:
+    """Load a JSON manifest, returning an empty mapping when unavailable."""
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return manifest if isinstance(manifest, dict) else {}
+
+
+def valid_manifest_header(manifest: dict) -> bool:
+    """Check the immutable identity of the deterministic calibration set."""
+    entries = manifest.get("images")
+    return (
+        manifest.get("dataset") == "COCO"
+        and manifest.get("split") == "val2017"
+        and manifest.get("seed") == SEED
+        and manifest.get("target") == TARGET_COUNT
+        and manifest.get("count") == TARGET_COUNT
+        and isinstance(entries, list)
+        and len(entries) == TARGET_COUNT
+    )
+
+
+def verified_cached_entry(
+    output_path: Path, previous_entry: object, expected_entry: dict
+) -> bool:
+    """Reuse a cached image only when its prior provenance and hash still match."""
+    if not isinstance(previous_entry, dict):
+        return False
+    if any(previous_entry.get(key) != value for key, value in expected_entry.items()):
+        return False
+    expected_hash = previous_entry.get("sha256")
+    return (
+        output_path.is_file()
+        and output_path.stat().st_size > 1000
+        and looks_like_jpeg(output_path)
+        and is_sha256(expected_hash)
+        and sha256_file(output_path) == expected_hash
+    )
 
 
 def download_annotations() -> None:
     """Download and extract the COCO validation annotation file."""
-    """Download and extract the COCO validation annotation file."""
     if ANN_JSON.exists() and ANN_JSON.stat().st_size > 1_000_000:
         print(f"Using cached {ANN_JSON}")
         return
-    url = "http://images.cocodataset.org/annotations/annotations_trainval2017.zip"
+    url = "https://images.cocodataset.org/annotations/annotations_trainval2017.zip"
     if not ANN_ZIP.exists():
-        print(f"Downloading COCO annotations (~241MB): {url}")
+        print(f"Downloading COCO annotations (~241 MB): {url}")
         urlretrieve(url, ANN_ZIP)
     print("Extracting instances_val2017.json ...")
-    with zipfile.ZipFile(ANN_ZIP) as zf:
-        with zf.open("annotations/instances_val2017.json") as src:
-            ANN_JSON.write_bytes(src.read())
+    with zipfile.ZipFile(ANN_ZIP) as archive:
+        with archive.open("annotations/instances_val2017.json") as source:
+            ANN_JSON.write_bytes(source.read())
     print(f"Saved {ANN_JSON} ({ANN_JSON.stat().st_size / 1e6:.1f} MB)")
 
 
-def pick_diverse_images(n: int) -> list[dict]:
+def pick_diverse_images(count: int) -> list[dict]:
     """Select a deterministic category-diverse subset of COCO images."""
-    """Select a deterministic category-diverse subset of COCO images."""
-    with open(ANN_JSON, encoding="utf-8") as f:
-        coco = json.load(f)
+    with ANN_JSON.open(encoding="utf-8") as stream:
+        coco = json.load(stream)
 
-    id_to_cats: dict[int, set[int]] = defaultdict(set)
-    for ann in coco["annotations"]:
-        id_to_cats[ann["image_id"]].add(ann["category_id"])
+    image_categories: dict[int, set[int]] = defaultdict(set)
+    for annotation in coco["annotations"]:
+        image_categories[annotation["image_id"]].add(annotation["category_id"])
 
-    cat_names = {c["id"]: c["name"] for c in coco["categories"]}
-    images = {img["id"]: img for img in coco["images"]}
-
-    by_cat: dict[int, list[dict]] = defaultdict(list)
-    for img_id, img in images.items():
-        cats = id_to_cats.get(img_id)
-        if not cats:
-            continue
-        primary = sorted(cats)[0]
-        by_cat[primary].append(img)
+    category_names = {category["id"]: category["name"] for category in coco["categories"]}
+    images = {image["id"]: image for image in coco["images"]}
+    images_by_category: dict[int, list[dict]] = defaultdict(list)
+    for image_id, image in images.items():
+        categories = image_categories.get(image_id)
+        if categories:
+            images_by_category[sorted(categories)[0]].append(image)
 
     rng = random.Random(SEED)
     selected: list[dict] = []
     used_ids: set[int] = set()
+    category_ids = sorted(
+        images_by_category,
+        key=lambda category_id: category_names.get(category_id, str(category_id)),
+    )
+    rng.shuffle(category_ids)
 
-    cat_ids = sorted(by_cat.keys(), key=lambda c: cat_names.get(c, str(c)))
-    rng.shuffle(cat_ids)
-    while len(selected) < n and cat_ids:
+    while len(selected) < count and category_ids:
         progressed = False
-        for cid in cat_ids:
-            pool = [x for x in by_cat[cid] if x["id"] not in used_ids]
+        for category_id in category_ids:
+            pool = [
+                image
+                for image in images_by_category[category_id]
+                if image["id"] not in used_ids
+            ]
             if not pool:
                 continue
-            img = rng.choice(pool)
-            selected.append(img)
-            used_ids.add(img["id"])
+            image = rng.choice(pool)
+            selected.append(image)
+            used_ids.add(image["id"])
             progressed = True
-            if len(selected) >= n:
+            if len(selected) >= count:
                 break
         if not progressed:
             break
 
-    if len(selected) < n:
-        rest = [img for img in images.values() if img["id"] in id_to_cats and img["id"] not in used_ids]
-        rng.shuffle(rest)
-        for img in rest:
-            selected.append(img)
-            used_ids.add(img["id"])
-            if len(selected) >= n:
-                break
+    if len(selected) < count:
+        remaining = [
+            image
+            for image in images.values()
+            if image["id"] in image_categories and image["id"] not in used_ids
+        ]
+        rng.shuffle(remaining)
+        selected.extend(remaining[: count - len(selected)])
 
-    n_cat_sets = len({frozenset(id_to_cats[i["id"]]) for i in selected})
-    print(f"Selected {len(selected)} images across {n_cat_sets} category sets")
-    return selected[:n]
+    category_sets = {
+        frozenset(image_categories[image["id"]]) for image in selected[:count]
+    }
+    print(f"Selected {min(len(selected), count)} images across {len(category_sets)} category sets")
+    return selected[:count]
 
 
-def download_images(images: list[dict], out_dir: Path) -> None:
-    """Download selected COCO images and write their local manifest."""
-    """Download selected COCO images and write their local manifest."""
-    out_dir.mkdir(parents=True, exist_ok=True)
-    root = out_dir.parent
-    manifest = []
-    ok = 0
-    for i, img in enumerate(images):
-        fname = img["file_name"]
-        url = f"{COCO_IMG_BASE}/{fname}"
-        out_name = f"coco_{i:02d}_{fname}"
-        out_path = out_dir / out_name
-        if out_path.exists() and out_path.stat().st_size > 1000:
-            print(f"  skip exists {out_name}")
-            ok += 1
-            manifest.append({"local": out_name, "coco_file": fname, "url": url, "width": img["width"], "height": img["height"]})
-            continue
-        try:
-            print(f"  [{i+1}/{len(images)}] {url}")
-            urlretrieve(url, out_path)
-            ok += 1
-            manifest.append({"local": out_name, "coco_file": fname, "url": url, "width": img["width"], "height": img["height"]})
-        except Exception as e:
-            print(f"  FAIL {fname}: {e}", file=sys.stderr)
+def download_images(images: list[dict], output_dir: Path) -> None:
+    """Download selected COCO images and write a provenance manifest."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    manifest_path = output_dir.parent / "images_coco_manifest.json"
+    previous_manifest = load_manifest(manifest_path)
+    previous_entries = {}
+    if valid_manifest_header(previous_manifest):
+        previous_entries = {
+            entry.get("local"): entry
+            for entry in previous_manifest["images"]
+            if isinstance(entry, dict) and isinstance(entry.get("local"), str)
+        }
 
-    manifest_path = root / "images_coco_manifest.json"
-    with open(manifest_path, "w", encoding="utf-8") as f:
-        json.dump({"count": ok, "target": len(images), "images": manifest}, f, indent=2, ensure_ascii=False)
-    print(f"Downloaded {ok}/{len(images)} -> {out_dir}")
+    manifest: list[dict] = []
+    for index, image in enumerate(images):
+        coco_name = image["file_name"]
+        url = f"{COCO_IMG_BASE}/{coco_name}"
+        local_name = f"coco_{index:02d}_{coco_name}"
+        output_path = output_dir / local_name
+        expected_entry = {
+            "local": local_name,
+            "coco_file": coco_name,
+            "url": url,
+            "width": image["width"],
+            "height": image["height"],
+        }
+        if verified_cached_entry(
+            output_path, previous_entries.get(local_name), expected_entry
+        ):
+            print(f"  skip verified {local_name}")
+        else:
+            print(f"  [{index + 1}/{len(images)}] {url}")
+            temporary_path = output_path.with_name(output_path.name + ".part")
+            temporary_path.unlink(missing_ok=True)
+            try:
+                urlretrieve(url, temporary_path)
+                if temporary_path.stat().st_size <= 1000 or not looks_like_jpeg(
+                    temporary_path
+                ):
+                    raise RuntimeError(f"Downloaded file is not a valid COCO JPEG: {url}")
+                temporary_path.replace(output_path)
+            finally:
+                temporary_path.unlink(missing_ok=True)
+        manifest.append({**expected_entry, "sha256": sha256_file(output_path)})
+
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "dataset": "COCO",
+                "split": "val2017",
+                "seed": SEED,
+                "count": len(manifest),
+                "target": TARGET_COUNT,
+                "images": manifest,
+            },
+            indent=2,
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
     print(f"Manifest: {manifest_path}")
 
 
+def verify_images(output_dir: Path) -> bool:
+    """Verify that the calibration directory contains only manifest-backed COCO images."""
+    manifest_path = output_dir.parent / "images_coco_manifest.json"
+    if not manifest_path.is_file():
+        print(f"ERROR: missing COCO manifest: {manifest_path}", file=sys.stderr)
+        return False
+    manifest = load_manifest(manifest_path)
+    if not manifest:
+        print(f"ERROR: invalid COCO manifest: {manifest_path}", file=sys.stderr)
+        return False
+    if not valid_manifest_header(manifest):
+        print(
+            "ERROR: manifest must describe the deterministic 50-image "
+            "COCO val2017 set (seed 42)",
+            file=sys.stderr,
+        )
+        return False
+
+    entries = manifest["images"]
+    expected_names: set[str] = set()
+    for index, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            print(f"ERROR: invalid COCO manifest entry: {entry}", file=sys.stderr)
+            return False
+        local_name = entry.get("local", "")
+        coco_name = entry.get("coco_file", "")
+        url = entry.get("url", "")
+        width = entry.get("width")
+        height = entry.get("height")
+        expected_hash = entry.get("sha256")
+        expected_local_name = f"coco_{index:02d}_{coco_name}"
+        if (
+            not isinstance(coco_name, str)
+            or Path(coco_name).name != coco_name
+            or not coco_name.endswith(".jpg")
+            or local_name != expected_local_name
+        ):
+            print(f"ERROR: invalid COCO manifest entry: {entry}", file=sys.stderr)
+            return False
+        if url != f"{COCO_IMG_BASE}/{coco_name}":
+            print(f"ERROR: non-COCO source URL: {url}", file=sys.stderr)
+            return False
+        if (
+            not isinstance(width, int)
+            or isinstance(width, bool)
+            or width <= 0
+            or not isinstance(height, int)
+            or isinstance(height, bool)
+            or height <= 0
+        ):
+            print(f"ERROR: invalid COCO image dimensions: {entry}", file=sys.stderr)
+            return False
+        if not is_sha256(expected_hash):
+            print(f"ERROR: missing or invalid SHA256: {entry}", file=sys.stderr)
+            return False
+        image_path = output_dir / local_name
+        if not image_path.is_file() or image_path.stat().st_size <= 1000:
+            print(f"ERROR: missing or invalid calibration image: {image_path}", file=sys.stderr)
+            return False
+        if not looks_like_jpeg(image_path):
+            print(f"ERROR: calibration image is not JPEG: {image_path}", file=sys.stderr)
+            return False
+        if sha256_file(image_path) != expected_hash:
+            print(f"ERROR: SHA256 mismatch: {image_path}", file=sys.stderr)
+            return False
+        expected_names.add(local_name)
+
+    actual_names = {
+        path.name
+        for path in output_dir.iterdir()
+        if path.is_file() and path.suffix.lower() in IMAGE_SUFFIXES
+    }
+    if actual_names != expected_names:
+        extras = sorted(actual_names - expected_names)
+        missing = sorted(expected_names - actual_names)
+        print("ERROR: calibration image set differs from manifest", file=sys.stderr)
+        if extras:
+            print(f"  unexpected images: {extras}", file=sys.stderr)
+        if missing:
+            print(f"  missing images: {missing}", file=sys.stderr)
+        return False
+
+    print(
+        f"Verified {len(expected_names)} real COCO val2017 calibration images: "
+        f"{output_dir}"
+    )
+    return True
+
+
 def main() -> int:
-    """Parse CLI arguments and prepare the calibration image set."""
-    """Parse CLI arguments and prepare the calibration image set."""
-    parser = argparse.ArgumentParser(description="Download COCO calibration images")
-    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUT, help="Output image directory")
+    """Download or verify the deterministic COCO calibration set."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUT)
+    parser.add_argument(
+        "--verify-only",
+        action="store_true",
+        help="Validate the existing manifest-backed image set without downloading",
+    )
     args = parser.parse_args()
 
+    if args.verify_only:
+        return 0 if verify_images(args.output_dir) else 1
+
     download_annotations()
-    images = pick_diverse_images(TARGET_COUNT)
-    download_images(images, args.output_dir)
-    n = len(list(args.output_dir.glob("coco_*.jpg")))
-    print(f"\nDone. {n} COCO images in {args.output_dir}")
-    return 0 if n >= 30 else 1
+    download_images(pick_diverse_images(TARGET_COUNT), args.output_dir)
+    return 0 if verify_images(args.output_dir) else 1
 
 
 if __name__ == "__main__":

--- a/samples/llm/gemma4-e2b/conversion/scripts/calibration/generate_calib_images.py
+++ b/samples/llm/gemma4-e2b/conversion/scripts/calibration/generate_calib_images.py
@@ -1,69 +1,28 @@
 #!/usr/bin/env python3
-"""Generate synthetic calibration images (gradients, noise, patterns).
+"""Reject synthetic calibration data and point users to the COCO workflow."""
 
-Note: Real COCO images are recommended for best quantization accuracy.
-This script is provided as a fallback when network access is unavailable.
+from __future__ import annotations
 
-Usage:
-    python generate_calib_images.py [--output-dir ../../calibration_data/images]
-"""
 import argparse
-import os
+import sys
 from pathlib import Path
-
-import numpy as np
-from PIL import Image
 
 DEFAULT_OUT = Path(__file__).resolve().parent.parent.parent / "calibration_data" / "images"
 
 
 def main() -> int:
-    """Generate normalized image inputs for Gemma4 vision calibration."""
-    """Generate normalized image inputs for Gemma4 vision calibration."""
-    parser = argparse.ArgumentParser(description="Generate synthetic calibration images")
+    """Exit without creating synthetic images."""
+    parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUT)
     args = parser.parse_args()
-
-    output_dir = args.output_dir
-    output_dir.mkdir(parents=True, exist_ok=True)
-    np.random.seed(42)
-
-    sizes = [(224, 224), (336, 336), (560, 560), (896, 896), (1024, 1024)]
-    count = 0
-
-    for i, (height, width) in enumerate(sizes):
-        gradient = np.zeros((height, width, 3), dtype=np.uint8)
-        for y in range(height):
-            gradient[y, :, 0] = int(255 * y / height)
-            gradient[y, :, 1] = int(255 * (1 - y / height))
-            gradient[y, :, 2] = 128
-        Image.fromarray(gradient, "RGB").save(output_dir / f"gradient_{i}_{height}x{width}.jpg", "JPEG")
-        count += 1
-
-        noise = np.random.randint(0, 255, (height, width, 3), dtype=np.uint8)
-        Image.fromarray(noise, "RGB").save(output_dir / f"noise_{i}_{height}x{width}.jpg", "JPEG")
-        count += 1
-
-        pattern = np.zeros((height, width, 3), dtype=np.uint8)
-        for y in range(height):
-            for x in range(width):
-                if (x // 32 + y // 32) % 2 == 0:
-                    pattern[y, x] = [255, 255, 255]
-        Image.fromarray(pattern, "RGB").save(output_dir / f"pattern_{i}_{height}x{width}.jpg", "JPEG")
-        count += 1
-
-        stripes = np.zeros((height, width, 3), dtype=np.uint8)
-        colors = [(255, 0, 0), (0, 255, 0), (0, 0, 255), (255, 255, 0), (255, 0, 255)]
-        sw = width // len(colors)
-        for j, color in enumerate(colors):
-            start = j * sw
-            end = (j + 1) * sw if j < len(colors) - 1 else width
-            stripes[:, start:end] = color
-        Image.fromarray(stripes, "RGB").save(output_dir / f"stripes_{i}_{height}x{width}.jpg", "JPEG")
-        count += 1
-
-    print(f"Generated {count} synthetic images -> {output_dir}")
-    return 0
+    downloader = Path(__file__).with_name("download_coco_images.py")
+    print(
+        "Synthetic Vision calibration is disabled for this sample. "
+        "Use the deterministic 50-image COCO val2017 set instead:\n"
+        f"  python3 {downloader} --output-dir {args.output_dir}",
+        file=sys.stderr,
+    )
+    return 2
 
 
 if __name__ == "__main__":

--- a/samples/llm/gemma4-e2b/conversion/scripts/compile/compile_text_decode.py
+++ b/samples/llm/gemma4-e2b/conversion/scripts/compile/compile_text_decode.py
@@ -1,17 +1,42 @@
 #!/usr/bin/env python3
-"""从已有 decode convert_removed.bc 续编 HBO，并与 prefill.hbo link 成 HBM。"""
+"""Resume Text decode HBO compilation and link it with the prefill HBO."""
+
+from __future__ import annotations
+
 import os
-import sys
 
 from hbdk4.compiler.apis import compile, link, load
 from hbdk4.compiler.hbm import Hbo
 
+TARGET_DEFAULTS = {
+    "s100": {"march": "nash-e", "decode_cores": 1, "jobs": 29, "opt": 0},
+    "s100p": {"march": "nash-m", "decode_cores": 1, "jobs": 29, "opt": 0},
+    "s600": {"march": "nash-p", "decode_cores": 2, "jobs": 22, "opt": 1},
+}
+
+TARGET_SOC = os.environ.get("TARGET_SOC", "s100p").lower()
+if TARGET_SOC not in TARGET_DEFAULTS:
+    raise ValueError("TARGET_SOC must be s100, s100p, or s600")
+DEFAULTS = TARGET_DEFAULTS[TARGET_SOC]
+
 OUT_DIR = os.environ.get(
     "COMPILE_OUTPUT_DIR",
-    os.path.join(os.path.dirname(__file__), "..", "..", "output", "gemma4_e2b_text"),
+    os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "..",
+        "output",
+        f"gemma4_e2b_text_{TARGET_SOC}",
+    ),
 )
 OUT_DIR = os.path.abspath(OUT_DIR)
-PREFIX = os.path.join(OUT_DIR, "gemma4-e2b_lm_chunk_256_cache_4096_ptq")
+
+CHUNK_SIZE = int(os.environ.get("CHUNK_SIZE", "256"))
+CACHE_LEN = int(os.environ.get("CACHE_LEN", "4096"))
+PREFIX = os.path.join(
+    OUT_DIR,
+    f"gemma4-e2b_lm_chunk_{CHUNK_SIZE}_cache_{CACHE_LEN}_ptq",
+)
 
 DECODE_BC = f"{PREFIX}.decode_convert_removed.bc"
 PREFILL_HBO = f"{PREFIX}.prefill.hbo"
@@ -19,57 +44,64 @@ DECODE_HBO = f"{PREFIX}.decode.hbo"
 HBM_PATH = f"{PREFIX}.hbm"
 CACHE_PATH = os.path.join(OUT_DIR, "compile_cache_decode")
 
-JOBS = int(os.environ.get("HBDK_JOBS", "29"))
-OPT = int(os.environ.get("HBDK_OPT", "0"))
+MARCH = os.environ.get("HBDK_MARCH", DEFAULTS["march"])
+DECODE_CORE_NUM = int(
+    os.environ.get("DECODE_CORE_NUM", str(DEFAULTS["decode_cores"]))
+)
+JOBS = int(os.environ.get("HBDK_JOBS", str(DEFAULTS["jobs"])))
+OPT = int(os.environ.get("HBDK_OPT", str(DEFAULTS["opt"])))
 CACHE_MODE = os.environ.get("HBDK_CACHE_MODE", "enable")
-MARCH = os.environ.get("HBDK_MARCH", "nash-m")
+MAX_L2M_SIZE = int(os.environ.get("GEMMA4_MAX_L2M_SIZE", "25165824"))
 
 
-def log(msg: str) -> None:
-    """Print a flush-enabled progress message for the compile workflow."""
-    """Print a flush-enabled progress message for the compile workflow."""
-    print(msg, flush=True)
+def log(message: str) -> None:
+    """Print a flush-enabled progress message."""
+    print(message, flush=True)
 
 
 def main() -> int:
-    """Compile the Gemma4 text decode graph from command-line options."""
-    """Compile the Gemma4 text decode graph from command-line options."""
-    for path, name in [
-        (DECODE_BC, "decode BC"),
-        (PREFILL_HBO, "prefill HBO"),
-    ]:
+    """Compile the decode graph and link the selected Text HBM."""
+    for path, name in ((DECODE_BC, "decode BC"), (PREFILL_HBO, "prefill HBO")):
         if not os.path.isfile(path):
             log(f"ERROR: missing {name}: {path}")
             return 1
 
-    log(f"[config] jobs={JOBS} opt={OPT} cache_mode={CACHE_MODE} march={MARCH}")
-    if os.path.isfile(PREFILL_HBO) and os.path.isfile(DECODE_HBO):
-        log("[fast-path] Both HBO files exist, linking only ...")
+    log(
+        f"[config] target={TARGET_SOC} march={MARCH} cores={DECODE_CORE_NUM} "
+        f"jobs={JOBS} opt={OPT} cache_mode={CACHE_MODE}"
+    )
+    if os.path.isfile(DECODE_HBO) and os.path.getsize(DECODE_HBO) > 0:
+        log("[fast-path] Decode HBO exists; linking prefill + decode only ...")
         link([Hbo(PREFILL_HBO), Hbo(DECODE_HBO)], HBM_PATH)
         log(f"DONE: {HBM_PATH}")
         return 0
 
     log(f"[1/3] Loading decode BC: {DECODE_BC}")
     decode_module = load(DECODE_BC)
-    log(f"      Functions: {[f.name for f in decode_module.functions]}")
+    log(f"      Functions: {[function.name for function in decode_module.functions]}")
 
     os.makedirs(CACHE_PATH, exist_ok=True)
-    if os.path.isfile(DECODE_HBO) and os.path.getsize(DECODE_HBO) > 0:
-        log(f"[2/3] Skip compile: decode HBO already exists ({DECODE_HBO})")
-    else:
-        log(f"[2/3] Compiling decode HBO -> {DECODE_HBO}")
-        decode_hbo = compile(
-            decode_module,
-            DECODE_HBO,
-            march=MARCH,
-            opt=OPT,
-            jobs=JOBS,
-            core_num=1,
-            progress_bar=True,
-            cache_mode=CACHE_MODE,
-            cache_path=CACHE_PATH,
+    compile_kwargs = {
+        "march": MARCH,
+        "opt": OPT,
+        "jobs": JOBS,
+        "core_num": DECODE_CORE_NUM,
+        "progress_bar": True,
+        "cache_mode": CACHE_MODE,
+        "cache_path": CACHE_PATH,
+    }
+    if DECODE_CORE_NUM > 1:
+        compile_kwargs["max_l2m_size"] = MAX_L2M_SIZE
+    if MARCH == "nash-p":
+        compile_kwargs.update(
+            enable_hpc=True,
+            input_no_padding=True,
+            output_no_padding=True,
         )
-        log(f"      decode HBO done: {DECODE_HBO}")
+
+    log(f"[2/3] Compiling decode HBO -> {DECODE_HBO}")
+    compile(decode_module, DECODE_HBO, **compile_kwargs)
+    log(f"      Decode HBO done: {DECODE_HBO}")
 
     log(f"[3/3] Linking prefill + decode -> {HBM_PATH}")
     link([Hbo(PREFILL_HBO), Hbo(DECODE_HBO)], HBM_PATH)
@@ -78,4 +110,4 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    raise SystemExit(main())

--- a/samples/llm/gemma4-e2b/conversion/scripts/compile/compile_vision.py
+++ b/samples/llm/gemma4-e2b/conversion/scripts/compile/compile_vision.py
@@ -1,18 +1,41 @@
 #!/usr/bin/env python3
-"""从已有 convert.bc 编译 Vision HBO/HBM（续编用）"""
+"""Resume Vision HBO/HBM compilation from an existing converted BC."""
+
+from __future__ import annotations
+
 import os
 
 from hbdk4.compiler.apis import compile, link, load
 
+TARGET_DEFAULTS = {
+    "s100": {"march": "nash-e", "cores": 1, "jobs": 25, "opt": 0},
+    "s100p": {"march": "nash-m", "cores": 1, "jobs": 25, "opt": 0},
+    "s600": {"march": "nash-p", "cores": 4, "jobs": 22, "opt": 1},
+}
+
+TARGET_SOC = os.environ.get("TARGET_SOC", "s100p").lower()
+if TARGET_SOC not in TARGET_DEFAULTS:
+    raise ValueError("TARGET_SOC must be s100, s100p, or s600")
+DEFAULTS = TARGET_DEFAULTS[TARGET_SOC]
+
 OUT_DIR = os.environ.get(
     "COMPILE_OUTPUT_DIR",
-    os.path.join(os.path.dirname(__file__), "..", "..", "output", "gemma4_e2b_vision"),
+    os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "..",
+        "output",
+        f"gemma4_e2b_vision_{TARGET_SOC}",
+    ),
 )
 OUT_DIR = os.path.abspath(OUT_DIR)
 
-JOBS = int(os.environ.get("HBDK_JOBS", "25"))
-OPT = int(os.environ.get("HBDK_OPT", "0"))
+MARCH = os.environ.get("HBDK_MARCH", DEFAULTS["march"])
+CORE_NUM = int(os.environ.get("VIT_CORE_NUM", str(DEFAULTS["cores"])))
+JOBS = int(os.environ.get("HBDK_JOBS", str(DEFAULTS["jobs"])))
+OPT = int(os.environ.get("HBDK_OPT", str(DEFAULTS["opt"])))
 CACHE_MODE = os.environ.get("HBDK_CACHE_MODE", "enable")
+MAX_L2M_SIZE = int(os.environ.get("GEMMA4_MAX_L2M_SIZE", "25165824"))
 
 BC_PATH = os.path.join(OUT_DIR, "gemma4-e2b_vit_ptq.convert.bc")
 HBO_PATH = os.path.join(OUT_DIR, "gemma4-e2b_vit_ptq.hbo")
@@ -20,32 +43,47 @@ HBM_PATH = os.path.join(OUT_DIR, "gemma4-e2b_vit_ptq.hbm")
 CACHE_PATH = os.path.join(OUT_DIR, "compile_cache")
 
 
-def log(msg):
-    """Print a flush-enabled progress message for vision compilation."""
-    """Print a flush-enabled progress message for vision compilation."""
-    print(msg, flush=True)
+def log(message: str) -> None:
+    """Print a flush-enabled progress message."""
+    print(message, flush=True)
 
 
-log(f"[config] jobs={JOBS} opt={OPT} cache_mode={CACHE_MODE} march=nash-m")
-log(f"[1/3] Loading {BC_PATH} ...")
-module = load(BC_PATH)
-log(f"      Functions: {[f.name for f in module.functions]}")
+def main() -> int:
+    """Compile and link the Vision model for the selected SoC."""
+    if not os.path.isfile(BC_PATH):
+        log(f"ERROR: missing converted Vision BC: {BC_PATH}")
+        return 1
 
-os.makedirs(CACHE_PATH, exist_ok=True)
-log(f"[2/3] Compiling HBO (jobs={JOBS}, opt={OPT}) ...")
-hbo = compile(
-    module,
-    HBO_PATH,
-    march="nash-m",
-    opt=OPT,
-    jobs=JOBS,
-    core_num=1,
-    progress_bar=True,
-    cache_mode=CACHE_MODE,
-    cache_path=CACHE_PATH,
-)
-log(f"      HBO done: {HBO_PATH}")
+    log(
+        f"[config] target={TARGET_SOC} march={MARCH} cores={CORE_NUM} "
+        f"jobs={JOBS} opt={OPT} cache_mode={CACHE_MODE}"
+    )
+    log(f"[1/3] Loading {BC_PATH} ...")
+    module = load(BC_PATH)
+    log(f"      Functions: {[function.name for function in module.functions]}")
 
-log(f"[3/3] Linking HBM -> {HBM_PATH} ...")
-link([hbo], HBM_PATH)
-log(f"DONE: {HBM_PATH}")
+    os.makedirs(CACHE_PATH, exist_ok=True)
+    compile_kwargs = {
+        "march": MARCH,
+        "opt": OPT,
+        "jobs": JOBS,
+        "core_num": CORE_NUM,
+        "progress_bar": True,
+        "cache_mode": CACHE_MODE,
+        "cache_path": CACHE_PATH,
+    }
+    if CORE_NUM > 1:
+        compile_kwargs["max_l2m_size"] = MAX_L2M_SIZE
+
+    log(f"[2/3] Compiling HBO -> {HBO_PATH}")
+    hbo = compile(module, HBO_PATH, **compile_kwargs)
+    log(f"      HBO done: {HBO_PATH}")
+
+    log(f"[3/3] Linking HBM -> {HBM_PATH}")
+    link([hbo], HBM_PATH)
+    log(f"DONE: {HBM_PATH}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/samples/llm/gemma4-e2b/conversion/scripts/compile/run_text_compile.sh
+++ b/samples/llm/gemma4-e2b/conversion/scripts/compile/run_text_compile.sh
@@ -1,46 +1,109 @@
-#!/bin/bash
-# Text HBM 编译脚本（prefill + decode → link 成单个 HBM）
-# 用法: bash run_text_compile.sh
-# 环境变量（可选）:
-#   GEMMA4_E2B_DIR   - HuggingFace 权重目录
-#   OUTPUT_DIR       - 编译输出目录
-#   CALIB_TEXT_DIR   - 校准文本目录
-#   CHUNK_SIZE       - prefill chunk 大小 (默认 256)
-#   CACHE_LEN        - KV cache 长度 (默认 4096)
+#!/usr/bin/env bash
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
+TARGET_SOC="${TARGET_SOC:-s100p}"
+TARGET_SOC="${TARGET_SOC,,}"
+case "$TARGET_SOC" in
+  s100)
+    DEFAULT_MARCH="nash-e"
+    DEFAULT_PREFILL_CORE_NUM=1
+    DEFAULT_DECODE_CORE_NUM=1
+    DEFAULT_HBDK_JOBS=29
+    DEFAULT_HBDK_OPT=0
+    ;;
+  s100p)
+    DEFAULT_MARCH="nash-m"
+    DEFAULT_PREFILL_CORE_NUM=1
+    DEFAULT_DECODE_CORE_NUM=1
+    DEFAULT_HBDK_JOBS=29
+    DEFAULT_HBDK_OPT=0
+    ;;
+  s600)
+    DEFAULT_MARCH="nash-p"
+    DEFAULT_PREFILL_CORE_NUM=2
+    DEFAULT_DECODE_CORE_NUM=2
+    DEFAULT_HBDK_JOBS=22
+    DEFAULT_HBDK_OPT=1
+    ;;
+  *)
+    echo "Unsupported TARGET_SOC=$TARGET_SOC (expected s100, s100p, or s600)" >&2
+    exit 2
+    ;;
+esac
+
+HBDK_MARCH="${HBDK_MARCH:-$DEFAULT_MARCH}"
+PREFILL_CORE_NUM="${PREFILL_CORE_NUM:-$DEFAULT_PREFILL_CORE_NUM}"
+DECODE_CORE_NUM="${DECODE_CORE_NUM:-$DEFAULT_DECODE_CORE_NUM}"
+HBDK_JOBS="${HBDK_JOBS:-$DEFAULT_HBDK_JOBS}"
+HBDK_OPT="${HBDK_OPT:-$DEFAULT_HBDK_OPT}"
+GEMMA4_MAX_L2M_SIZE="${GEMMA4_MAX_L2M_SIZE:-25165824}"
+
 GEMMA4_E2B_DIR="${GEMMA4_E2B_DIR:-$REPO_ROOT/gemma4-e2b}"
-OUTPUT_DIR="${OUTPUT_DIR:-$REPO_ROOT/output/gemma4_e2b_text}"
+OUTPUT_DIR="${OUTPUT_DIR:-$REPO_ROOT/output/gemma4_e2b_text_$TARGET_SOC}"
 CALIB_TEXT_DIR="${CALIB_TEXT_DIR:-$REPO_ROOT/calibration_data/text}"
 CHUNK_SIZE="${CHUNK_SIZE:-256}"
 CACHE_LEN="${CACHE_LEN:-4096}"
+DEVICE="${DEVICE:-cpu}"
+CACHE_PATH="${CACHE_PATH:-$OUTPUT_DIR/.hbdk_cache}"
 
-OELLM_BUILD=$(python -c "import leap_llm, os; print(os.path.join(os.path.dirname(leap_llm.__file__), 'apis', 'oellm_build.py'))")
+[[ -d "$GEMMA4_E2B_DIR" ]] || {
+  echo "Missing Hugging Face model directory: $GEMMA4_E2B_DIR" >&2
+  exit 2
+}
+[[ -e "$CALIB_TEXT_DIR" ]] || {
+  echo "Missing text calibration data: $CALIB_TEXT_DIR" >&2
+  exit 2
+}
+if [[ -d "$CALIB_TEXT_DIR" ]] && ! find "$CALIB_TEXT_DIR" -type f -print -quit | grep -q .; then
+  echo "Text calibration directory is empty: $CALIB_TEXT_DIR" >&2
+  exit 2
+fi
 
-mkdir -p "$OUTPUT_DIR"
+OELLM_BUILD="$(python3 -c "import leap_llm, os; print(os.path.join(os.path.dirname(leap_llm.__file__), 'apis', 'oellm_build.py'))")"
+
+mkdir -p "$OUTPUT_DIR" "$CACHE_PATH"
 ulimit -s unlimited
+export PYTHONUNBUFFERED=1
+export GEMMA4_MAX_L2M_SIZE
 
-echo "=== Text compile ==="
-echo "  model:     $GEMMA4_E2B_DIR"
-echo "  output:    $OUTPUT_DIR"
-echo "  calib:     $CALIB_TEXT_DIR"
-echo "  chunk:     $CHUNK_SIZE"
-echo "  cache_len: $CACHE_LEN"
+LOG="$OUTPUT_DIR/text_compile_$(date +%Y%m%d_%H%M%S).log"
+
+echo "=== Gemma4 Text compile ==="
+echo "  target_soc:    $TARGET_SOC"
+echo "  march:         $HBDK_MARCH"
+echo "  prefill cores: $PREFILL_CORE_NUM"
+echo "  decode cores:  $DECODE_CORE_NUM"
+echo "  model:         $GEMMA4_E2B_DIR"
+echo "  output:        $OUTPUT_DIR"
+echo "  calibration:   $CALIB_TEXT_DIR"
+echo "  chunk/cache:   $CHUNK_SIZE / $CACHE_LEN"
+echo "  jobs/opt:      $HBDK_JOBS / $HBDK_OPT"
 echo
 
-python -u "$OELLM_BUILD" \
-    --model_name gemma4-e2b-text \
-    --march nash-m \
-    --input_model_path "$GEMMA4_E2B_DIR" \
-    --output_model_path "$OUTPUT_DIR" \
-    --calib_text_path "$CALIB_TEXT_DIR" \
-    --chunk_size "$CHUNK_SIZE" \
-    --cache_len "$CACHE_LEN" \
-    --device cpu \
-    --core_num 1 \
-    2>&1 | tee "$OUTPUT_DIR/text_compile.log"
+python3 -u "$OELLM_BUILD" \
+  --model_name gemma4-e2b-text \
+  --march "$HBDK_MARCH" \
+  --input_model_path "$GEMMA4_E2B_DIR" \
+  --output_model_path "$OUTPUT_DIR" \
+  --calib_text_path "$CALIB_TEXT_DIR" \
+  --chunk_size "$CHUNK_SIZE" \
+  --cache_len "$CACHE_LEN" \
+  --device "$DEVICE" \
+  --prefill_core_num "$PREFILL_CORE_NUM" \
+  --decode_core_num "$DECODE_CORE_NUM" \
+  --jobs "$HBDK_JOBS" \
+  --opt "$HBDK_OPT" \
+  --cache_path "$CACHE_PATH" \
+  2>&1 | tee "$LOG"
 
-echo "Done: $OUTPUT_DIR/gemma4-e2b_lm_chunk_${CHUNK_SIZE}_cache_${CACHE_LEN}_ptq.hbm"
+HBM="$(find "$OUTPUT_DIR" -maxdepth 2 -name '*_ptq*.hbm' -not -name '*_vit_ptq*.hbm' -print -quit)"
+TOK="$(find "$OUTPUT_DIR" -maxdepth 2 -name 'tok_embeddings.bin' -print -quit)"
+[[ -n "$HBM" && -n "$TOK" ]] || {
+  echo "Missing Text artifacts; see $LOG" >&2
+  exit 1
+}
+echo "text_hbm=$HBM"
+echo "tok_embeddings=$TOK"

--- a/samples/llm/gemma4-e2b/conversion/scripts/compile/run_text_decode_resume.sh
+++ b/samples/llm/gemma4-e2b/conversion/scripts/compile/run_text_decode_resume.sh
@@ -1,51 +1,81 @@
-#!/bin/bash
-# Text decode 续编脚本（decode 阶段 OOM 后可单独续编）
-# 用于 prefill 已编译完成、decode 需要重试或续编的场景
-# 用法: bash run_text_decode_resume.sh
-# 环境变量（可选）:
-#   OUTPUT_DIR       - 编译输出目录
-#   MEM_LIMIT_GIB    - 虚拟内存上限 GiB (默认 110)
-#   HBDK_JOBS        - 编译并行度 (默认 29)
+#!/usr/bin/env bash
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
-OUTPUT_DIR="${OUTPUT_DIR:-$REPO_ROOT/output/gemma4_e2b_text}"
+TARGET_SOC="${TARGET_SOC:-s100p}"
+TARGET_SOC="${TARGET_SOC,,}"
+case "$TARGET_SOC" in
+  s100)
+    DEFAULT_MARCH="nash-e"
+    DEFAULT_DECODE_CORE_NUM=1
+    DEFAULT_HBDK_JOBS=29
+    DEFAULT_HBDK_OPT=0
+    ;;
+  s100p)
+    DEFAULT_MARCH="nash-m"
+    DEFAULT_DECODE_CORE_NUM=1
+    DEFAULT_HBDK_JOBS=29
+    DEFAULT_HBDK_OPT=0
+    ;;
+  s600)
+    DEFAULT_MARCH="nash-p"
+    DEFAULT_DECODE_CORE_NUM=2
+    DEFAULT_HBDK_JOBS=22
+    DEFAULT_HBDK_OPT=1
+    ;;
+  *)
+    echo "Unsupported TARGET_SOC=$TARGET_SOC (expected s100, s100p, or s600)" >&2
+    exit 2
+    ;;
+esac
+
+OUTPUT_DIR="${OUTPUT_DIR:-$REPO_ROOT/output/gemma4_e2b_text_$TARGET_SOC}"
+CHUNK_SIZE="${CHUNK_SIZE:-256}"
+CACHE_LEN="${CACHE_LEN:-4096}"
 MEM_LIMIT_GIB="${MEM_LIMIT_GIB:-110}"
 MEM_LIMIT_BYTES=$((MEM_LIMIT_GIB * 1024 * 1024 * 1024))
 
-export HBDK_JOBS="${HBDK_JOBS:-29}"
-export HBDK_OPT="${HBDK_OPT:-0}"
+export HBDK_MARCH="${HBDK_MARCH:-$DEFAULT_MARCH}"
+export DECODE_CORE_NUM="${DECODE_CORE_NUM:-$DEFAULT_DECODE_CORE_NUM}"
+export HBDK_JOBS="${HBDK_JOBS:-$DEFAULT_HBDK_JOBS}"
+export HBDK_OPT="${HBDK_OPT:-$DEFAULT_HBDK_OPT}"
 export HBDK_CACHE_MODE="${HBDK_CACHE_MODE:-enable}"
+export GEMMA4_MAX_L2M_SIZE="${GEMMA4_MAX_L2M_SIZE:-25165824}"
+export CHUNK_SIZE CACHE_LEN
+export COMPILE_OUTPUT_DIR="$OUTPUT_DIR"
 
-LOG="${OUTPUT_DIR}/text_decode_resume.log"
+mkdir -p "$OUTPUT_DIR"
+LOG="$OUTPUT_DIR/text_decode_resume_$(date +%Y%m%d_%H%M%S).log"
 
-echo "=== Text decode resume ==="
-echo "  HBDK_JOBS=$HBDK_JOBS  HBDK_OPT=$HBDK_OPT  MEM_LIMIT=${MEM_LIMIT_GIB}GiB"
+echo "=== Gemma4 Text decode resume ==="
+echo "  target_soc:    $TARGET_SOC"
+echo "  march:         $HBDK_MARCH"
+echo "  decode cores:  $DECODE_CORE_NUM"
+echo "  output:        $OUTPUT_DIR"
+echo "  chunk/cache:   $CHUNK_SIZE / $CACHE_LEN"
+echo "  jobs/opt:      $HBDK_JOBS / $HBDK_OPT"
+echo "  memory limit:  ${MEM_LIMIT_GIB} GiB"
 echo
 
-echo "=== memory / swap ==="
 free -h
 if swapon --show 2>/dev/null | grep -q .; then
   echo "swap: enabled"
 else
-  echo "WARNING: no swap active. Run first: bash $SCRIPT_DIR/setup_swap.sh"
+  echo "WARNING: no swap active. Run: bash $SCRIPT_DIR/setup_swap.sh" >&2
 fi
 echo
 
-# 设置 OUTPUT_DIR 环境变量给 Python 脚本
-export COMPILE_OUTPUT_DIR="$OUTPUT_DIR"
-
 if command -v prlimit >/dev/null 2>&1; then
   echo "Starting with prlimit --as=${MEM_LIMIT_GIB}GiB ..."
-  exec prlimit --as="$MEM_LIMIT_BYTES" \
-    python -u "$SCRIPT_DIR/compile_text_decode.py" \
+  prlimit --as="$MEM_LIMIT_BYTES" \
+    python3 -u "$SCRIPT_DIR/compile_text_decode.py" \
     2>&1 | tee "$LOG"
 else
   echo "prlimit not found, falling back to ulimit -v ..."
   ULIMIT_KB=$((MEM_LIMIT_GIB * 1024 * 1024))
   ulimit -v "$ULIMIT_KB"
-  exec python -u "$SCRIPT_DIR/compile_text_decode.py" \
+  python3 -u "$SCRIPT_DIR/compile_text_decode.py" \
     2>&1 | tee "$LOG"
 fi

--- a/samples/llm/gemma4-e2b/conversion/scripts/compile/run_vision_compile.sh
+++ b/samples/llm/gemma4-e2b/conversion/scripts/compile/run_vision_compile.sh
@@ -1,44 +1,97 @@
-#!/bin/bash
-# Vision HBM 编译脚本
-# 用法: bash run_vision_compile.sh
-# 环境变量（可选）:
-#   GEMMA4_E2B_DIR   - HuggingFace 权重目录 (默认: ../../gemma4-e2b)
-#   OUTPUT_DIR       - 编译输出目录 (默认: ../../output/gemma4_e2b_vision)
-#   CALIB_IMAGE_DIR  - 校准图像目录 (默认: ../../calibration_data/images)
-#   DEVICE           - 校准设备 (默认: cuda:0)
+#!/usr/bin/env bash
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
+TARGET_SOC="${TARGET_SOC:-s100p}"
+TARGET_SOC="${TARGET_SOC,,}"
+case "$TARGET_SOC" in
+  s100)
+    DEFAULT_MARCH="nash-e"
+    DEFAULT_VIT_CORE_NUM=1
+    DEFAULT_HBDK_JOBS=25
+    DEFAULT_HBDK_OPT=0
+    ;;
+  s100p)
+    DEFAULT_MARCH="nash-m"
+    DEFAULT_VIT_CORE_NUM=1
+    DEFAULT_HBDK_JOBS=25
+    DEFAULT_HBDK_OPT=0
+    ;;
+  s600)
+    DEFAULT_MARCH="nash-p"
+    DEFAULT_VIT_CORE_NUM=4
+    DEFAULT_HBDK_JOBS=22
+    DEFAULT_HBDK_OPT=1
+    ;;
+  *)
+    echo "Unsupported TARGET_SOC=$TARGET_SOC (expected s100, s100p, or s600)" >&2
+    exit 2
+    ;;
+esac
+
+HBDK_MARCH="${HBDK_MARCH:-$DEFAULT_MARCH}"
+VIT_CORE_NUM="${VIT_CORE_NUM:-$DEFAULT_VIT_CORE_NUM}"
+HBDK_JOBS="${HBDK_JOBS:-$DEFAULT_HBDK_JOBS}"
+HBDK_OPT="${HBDK_OPT:-$DEFAULT_HBDK_OPT}"
+GEMMA4_MAX_L2M_SIZE="${GEMMA4_MAX_L2M_SIZE:-25165824}"
+
 GEMMA4_E2B_DIR="${GEMMA4_E2B_DIR:-$REPO_ROOT/gemma4-e2b}"
-OUTPUT_DIR="${OUTPUT_DIR:-$REPO_ROOT/output/gemma4_e2b_vision}"
+OUTPUT_DIR="${OUTPUT_DIR:-$REPO_ROOT/output/gemma4_e2b_vision_$TARGET_SOC}"
 CALIB_IMAGE_DIR="${CALIB_IMAGE_DIR:-$REPO_ROOT/calibration_data/images}"
 DEVICE="${DEVICE:-cuda:0}"
+CACHE_PATH="${CACHE_PATH:-$OUTPUT_DIR/.hbdk_cache}"
 
-OELLM_BUILD=$(python -c "import leap_llm, os; print(os.path.join(os.path.dirname(leap_llm.__file__), 'apis', 'oellm_build.py'))")
+[[ -d "$GEMMA4_E2B_DIR" ]] || {
+  echo "Missing Hugging Face model directory: $GEMMA4_E2B_DIR" >&2
+  exit 2
+}
+[[ -d "$CALIB_IMAGE_DIR" ]] || {
+  echo "Missing calibration image directory: $CALIB_IMAGE_DIR" >&2
+  exit 2
+}
 
-mkdir -p "$OUTPUT_DIR"
+python3 "$SCRIPT_DIR/../calibration/download_coco_images.py" \
+  --output-dir "$CALIB_IMAGE_DIR" \
+  --verify-only
 
-# 增大栈大小，解决 hbdk4 compile_hbo segfault
+OELLM_BUILD="$(python3 -c "import leap_llm, os; print(os.path.join(os.path.dirname(leap_llm.__file__), 'apis', 'oellm_build.py'))")"
+
+mkdir -p "$OUTPUT_DIR" "$CACHE_PATH"
 ulimit -s unlimited
-export CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:-0}"
+export PYTHONUNBUFFERED=1
+export GEMMA4_MAX_L2M_SIZE
 
-echo "=== Vision compile ==="
-echo "  model:   $GEMMA4_E2B_DIR"
-echo "  output:  $OUTPUT_DIR"
-echo "  calib:   $CALIB_IMAGE_DIR"
-echo "  device:  $DEVICE"
+LOG="$OUTPUT_DIR/vision_compile_$(date +%Y%m%d_%H%M%S).log"
+
+echo "=== Gemma4 Vision compile ==="
+echo "  target_soc:   $TARGET_SOC"
+echo "  march:        $HBDK_MARCH"
+echo "  BPU cores:    $VIT_CORE_NUM"
+echo "  model:        $GEMMA4_E2B_DIR"
+echo "  output:       $OUTPUT_DIR"
+echo "  calibration:  $CALIB_IMAGE_DIR (verified COCO val2017)"
+echo "  device:       $DEVICE"
+echo "  jobs/opt:     $HBDK_JOBS / $HBDK_OPT"
 echo
 
-python -u "$OELLM_BUILD" \
-    --model_name gemma4-e2b-vision \
-    --march nash-m \
-    --input_model_path "$GEMMA4_E2B_DIR" \
-    --output_model_path "$OUTPUT_DIR" \
-    --calib_image_path "$CALIB_IMAGE_DIR" \
-    --device "$DEVICE" \
-    --vit_core_num 1 \
-    2>&1 | tee "$OUTPUT_DIR/vision_compile.log"
+python3 -u "$OELLM_BUILD" \
+  --model_name gemma4-e2b-vision \
+  --march "$HBDK_MARCH" \
+  --input_model_path "$GEMMA4_E2B_DIR" \
+  --output_model_path "$OUTPUT_DIR" \
+  --calib_image_path "$CALIB_IMAGE_DIR" \
+  --device "$DEVICE" \
+  --vit_core_num "$VIT_CORE_NUM" \
+  --jobs "$HBDK_JOBS" \
+  --opt "$HBDK_OPT" \
+  --cache_path "$CACHE_PATH" \
+  2>&1 | tee "$LOG"
 
-echo "Done: $OUTPUT_DIR/gemma4-e2b_vit_ptq.hbm"
+HBM="$(find "$OUTPUT_DIR" -maxdepth 2 -name '*_vit_ptq*.hbm' -print -quit)"
+[[ -n "$HBM" ]] || {
+  echo "No Vision HBM produced; see $LOG" >&2
+  exit 1
+}
+echo "vision_hbm=$HBM"

--- a/samples/llm/gemma4-e2b/conversion/scripts/verify/quick_text_verify.py
+++ b/samples/llm/gemma4-e2b/conversion/scripts/verify/quick_text_verify.py
@@ -3,12 +3,14 @@
 
 Usage:
     python quick_text_verify.py \
+        --target-soc s600 \
         --model-dir ../../gemma4-e2b \
-        --bc-path ../../output/gemma4_e2b_text/gemma4-e2b_lm_chunk_256_cache_4096_ptq.prefill_convert.bc \
+        --bc-path ../../output/gemma4_e2b_text_s600/gemma4-e2b_lm_chunk_256_cache_4096_ptq.prefill_convert.bc \
         --prompts ../../calibration_data/text_verify/calibration.json
 """
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -27,7 +29,6 @@ DEVICE = "cpu"
 
 
 def prepare_chunk_inputs(text_model, preparer, prompt, bc_meta):
-    """Build one prefill chunk and its BC-runtime input tensor mapping."""
     """Build one prefill chunk and its BC-runtime input tensor mapping."""
     chunks, pos, full_masks, sliding_masks = preparer.prepare_inputs(prompt)
     if not chunks:
@@ -62,13 +63,28 @@ def prepare_chunk_inputs(text_model, preparer, prompt, bc_meta):
 
 def main():
     """Compare Gemma4 text BC logits with the PyTorch reference output."""
-    """Compare Gemma4 text BC logits with the PyTorch reference output."""
     parser = argparse.ArgumentParser(description="Text BC lightweight verification")
+    parser.add_argument(
+        "--target-soc",
+        choices=("s100", "s100p", "s600"),
+        default=os.environ.get("TARGET_SOC", "s100p").lower(),
+        help="Target SoC used to select the default BC output directory.",
+    )
     parser.add_argument("--model-dir", default=str(REPO_ROOT / "gemma4-e2b"))
-    parser.add_argument("--bc-path", default=str(REPO_ROOT / "output/gemma4_e2b_text/gemma4-e2b_lm_chunk_256_cache_4096_ptq.prefill_convert.bc"))
+    parser.add_argument("--bc-path", default=None)
     parser.add_argument("--prompts", default=str(REPO_ROOT / "calibration_data/text_verify/calibration.json"))
-    parser.add_argument("--output", default=str(REPO_ROOT / "output/e2b_text_verify_quick.json"))
+    parser.add_argument("--output", default=None)
     args = parser.parse_args()
+    if args.bc_path is None:
+        args.bc_path = str(
+            REPO_ROOT
+            / f"output/gemma4_e2b_text_{args.target_soc}"
+            / "gemma4-e2b_lm_chunk_256_cache_4096_ptq.prefill_convert.bc"
+        )
+    if args.output is None:
+        args.output = str(
+            REPO_ROOT / f"output/e2b_text_verify_quick_{args.target_soc}.json"
+        )
 
     with open(args.prompts, encoding="utf-8") as f:
         prompts = [x["text"] for x in json.load(f)]
@@ -122,7 +138,7 @@ def main():
     with open(args.output, "w", encoding="utf-8") as f:
         json.dump({"results": results, "mean_cosine": mean}, f, indent=2, ensure_ascii=False)
     print(f"Saved: {args.output}")
-    return 0 if mean and mean >= 0.99 else 1
+    return 0 if mean is not None and mean >= 0.99 else 1
 
 
 if __name__ == "__main__":

--- a/samples/llm/gemma4-e2b/conversion/scripts/verify/run_remote_hbm_verify.sh
+++ b/samples/llm/gemma4-e2b/conversion/scripts/verify/run_remote_hbm_verify.sh
@@ -1,39 +1,72 @@
 #!/usr/bin/env bash
-# Remote HBM verify — run on a PC that can SSH to the S100P board.
-# HBM mode cannot run locally; it must execute on the board via SSH.
+# Run HBM verification on an RDK S-series board reachable over SSH.
 #
-# Usage: bash run_remote_hbm_verify.sh
-# Env vars: BOARD_IP, BOARD_USER, BOARD_PORT, SDK_ROOT, GEMMA_ROOT
+# Usage:
+#   BOARD_IP=192.0.2.10 TARGET_SOC=s600 bash run_remote_hbm_verify.sh
+#
+# Optional env vars: BOARD_USER, BOARD_PORT, REMOTE_PATH, PYTHON_BIN,
+# MODEL_DIR, VISION_HBM, TEXT_HBM, CALIB_IMG, CALIB_TEXT, CONVERSION_ROOT.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+CONVERSION_ROOT="${CONVERSION_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
 
-GEMMA_ROOT="${GEMMA_ROOT:-$REPO_ROOT}"
-MODEL_DIR="${MODEL_DIR:-$GEMMA_ROOT/gemma4-e2b}"
-VISION_HBM="${VISION_HBM:-$GEMMA_ROOT/output/gemma4_e2b_vision/gemma4-e2b_vit_ptq.hbm}"
-TEXT_HBM="${TEXT_HBM:-$GEMMA_ROOT/output/gemma4_e2b_text/gemma4-e2b_lm_chunk_256_cache_4096_ptq.hbm}"
-CALIB_IMG="${CALIB_IMG:-$GEMMA_ROOT/calibration_data/images/coco_00_000000000802.jpg}"
-CALIB_TEXT="${CALIB_TEXT:-$GEMMA_ROOT/calibration_data/text_verify}"
+TARGET_SOC="${TARGET_SOC:-s100p}"
+TARGET_SOC="${TARGET_SOC,,}"
+case "$TARGET_SOC" in
+  s100|s100p|s600)
+    ;;
+  *)
+    echo "ERROR: unsupported TARGET_SOC=$TARGET_SOC" >&2
+    exit 2
+    ;;
+esac
 
-BOARD_IP="${BOARD_IP:-192.168.127.10}"
+PYTHON_BIN="${PYTHON_BIN:-python}"
+MODEL_DIR="${MODEL_DIR:-$CONVERSION_ROOT/gemma4-e2b}"
+VISION_HBM="${VISION_HBM:-$CONVERSION_ROOT/output/gemma4_e2b_vision_$TARGET_SOC/gemma4-e2b_vit_ptq.hbm}"
+TEXT_HBM="${TEXT_HBM:-$CONVERSION_ROOT/output/gemma4_e2b_text_$TARGET_SOC/gemma4-e2b_lm_chunk_256_cache_4096_ptq.hbm}"
+CALIB_IMG="${CALIB_IMG:-$CONVERSION_ROOT/calibration_data/images/coco_00_000000000802.jpg}"
+CALIB_TEXT="${CALIB_TEXT:-$CONVERSION_ROOT/calibration_data/text_verify}"
+
+BOARD_IP="${BOARD_IP:-}"
 BOARD_USER="${BOARD_USER:-root}"
 BOARD_PORT="${BOARD_PORT:-22}"
 REMOTE_PATH="${REMOTE_PATH:-/tmp/}"
 
-VERIFIER=$(python -c "import leap_llm, os; print(os.path.join(os.path.dirname(leap_llm.__file__), 'apis', 'verifier_cli.py'))")
+if [[ -z "$BOARD_IP" ]]; then
+  echo "ERROR: BOARD_IP is required." >&2
+  echo "Example: BOARD_IP=192.0.2.10 TARGET_SOC=$TARGET_SOC bash $0" >&2
+  exit 2
+fi
+for required_path in "$MODEL_DIR" "$VISION_HBM" "$TEXT_HBM" "$CALIB_IMG" "$CALIB_TEXT"; do
+  if [[ ! -e "$required_path" ]]; then
+    echo "ERROR: required path does not exist: $required_path" >&2
+    exit 2
+  fi
+done
+command -v ssh >/dev/null 2>&1 || {
+  echo "ERROR: ssh is required" >&2
+  exit 2
+}
+
+VERIFIER=$("$PYTHON_BIN" -c "import leap_llm, os; print(os.path.join(os.path.dirname(leap_llm.__file__), 'apis', 'verifier_cli.py'))")
 
 echo "=== Preflight ==="
-python -c "import leap_llm; print('leap_llm ok')"
+echo "target_soc : $TARGET_SOC"
+echo "board      : ${BOARD_USER}@${BOARD_IP}:${BOARD_PORT}"
+echo "vision_hbm : $VISION_HBM"
+echo "text_hbm   : $TEXT_HBM"
+"$PYTHON_BIN" -c "import leap_llm; print('leap_llm ok')"
 ssh -p "$BOARD_PORT" -o ConnectTimeout=10 "${BOARD_USER}@${BOARD_IP}" \
   "df -h /tmp && free -h"
 
 TS=$(date +%Y%m%d_%H%M%S)
-LOG_DIR="$GEMMA_ROOT/output/remote_verify_${TS}"
+LOG_DIR="$CONVERSION_ROOT/output/remote_verify_${TARGET_SOC}_${TS}"
 mkdir -p "$LOG_DIR"
 
 echo "=== Vision remote ==="
-python "$VERIFIER" \
+"$PYTHON_BIN" "$VERIFIER" \
   --model_name gemma4-e2b-vision \
   --model_dir "$MODEL_DIR" \
   --hbm_vlm_model_path "$VISION_HBM" \
@@ -45,7 +78,7 @@ python "$VERIFIER" \
   2>&1 | tee "$LOG_DIR/vision_remote.log"
 
 echo "=== Text remote ==="
-python "$VERIFIER" \
+"$PYTHON_BIN" "$VERIFIER" \
   --model_name gemma4-e2b-text \
   --model_dir "$MODEL_DIR" \
   --hbm_llm_model_path "$TEXT_HBM" \

--- a/samples/llm/gemma4-e2b/evaluator/README.md
+++ b/samples/llm/gemma4-e2b/evaluator/README.md
@@ -9,18 +9,29 @@ Tools and workflows to verify quantized accuracy and on-board tensor alignment.
 From your OE-LLM conda environment:
 
 ```bash
+cd samples/llm/gemma4-e2b/conversion
+conda activate oellm
+export TARGET_SOC=s600  # replace with s100 or s100p when needed
+
 # Vision BC cosine similarity
-python -u leap_llm/apis/verifier_cli.py \
+python -m leap_llm.apis.verifier_cli \
     --model_name gemma4-e2b-vision \
     --model_dir ./gemma4-e2b \
-    --quant_vlm_model_path ./output/gemma4_e2b_vision/gemma4-e2b_vit_ptq.bc \
+    --quant_vlm_model_path ./output/gemma4_e2b_vision_${TARGET_SOC}/gemma4-e2b_vit_ptq.bc \
     --input_image_path ./calibration_data/images/coco_00_000000000802.jpg
 
 # Text BC quick check
-python -u conversion/scripts/verify/quick_text_verify.py
+python -u scripts/verify/quick_text_verify.py --target-soc "$TARGET_SOC"
+# Output: output/e2b_text_verify_quick_${TARGET_SOC}.json
 ```
 
 Scripts live under [conversion/scripts/verify/](../conversion/scripts/verify/).
+For on-board HBM comparison, provide the board address explicitly:
+
+```bash
+BOARD_IP=<board-ip> TARGET_SOC="$TARGET_SOC" \
+  bash scripts/verify/run_remote_hbm_verify.sh
+```
 
 ## Board-side (golden mask / KV)
 

--- a/samples/llm/gemma4-e2b/evaluator/README_cn.md
+++ b/samples/llm/gemma4-e2b/evaluator/README_cn.md
@@ -9,18 +9,29 @@
 在 OE-LLM conda 环境中：
 
 ```bash
+cd samples/llm/gemma4-e2b/conversion
+conda activate oellm
+export TARGET_SOC=s600  # 需要时替换为 s100 或 s100p
+
 # Vision BC cosine similarity
-python -u leap_llm/apis/verifier_cli.py \
+python -m leap_llm.apis.verifier_cli \
     --model_name gemma4-e2b-vision \
     --model_dir ./gemma4-e2b \
-    --quant_vlm_model_path ./output/gemma4_e2b_vision/gemma4-e2b_vit_ptq.bc \
+    --quant_vlm_model_path ./output/gemma4_e2b_vision_${TARGET_SOC}/gemma4-e2b_vit_ptq.bc \
     --input_image_path ./calibration_data/images/coco_00_000000000802.jpg
 
 # Text BC 快速验证
-python -u conversion/scripts/verify/quick_text_verify.py
+python -u scripts/verify/quick_text_verify.py --target-soc "$TARGET_SOC"
+# 输出：output/e2b_text_verify_quick_${TARGET_SOC}.json
 ```
 
 脚本位于 [conversion/scripts/verify/](../conversion/scripts/verify/)。
+如需在板端进行 HBM 对比，必须显式提供板端地址：
+
+```bash
+BOARD_IP=<板端IP> TARGET_SOC="$TARGET_SOC" \
+  bash scripts/verify/run_remote_hbm_verify.sh
+```
 
 ## 板端（golden mask / KV 对齐）
 

--- a/samples/llm/gemma4-e2b/model/README.md
+++ b/samples/llm/gemma4-e2b/model/README.md
@@ -2,13 +2,26 @@
 
 [简体中文](./README_cn.md) | **English**
 
-Pre-compiled Gemma4-E2B runtime model files (~6 GB) are hosted on the
-D-Robotics model archive:
+The runtime uses the same filenames and directory layout on S100, S100P, and
+S600, but the two HBM files must match the board SoC. The download script
+detects the SoC and never substitutes an HBM compiled for another target.
 
 ```bash
 export GEMMA4_HOME=~/gemma4_e2b   # optional, this is the default
 bash download_model.sh
 ```
+
+The public `rdk_s100` archive contains the validated S100P (`nash-m`)
+HBMs, while `rdk_s600` contains the validated S600 (`nash-p`) HBMs. Both
+are selected automatically. For S100 (`nash-e`), pre-place matching HBMs
+under `$GEMMA4_HOME/model` or provide their directory URL explicitly:
+
+```bash
+GEMMA4_SOC=s100 GEMMA4_MODEL_BASE_URL=https://your-server/path/to/s100/model bash download_model.sh
+```
+
+The token embedding table and tokenizer are shared across all targets
+and are downloaded from the common archive when missing.
 
 The script downloads these runtime files:
 
@@ -24,7 +37,7 @@ tokenizer/tokenizer_config.json
 
 | File | Size | Description |
 | --- | --- | --- |
-| `model/gemma4-e2b_vit_ptq.hbm` | 329 MB | Vision encoder HBM |
+| `model/gemma4-e2b_vit_ptq.hbm` | 329–377 MB | Platform-specific Vision encoder HBM |
 | `model/gemma4-e2b_lm_chunk_256_cache_4096_ptq.hbm` | 4.5 GB | Text LLM HBM |
 | `model/tok_embeddings.bin` | 1.5 GB | External token embedding table |
 | `tokenizer/` | ~32 MB | `tokenizer.json`, chat template, config |
@@ -33,6 +46,8 @@ tokenizer/tokenizer_config.json
 
 ```bash
 sha256sum ~/gemma4_e2b/model/*.hbm
-# Vision: 470791849d21cffadb388cc61c8f4b1452078c1722d302fd8a8ac775ee9769f1
-# Text:   3e4d4940051e4e8dc0cb434e972e7aae75d49504da3fac435e303f68af73a25f
+# S100P Vision: 470791849d21cffadb388cc61c8f4b1452078c1722d302fd8a8ac775ee9769f1
+# S100P Text:   3e4d4940051e4e8dc0cb434e972e7aae75d49504da3fac435e303f68af73a25f
+# S600 Vision:  a5998ca829cff121aa5672567b20e7be9f527da5b0220962b0fe7467bf8ff7b7
+# S600 Text:    aab1831b1ea2b86763d5457890d89c55b684e4ba4834c1e008c668813d1cf646
 ```

--- a/samples/llm/gemma4-e2b/model/README_cn.md
+++ b/samples/llm/gemma4-e2b/model/README_cn.md
@@ -2,12 +2,20 @@
 
 **简体中文** | [English](./README.md)
 
-Gemma4-E2B 预编译运行模型文件（约 6 GB）托管在地瓜机器人模型服务器：
+S100、S100P 与 S600 使用相同的文件名和目录结构，但两个 HBM 文件必须与板端 SoC 匹配。下载脚本会自动识别 SoC，不会用其他平台 HBM 替代当前平台模型。
 
 ```bash
 export GEMMA4_HOME=~/gemma4_e2b   # 可选，默认值
 bash download_model.sh
 ```
+
+公开的 `rdk_s100` 模型归档包含已验证的 S100P（`nash-m`）HBM，`rdk_s600` 包含已验证的 S600（`nash-p`）HBM，两者都会按 SoC 自动选择。S100（`nash-e`）请先将匹配的两个 HBM 放到 `$GEMMA4_HOME/model`，或显式提供对应模型目录 URL：
+
+```bash
+GEMMA4_SOC=s100 GEMMA4_MODEL_BASE_URL=https://your-server/path/to/s100/model bash download_model.sh
+```
+
+Token embedding 表和 tokenizer 在三个目标平台间共用，缺失时仍从公共归档下载。
 
 脚本会下载以下运行时文件：
 
@@ -23,7 +31,7 @@ tokenizer/tokenizer_config.json
 
 | 文件 | 大小 | 说明 |
 | --- | --- | --- |
-| `model/gemma4-e2b_vit_ptq.hbm` | 329 MB | Vision 编码器 HBM |
+| `model/gemma4-e2b_vit_ptq.hbm` | 329–377 MB | 平台对应的 Vision 编码器 HBM |
 | `model/gemma4-e2b_lm_chunk_256_cache_4096_ptq.hbm` | 4.5 GB | Text LLM HBM |
 | `model/tok_embeddings.bin` | 1.5 GB | 外挂 token embedding 表 |
 | `tokenizer/` | ~32 MB | tokenizer.json、chat template、config |
@@ -32,6 +40,8 @@ tokenizer/tokenizer_config.json
 
 ```bash
 sha256sum ~/gemma4_e2b/model/*.hbm
-# Vision: 470791849d21cffadb388cc61c8f4b1452078c1722d302fd8a8ac775ee9769f1
-# Text:   3e4d4940051e4e8dc0cb434e972e7aae75d49504da3fac435e303f68af73a25f
+# S100P Vision: 470791849d21cffadb388cc61c8f4b1452078c1722d302fd8a8ac775ee9769f1
+# S100P Text:   3e4d4940051e4e8dc0cb434e972e7aae75d49504da3fac435e303f68af73a25f
+# S600 Vision:  a5998ca829cff121aa5672567b20e7be9f527da5b0220962b0fe7467bf8ff7b7
+# S600 Text:    aab1831b1ea2b86763d5457890d89c55b684e4ba4834c1e008c668813d1cf646
 ```

--- a/samples/llm/gemma4-e2b/model/download_model.sh
+++ b/samples/llm/gemma4-e2b/model/download_model.sh
@@ -2,32 +2,79 @@
 set -euo pipefail
 
 GEMMA4_HOME="${GEMMA4_HOME:-$HOME/gemma4_e2b}"
-MODEL_BASE_URL="https://archive.d-robotics.cc/downloads/rdk_model_zoo/rdk_s100/gemma4_e2b/model"
-TOKENIZER_BASE_URL="https://archive.d-robotics.cc/downloads/rdk_model_zoo/rdk_s100/gemma4_e2b/tokenizer"
+SOC="${GEMMA4_SOC:-}"
+if [[ -z "$SOC" && -r /sys/class/boardinfo/soc_name ]]; then
+  SOC=$(tr 'A-Z' 'a-z' </sys/class/boardinfo/soc_name)
+fi
+SOC="${SOC:-s100p}"
+
+S100P_MODEL_BASE_URL="https://archive.d-robotics.cc/downloads/rdk_model_zoo/rdk_s100/gemma4_e2b/model"
+S600_MODEL_BASE_URL="https://archive.d-robotics.cc/downloads/rdk_model_zoo/rdk_s600/gemma4_e2b/model"
+COMMON_MODEL_BASE_URL="${GEMMA4_COMMON_MODEL_BASE_URL:-$S100P_MODEL_BASE_URL}"
+TOKENIZER_BASE_URL="${GEMMA4_TOKENIZER_BASE_URL:-https://archive.d-robotics.cc/downloads/rdk_model_zoo/rdk_s100/gemma4_e2b/tokenizer}"
+MODEL_BASE_URL="${GEMMA4_MODEL_BASE_URL:-}"
+
+case "$SOC" in
+  s100p)
+    MODEL_BASE_URL="${MODEL_BASE_URL:-$S100P_MODEL_BASE_URL}"
+    ;;
+  s100)
+    ;;
+  s600)
+    MODEL_BASE_URL="${MODEL_BASE_URL:-$S600_MODEL_BASE_URL}"
+    ;;
+  *)
+    echo "ERROR: unsupported SoC '$SOC'. Set GEMMA4_SOC and GEMMA4_MODEL_BASE_URL."
+    exit 1
+    ;;
+esac
+
+download_file() {
+  local base_url="$1"
+  local file_name="$2"
+  local output_dir="$3"
+  local destination="$output_dir/$file_name"
+  if [[ -s "$destination" ]]; then
+    echo "Found $destination"
+    return
+  fi
+  mkdir -p "$output_dir"
+  echo "Downloading $file_name..."
+  wget -c -O "$destination.part" "$base_url/$file_name"
+  mv -f "$destination.part" "$destination"
+}
 
 echo "GEMMA4_HOME : $GEMMA4_HOME"
-echo "Model URL   : $MODEL_BASE_URL"
+echo "SOC         : $SOC"
 
-if [[ -f "$GEMMA4_HOME/model/gemma4-e2b_vit_ptq.hbm" && \
-      -f "$GEMMA4_HOME/model/gemma4-e2b_lm_chunk_256_cache_4096_ptq.hbm" && \
-      -f "$GEMMA4_HOME/model/tok_embeddings.bin" && \
-      -f "$GEMMA4_HOME/tokenizer/tokenizer.json" && \
-      -f "$GEMMA4_HOME/tokenizer/tokenizer_config.json" ]]; then
-  echo "Model and tokenizer files already present, skip download."
-else
-  mkdir -p "$GEMMA4_HOME/model" "$GEMMA4_HOME/tokenizer"
-  for model_file in \
-    gemma4-e2b_vit_ptq.hbm \
-    tok_embeddings.bin \
-    gemma4-e2b_lm_chunk_256_cache_4096_ptq.hbm; do
-    echo "Downloading $model_file..."
-    wget -c -P "$GEMMA4_HOME/model" "$MODEL_BASE_URL/$model_file"
-  done
-  for tokenizer_file in tokenizer.json tokenizer_config.json; do
-    echo "Downloading $tokenizer_file..."
-    wget -c -P "$GEMMA4_HOME/tokenizer" "$TOKENIZER_BASE_URL/$tokenizer_file"
+hbm_files=(
+  gemma4-e2b_vit_ptq.hbm
+  gemma4-e2b_lm_chunk_256_cache_4096_ptq.hbm
+)
+missing_hbm=false
+for model_file in "${hbm_files[@]}"; do
+  if [[ ! -s "$GEMMA4_HOME/model/$model_file" ]]; then
+    missing_hbm=true
+  fi
+done
+
+if $missing_hbm && [[ -z "$MODEL_BASE_URL" ]]; then
+  echo "ERROR: no default HBM archive is configured for $SOC."
+  echo "Place matching $SOC HBM files under $GEMMA4_HOME/model, or set:"
+  echo "  GEMMA4_MODEL_BASE_URL=<$SOC model directory URL>"
+  exit 1
+fi
+
+if [[ -n "$MODEL_BASE_URL" ]]; then
+  echo "HBM URL     : $MODEL_BASE_URL"
+  for model_file in "${hbm_files[@]}"; do
+    download_file "$MODEL_BASE_URL" "$model_file" "$GEMMA4_HOME/model"
   done
 fi
+
+download_file "$COMMON_MODEL_BASE_URL" tok_embeddings.bin "$GEMMA4_HOME/model"
+download_file "$TOKENIZER_BASE_URL" tokenizer.json "$GEMMA4_HOME/tokenizer"
+download_file "$TOKENIZER_BASE_URL" tokenizer_config.json "$GEMMA4_HOME/tokenizer"
 
 echo "Download complete."
 echo "Optional integrity check:"

--- a/samples/llm/gemma4-e2b/runtime/cpp/CMakeLists.txt
+++ b/samples/llm/gemma4-e2b/runtime/cpp/CMakeLists.txt
@@ -90,6 +90,7 @@ target_include_directories(gemma4_runtime PUBLIC
 )
 target_link_libraries(gemma4_runtime PUBLIC
   ${DNN_LIB} ${HBUCP_LIB} ${OpenCV_LIBS}
+  ${CMAKE_DL_LIBS}
   tokenizers_cpp
 )
 

--- a/samples/llm/gemma4-e2b/runtime/cpp/README.md
+++ b/samples/llm/gemma4-e2b/runtime/cpp/README.md
@@ -2,13 +2,13 @@
 
 [中文](./README_cn.md) | **English**
 
-C++ inference runtime for Gemma4-E2B VLM on D-Robotics RDK S100P (`march=nash-m`). Loads pre-compiled HBM models and runs real-time Vision-Language inference on the BPU.
+C++ inference runtime for Gemma4-E2B VLM on D-Robotics RDK S100P and S600. It loads pre-compiled HBM models built for the matching SoC and runs real-time Vision-Language inference on the BPU.
 
 > Part of [Gemma4-E2B sample](../../README.md). Full upstream project: [gemma4-e2b-rdk-s100p](https://github.com/shockley6668/gemma4-e2b-rdk-s100p).
 
 ## Prerequisites
 
-The S100P board must have the OE-LLM runtime installed:
+The board must have the OE-LLM runtime installed:
 
 ```bash
 # Verify Horizon BPU SDK
@@ -20,11 +20,11 @@ ls /usr/include/hobot/dnn/hb_dnn.h
 System dependencies (usually pre-installed on OE-LLM images):
 
 ```bash
-sudo apt install cmake g++ libopencv-dev libgflags-dev nlohmann-json3-dev cargo wget
+sudo apt install cmake g++ libopencv-dev libgflags-dev nlohmann-json3-dev cargo wget git curl
 ```
 
 > **No Python required.** Tokenization is done in native C++ via
-> `tokenizers-cpp` (vendored in `third_party/`), matching the
+> `tokenizers-cpp` (downloaded into `third_party/` at build time), matching the
 > OpenExplorer_LLM-s600 reference implementation.
 
 ## Directory Layout
@@ -61,8 +61,14 @@ Quick start (recommended):
 
 ```bash
 cd samples/llm/gemma4-e2b/runtime/cpp
-./run.sh
+./run.sh                              # interactive main
+./run.sh server --port=8000           # OpenAI-compatible HTTP API
+./run.sh demo text --prompt "Hello"  # single-shot diagnostic
 ```
+
+If the first argument starts with `-`, it is forwarded to `main`. The named
+entries `server`, `demo`, `text_bench`, and `golden_verify` select the other
+binaries while keeping the same dependency, model-download, and build flow.
 
 Manual build:
 
@@ -75,7 +81,16 @@ make -j$(nproc)
 
 The first build downloads and compiles `tokenizers-cpp` (HF tokenizers Rust
 binding + sentencepiece + abseil), which takes a few minutes. Subsequent
-builds are incremental and fast.
+builds are incremental and fast. The Rust binding requires Rust 1.79 or
+newer; if the system toolchain is older, the installer places the current
+stable rustup toolchain under `$HOME/.cargo`.
+
+For an offline build with a separately installed Abseil package, prevent
+SentencePiece from fetching Abseil again:
+
+```bash
+GEMMA4_ABSL_PREFIX=/opt/abseil ./run.sh
+```
 
 This produces 5 executables in `build/`:
 
@@ -94,13 +109,14 @@ export GEMMA4_HOME=~/gemma4_e2b
 bash ../../model/download_model.sh
 ```
 
-This downloads the 3 runtime model files and the 2 required tokenizer files
-from the D-Robotics model archive.
+On S100P and S600 this downloads the validated public HBM files plus the
+shared embedding and tokenizer assets. On S100, pre-place matching HBMs or
+set `GEMMA4_MODEL_BASE_URL`; missing shared assets are still downloaded.
 
 ```
 ~/gemma4_e2b/
 ├── model/
-│   ├── gemma4-e2b_vit_ptq.hbm                          # 329 MB  Vision
+│   ├── gemma4-e2b_vit_ptq.hbm                          # 329-377 MB Vision
 │   ├── gemma4-e2b_lm_chunk_256_cache_4096_ptq.hbm      # 4.5 GB  Text
 │   └── tok_embeddings.bin                               # 1.5 GB  Embedding
 └── tokenizer/
@@ -115,12 +131,17 @@ Set `GEMMA4_HOME` to point at the model directory, then run:
 ```bash
 export GEMMA4_HOME=~/gemma4_e2b
 
+# Manual S600 launch: run.sh applies these settings automatically
+unset LD_LIBRARY_PATH GEMMA4_USE_DNN_V3
+export HB_DNN_USER_DEFINED_L2M_SIZES=6:6:6:6
+
 # Interactive VLM chat (zero-arg default uses $GEMMA4_HOME)
 ./main
 
 # Inside the chat:
 #   /image /path/to/photo.jpg        Load an image
 #   What do you see in this image?   Ask a question
+#   /context                          Show KV-cache usage
 #   /reset                            Clear conversation
 #   /quit                             Exit
 ```
@@ -134,6 +155,16 @@ Image loaded (430080 features).
 gemma4> Describe this image
 This is a photograph of a Red Panda resting on a wooden structure...
 ```
+
+### 4096-token context
+
+- The Text HBM has a fixed 4096-token capacity, so `prompt_tokens + output_tokens <= 4096`.
+- `--max_tokens=0` is the default for both `main` and `gemma4_server`. It gives each turn all capacity remaining after the prompt, so a short prompt can receive an output budget close to 4096 tokens.
+- The next turn reserves at least `--min_response_tokens` tokens (256 by default). When needed, the oldest complete user/assistant pairs are removed and the KV cache is rebuilt.
+- `/context` reports used tokens, remaining capacity, and turn count. Stop tokens are neither printed nor stored in assistant text.
+- `main` loads both Text and Vision before entering the interactive loop and keeps both resident for the process lifetime. S100, S100P, and S600 share this lifecycle; `/image` only runs image preprocessing and Vision inference and never reloads either model.
+- Multimodal follow-ups retain the original image turn and explicitly inject the same Vision features beside the latest user question, with at most two 280-token image blocks in the prompt.
+- Internal diagnostics are quiet by default. Set `GEMMA4_DEBUG=1` to enable `[DEBUG]` and `[VLM-FIX]` output.
 
 ## Command-line Parameters
 
@@ -150,7 +181,8 @@ has a default that makes the binary runnable with zero arguments once
 | `--vision_hbm` | string | `$GEMMA4_HOME/model/gemma4-e2b_vit_ptq.hbm` | Path to vision ViT HBM |
 | `--tok_embeddings` | string | `$GEMMA4_HOME/model/tok_embeddings.bin` | External token embedding table |
 | `--tokenizer_path` | string | `$GEMMA4_HOME/tokenizer/tokenizer.json` | HF tokenizer JSON |
-| `--max_tokens` | int | `4096` (`kCacheLen`) | Max new tokens per turn |
+| `--max_tokens` | int | `0` | Max new tokens per turn; `0` uses all KV capacity remaining after the prompt |
+| `--min_response_tokens` | int | `256` | Minimum reply capacity preserved while trimming old history |
 
 ### `gemma4_demo` — single-shot text or VLM
 
@@ -167,14 +199,44 @@ has a default that makes the binary runnable with zero arguments once
 | `--image_path` | string | `""` | Image path (required when mode = `vlm`) |
 | `--max_tokens` | int | `32` | Max new tokens |
 
-### `gemma4_server` — long-running chat server
+### `gemma4_server` — OpenAI-compatible text chat
+
+`gemma4_server` keeps the Text HBM resident and exposes a serialized OpenAI-compatible HTTP API. Consecutive requests reuse the KV cache when their token prefixes match. The endpoint is text-only; image messages return HTTP 400 and should be handled with the interactive `main` executable.
+
+~~~bash
+cd samples/llm/gemma4-e2b/runtime/cpp
+./run.sh server --host=0.0.0.0 --port=8000
+~~~
+
+| Method | Endpoint | Description |
+|---|---|---|
+| `GET` | `/health` | Readiness, model id, context size, and cached-token count |
+| `GET` | `/v1/models` | OpenAI-compatible model list |
+| `POST` | `/v1/chat/completions` | Non-streaming JSON or SSE streaming chat completion |
+
+Non-streaming request:
+
+~~~bash
+curl http://127.0.0.1:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model":"gemma4-e2b","messages":[{"role":"user","content":"Write a long introduction to the RDK S600."}],"max_tokens":0}'
+~~~
+
+`max_tokens: 0` is a sample extension meaning “use every token remaining in the fixed 4096-token KV cache.” For SSE output, add `"stream": true`; `stream_options.include_usage` is also supported.
+
+For ChatBox, set the API type to OpenAI-compatible, the base URL to `http://BOARD_IP:8000/v1`, and the model to `gemma4-e2b`. If the client requires an API key, any non-empty placeholder is accepted because the server does not validate the `Authorization` header.
 
 | Flag | Type | Default | Description |
 |---|---|---|---|
+| `--host` | string | `0.0.0.0` | HTTP listen address |
+| `--port` | int | `8000` | HTTP listen port |
+| `--model` | string | `gemma4-e2b` | Model id exposed by `/v1/models` |
 | `--text_hbm` | string | same as `main` | Text LLM HBM |
-| `--vision_hbm` | string | same as `main` | Vision ViT HBM |
 | `--tok_embeddings` | string | same as `main` | Token embedding table |
-| `--max_tokens` | int | `128` | Max new tokens per request |
+| `--tokenizer_path` | string | same as `main` | HF tokenizer JSON |
+| `--max_tokens` | int | `0` | Default output limit; `0` uses all capacity remaining after the prompt |
+| `--min_response_tokens` | int | `256` | Reply capacity preserved while trimming old complete turns |
+| `--request_limit_mb` | int | `4` | Maximum HTTP request body size |
 
 ### `gemma4_text_bench` — text-only throughput / smoke test
 
@@ -212,6 +274,10 @@ Pass `--help` to any binary to see the gflags-generated full help.
 4. **Zero-copy KV cache** — KV cache memory is allocated once and shared between prefill and decode via pointer assignment, avoiding per-step memcpy.
 
 5. **Chunked prefill** — Prompts longer than `chunk_size=256` tokens are automatically split into multiple prefill chunks.
+
+6. **Full KV budgeting** — The interactive entry computes the output limit from the current prompt, can use the cache through `4096/4096`, and trims history by complete turns on the next request.
+
+7. **Unified dual-model lifecycle** — `main` always loads Vision before Text and keeps both resident for the process lifetime. This order avoids the S600 cross-core IOVA mapping conflict while preserving identical chat control flow on S100, S100P, and S600; only the matching HBMs, CMake SoC macros, and `run.sh` environment setup differ.
 
 ## Verification
 

--- a/samples/llm/gemma4-e2b/runtime/cpp/README.md
+++ b/samples/llm/gemma4-e2b/runtime/cpp/README.md
@@ -81,7 +81,7 @@ make -j$(nproc)
 
 The first build downloads and compiles `tokenizers-cpp` (HF tokenizers Rust
 binding + sentencepiece + abseil), which takes a few minutes. Subsequent
-builds are incremental and fast. The Rust binding requires Rust 1.79 or
+builds are incremental and fast. The Rust binding requires Rust 1.80 or
 newer; if the system toolchain is older, the installer places the current
 stable rustup toolchain under `$HOME/.cargo`.
 

--- a/samples/llm/gemma4-e2b/runtime/cpp/README_cn.md
+++ b/samples/llm/gemma4-e2b/runtime/cpp/README_cn.md
@@ -2,13 +2,13 @@
 
 **中文** | [English](./README.md)
 
-S100P 板端 Gemma4-E2B VLM 推理 C++ runtime，加载预编译 HBM 模型在 BPU 上跑实时视觉语言推理。
+RDK S100P / S600 板端 Gemma4-E2B VLM 推理 C++ runtime，加载与对应 SoC 匹配的预编译 HBM 模型，在 BPU 上运行实时视觉语言推理。
 
 > 属于 [Gemma4-E2B 示例](../../README_cn.md)。完整上游项目：[gemma4-e2b-rdk-s100p](https://github.com/shockley6668/gemma4-e2b-rdk-s100p)。
 
 ## 前置条件
 
-板子需安装 OE-LLM runtime：
+板端需安装 OE-LLM runtime：
 
 ```bash
 # 检查 Horizon BPU SDK
@@ -20,7 +20,7 @@ ls /usr/include/hobot/dnn/hb_dnn.h
 系统依赖：
 
 ```bash
-sudo apt install cmake g++ libopencv-dev libgflags-dev nlohmann-json3-dev cargo wget
+sudo apt install cmake g++ libopencv-dev libgflags-dev nlohmann-json3-dev cargo wget git curl
 ```
 
 > **无需 Python**。分词走原生 C++ `tokenizers-cpp`（构建时下载，见 `third_party/README_cn.md`），与 OpenExplorer_LLM-s600 参考实现一致。
@@ -59,8 +59,14 @@ runtime/cpp/                            C++ 源码（本目录）
 
 ```bash
 cd samples/llm/gemma4-e2b/runtime/cpp
-./run.sh
+./run.sh                              # 交互式 main
+./run.sh server --port=8000           # OpenAI 兼容 HTTP API
+./run.sh demo text --prompt "Hello"  # 单次诊断
 ```
+
+首个参数若以 `-` 开头，会直接传给 `main`。使用 `server`、`demo`、
+`text_bench` 或 `golden_verify` 可选择其他可执行文件，同时复用相同的
+依赖安装、模型下载和编译流程。
 
 手动编译：
 
@@ -71,7 +77,13 @@ cmake ..
 make -j$(nproc)
 ```
 
-首次编译会下载并构建 `tokenizers-cpp`（HF tokenizers Rust 绑定 + sentencepiece + abseil），耗时数分钟；之后增量编译很快。
+首次编译会下载并构建 `tokenizers-cpp`（HF tokenizers Rust 绑定 + sentencepiece + abseil），耗时数分钟；之后增量编译很快。 Rust binding 需要 Rust 1.79 或更高版本；若系统工具链过旧，安装脚本会在 `$HOME/.cargo` 下安装当前稳定版 rustup 工具链。
+
+离线环境若已安装独立 Abseil，可避免 SentencePiece 再次联网下载：
+
+```bash
+GEMMA4_ABSL_PREFIX=/opt/abseil ./run.sh
+```
 
 产出 5 个可执行文件：
 
@@ -90,12 +102,12 @@ export GEMMA4_HOME=~/gemma4_e2b
 bash ../../model/download_model.sh
 ```
 
-脚本从地瓜机器人模型服务器下载 3 个运行模型文件和 2 个必需的 tokenizer 文件。
+S100P 与 S600 会下载各自已验证的公共 HBM，以及共享 embedding 和 tokenizer。S100 需预置匹配的 HBM，或设置 `GEMMA4_MODEL_BASE_URL`；缺失的共享文件仍会自动下载。
 
 ```
 ~/gemma4_e2b/
 ├── model/
-│   ├── gemma4-e2b_vit_ptq.hbm                          # 329 MB  Vision
+│   ├── gemma4-e2b_vit_ptq.hbm                          # 329-377 MB Vision
 │   ├── gemma4-e2b_lm_chunk_256_cache_4096_ptq.hbm      # 4.5 GB  Text
 │   └── tok_embeddings.bin                               # 1.5 GB  Embedding
 └── tokenizer/
@@ -110,12 +122,17 @@ bash ../../model/download_model.sh
 ```bash
 export GEMMA4_HOME=~/gemma4_e2b
 
+# S600 手动启动时使用系统 DNN runtime；run.sh 会自动设置这些环境变量
+unset LD_LIBRARY_PATH GEMMA4_USE_DNN_V3
+export HB_DNN_USER_DEFINED_L2M_SIZES=6:6:6:6
+
 # 交互式 VLM 对话（零参数即可，默认从 $GEMMA4_HOME 解析路径）
 ./main
 
 # 对话内命令：
 #   /image /path/to/photo.jpg        为下一条消息加载图片
 #   你看到了什么？                    提问
+#   /context                          查看 KV cache 使用量
 #   /reset                            清空对话
 #   /quit                             退出
 ```
@@ -130,6 +147,16 @@ gemma4> 描述这张图片
 This is a photograph of a Red Panda resting on a wooden structure...
 ```
 
+### 4096-token 上下文
+
+- Text HBM 的总容量固定为 4096 tokens，约束是 `prompt_tokens + output_tokens <= 4096`。
+- `main` 和 `gemma4_server` 默认都使用 `--max_tokens=0`，表示每轮自动使用当前 prompt 之后的全部剩余容量；短 prompt 最多可获得接近 4096 tokens 的输出预算。
+- 新一轮至少为回复保留 `--min_response_tokens`（默认 256）个 token；空间不足时按完整 user/assistant 对裁掉最旧历史并重建 KV cache。
+- `/context` 显示当前使用量、剩余容量和轮数。停止 token 不会显示或写入 assistant 正文。
+- `main` 在进入交互循环前统一加载 Text 和 Vision，两者在整个会话期间常驻；S100/S100P/S600 共用同一生命周期，`/image` 只执行图片预处理和 Vision 推理，不会重新加载模型。
+- 图文追问会保留原始图片轮，并在当前用户问题旁再次显式注入同一组 Vision 特征；prompt 中最多包含两个 280-token 图片块。
+- 运行时默认不打印内部诊断；仅当设置 `GEMMA4_DEBUG=1` 时输出 `[DEBUG]` / `[VLM-FIX]` 信息。
+
 ## 命令行参数
 
 5 个可执行文件统一使用 [gflags](https://github.com/gflags/gflags) 解析命令行，参数名采用 `snake_case`（与 Model Zoo 规范一致）。每个参数都有合理默认值，导出 `GEMMA4_HOME` 后零参数即可运行。
@@ -142,7 +169,8 @@ This is a photograph of a Red Panda resting on a wooden structure...
 | `--vision_hbm` | string | `$GEMMA4_HOME/model/gemma4-e2b_vit_ptq.hbm` | Vision ViT HBM 路径 |
 | `--tok_embeddings` | string | `$GEMMA4_HOME/model/tok_embeddings.bin` | 外挂 token embedding 表 |
 | `--tokenizer_path` | string | `$GEMMA4_HOME/tokenizer/tokenizer.json` | HF tokenizer JSON |
-| `--max_tokens` | int | `4096`（`kCacheLen`） | 每轮最多生成 token 数 |
+| `--max_tokens` | int | `0` | 每轮最多生成 token 数；`0` 表示使用 prompt 后全部剩余 KV 容量 |
+| `--min_response_tokens` | int | `256` | 自动裁剪旧历史时为新回复保留的最小容量 |
 
 ### `gemma4_demo` — 单次文本或 VLM 推理
 
@@ -159,14 +187,44 @@ This is a photograph of a Red Panda resting on a wooden structure...
 | `--image_path` | string | `""` | 图片路径（vlm 模式必填） |
 | `--max_tokens` | int | `32` | 最多生成 token 数 |
 
-### `gemma4_server` — 长驻对话服务
+### `gemma4_server` — OpenAI 兼容文本服务
+
+`gemma4_server` 常驻加载 Text HBM，并提供串行的 OpenAI 兼容 HTTP API。连续请求的 token 前缀一致时会复用 KV cache。该接口仅支持文本；如果请求中包含图片会返回 HTTP 400，图文对话继续使用交互式 `main`。
+
+~~~bash
+cd samples/llm/gemma4-e2b/runtime/cpp
+./run.sh server --host=0.0.0.0 --port=8000
+~~~
+
+| 方法 | 接口 | 说明 |
+|---|---|---|
+| `GET` | `/health` | 就绪状态、模型名、上下文长度和已缓存 token 数 |
+| `GET` | `/v1/models` | OpenAI 兼容模型列表 |
+| `POST` | `/v1/chat/completions` | 普通 JSON 或 SSE 流式对话 |
+
+普通请求示例：
+
+~~~bash
+curl http://127.0.0.1:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model":"gemma4-e2b","messages":[{"role":"user","content":"请详细介绍 RDK S600。"}],"max_tokens":0}'
+~~~
+
+`max_tokens: 0` 是本样例扩展，表示使用固定 4096-token KV cache 中 prompt 之后的全部剩余容量。需要 SSE 时加入 `"stream": true`，同时支持 `stream_options.include_usage`。
+
+ChatBox 中选择 OpenAI 兼容接口，Base URL 填 `http://板端IP:8000/v1`，模型名填 `gemma4-e2b`。如果客户端强制要求 API Key，填任意非空占位值即可，服务端不会校验 `Authorization` 请求头。
 
 | 参数 | 类型 | 默认值 | 说明 |
 |---|---|---|---|
+| `--host` | string | `0.0.0.0` | HTTP 监听地址 |
+| `--port` | int | `8000` | HTTP 监听端口 |
+| `--model` | string | `gemma4-e2b` | `/v1/models` 返回的模型名 |
 | `--text_hbm` | string | 同 `main` | Text LLM HBM |
-| `--vision_hbm` | string | 同 `main` | Vision ViT HBM |
 | `--tok_embeddings` | string | 同 `main` | Token embedding 表 |
-| `--max_tokens` | int | `128` | 每次请求最多生成 token 数 |
+| `--tokenizer_path` | string | 同 `main` | HF tokenizer JSON |
+| `--max_tokens` | int | `0` | 默认输出上限；`0` 表示使用 prompt 后全部剩余容量 |
+| `--min_response_tokens` | int | `256` | 裁剪旧完整轮次时为回复保留的容量 |
+| `--request_limit_mb` | int | `4` | HTTP 请求体大小上限 |
 
 ### `gemma4_text_bench` — 纯文本吞吐 / 烟雾测试
 
@@ -204,6 +262,10 @@ This is a photograph of a Red Panda resting on a wooden structure...
 4. **零拷贝 KV cache** — KV cache 内存只分配一次，prefill 和 decode 通过指针赋值共享，避免每步 memcpy。
 
 5. **分块 prefill** — 超过 `chunk_size=256` token 的 prompt 自动拆成多个 prefill chunk。
+
+6. **完整 KV 预算** — 交互入口按当前 prompt 动态计算输出上限，可精确使用到 `4096/4096`，下一轮再按完整对话轮次裁剪旧历史。
+
+7. **统一双模型生命周期** — `main` 启动时统一按 Vision→Text 顺序加载两个模型，并在整个进程内常驻。该顺序避免 S600 跨 core IOVA 映射冲突，同时 S100/S100P/S600 共用完全相同的聊天主流程；板型差异只体现在匹配的 HBM、CMake SoC 宏和 `run.sh` 环境设置。
 
 ## 验证
 

--- a/samples/llm/gemma4-e2b/runtime/cpp/README_cn.md
+++ b/samples/llm/gemma4-e2b/runtime/cpp/README_cn.md
@@ -77,7 +77,7 @@ cmake ..
 make -j$(nproc)
 ```
 
-首次编译会下载并构建 `tokenizers-cpp`（HF tokenizers Rust 绑定 + sentencepiece + abseil），耗时数分钟；之后增量编译很快。 Rust binding 需要 Rust 1.79 或更高版本；若系统工具链过旧，安装脚本会在 `$HOME/.cargo` 下安装当前稳定版 rustup 工具链。
+首次编译会下载并构建 `tokenizers-cpp`（HF tokenizers Rust 绑定 + sentencepiece + abseil），耗时数分钟；之后增量编译很快。 Rust binding 需要 Rust 1.80 或更高版本；若系统工具链过旧，安装脚本会在 `$HOME/.cargo` 下安装当前稳定版 rustup 工具链。
 
 离线环境若已安装独立 Abseil，可避免 SentencePiece 再次联网下载：
 

--- a/samples/llm/gemma4-e2b/runtime/cpp/inc/gemma4_config.hpp
+++ b/samples/llm/gemma4-e2b/runtime/cpp/inc/gemma4_config.hpp
@@ -10,9 +10,24 @@
 #pragma once
 
 #include <cstdint>
+#include <cstdlib>
+#include <string_view>
 #include <vector>
 
 namespace gemma4 {
+
+inline bool RuntimeDebugEnabled() {
+  static const bool enabled = [] {
+    const char* value = std::getenv("GEMMA4_DEBUG");
+    if (value == nullptr) {
+      return false;
+    }
+    const std::string_view setting(value);
+    return !setting.empty() && setting != "0" && setting != "false" &&
+           setting != "FALSE";
+  }();
+  return enabled;
+}
 
 constexpr int kChunkSize = 256;
 constexpr int kCacheLen = 4096;
@@ -43,17 +58,26 @@ constexpr int kHeadDims[kNumKvLayers] = {
 };
 
 // Input tensor indices that need cache flush before each BPU inference.
-// KV cache tensors (indices 5..34) are BPU-owned and don't need CPU flush.
+// The runtime rolls newly produced KV rows into inputs 5..34 on CPU, so all
+// text inputs must be cleaned before the BPU reads them again.
 constexpr int kKvInputStart = 5;  // first KV cache input tensor index
 constexpr int kLogitsOutputIndex = 0;
 
-// Indices to flush: embedding, token_ids, position_ids, full_mask, sliding_mask
+inline std::vector<int> TextInputFlushIndices() {
+  std::vector<int> indices;
+  indices.reserve(kKvInputStart + 2 * kNumKvLayers);
+  for (int index = 0; index < kKvInputStart + 2 * kNumKvLayers; ++index) {
+    indices.push_back(index);
+  }
+  return indices;
+}
+
 inline std::vector<int> PrefillFlushIndices() {
-  return {0, 1, 2, 3, 4};
+  return TextInputFlushIndices();
 }
 
 inline std::vector<int> DecodeFlushIndices() {
-  return {0, 1, 2, 3, 4};
+  return TextInputFlushIndices();
 }
 
 }  // namespace gemma4

--- a/samples/llm/gemma4-e2b/runtime/cpp/inc/gemma4_embeddings.hpp
+++ b/samples/llm/gemma4-e2b/runtime/cpp/inc/gemma4_embeddings.hpp
@@ -17,6 +17,12 @@
 
 namespace gemma4 {
 
+/**
+ * @brief Own and query the external Gemma4-E2B token embedding table.
+ *
+ * The table is loaded once at construction and can build text-only or
+ * vision-injected hidden states for prefill.
+ */
 class TokenEmbeddings {
  public:
   explicit TokenEmbeddings(const std::string& path);

--- a/samples/llm/gemma4-e2b/runtime/cpp/inc/gemma4_kv_cache.hpp
+++ b/samples/llm/gemma4-e2b/runtime/cpp/inc/gemma4_kv_cache.hpp
@@ -21,6 +21,14 @@
 
 namespace gemma4 {
 
+/**
+ * @brief Own the per-layer BPU key-value cache for one text session.
+ *
+ * The cache exposes model input buffers, appends prefill/decode outputs, and
+ * compacts retained tokens after whole conversation turns are removed.
+ *
+ * @note Instances are not thread-safe.
+ */
 class KvCache {
  public:
   KvCache();

--- a/samples/llm/gemma4-e2b/runtime/cpp/inc/gemma4_kv_cache.hpp
+++ b/samples/llm/gemma4-e2b/runtime/cpp/inc/gemma4_kv_cache.hpp
@@ -37,42 +37,81 @@ class KvCache {
   KvCache(const KvCache&) = delete;
   KvCache& operator=(const KvCache&) = delete;
 
+  /// Physical cache offset where the next token will be written.
   int CacheStart() const { return cache_start_; }
+  /// Number of tokens currently occupied in the cache.
   int OccupiedLen() const { return occupied_len_; }
 
+  /// Mutable key-tensor pointer for decoder layer @p i.
   int8_t* KLayer(int i) { return static_cast<int8_t*>(k_mem_[i].virAddr); }
+  /// Mutable value-tensor pointer for decoder layer @p i.
   int8_t* VLayer(int i) { return static_cast<int8_t*>(v_mem_[i].virAddr); }
+  /// Const key-tensor pointer for decoder layer @p i.
   const int8_t* KLayer(int i) const {
     return static_cast<const int8_t*>(k_mem_[i].virAddr);
   }
+  /// Const value-tensor pointer for decoder layer @p i.
   const int8_t* VLayer(int i) const {
     return static_cast<const int8_t*>(v_mem_[i].virAddr);
   }
 
+  /// Mutable UCP memory struct for decoder layer @p i (keys).
   hbUCPSysMem& KMem(int i) { return k_mem_[i]; }
+  /// Mutable UCP memory struct for decoder layer @p i (values).
   hbUCPSysMem& VMem(int i) { return v_mem_[i]; }
 
+  /// Clear all cache state and release layer memory.
   void Reset();
 
-  // Allocate BPU-compatible memory for all KV layers using per-layer aligned sizes.
-  // k_bytes[i] and v_bytes[i] are the alignedByteSize from the model's input tensor.
+  /**
+   * @brief Allocate BPU-compatible memory for all KV layers.
+   *
+   * @param k_bytes Per-layer aligned key-byte sizes (from model inputs).
+   * @param v_bytes Per-layer aligned value-byte sizes (from model inputs).
+   */
   void Allocate(const std::vector<int64_t>& k_bytes,
                 const std::vector<int64_t>& v_bytes);
 
+  /**
+   * @brief Copy a prefill chunk's K/V outputs into the cache.
+   *
+   * @param k_outs Per-layer key output pointers.
+   * @param v_outs Per-layer value output pointers.
+   * @param row_strides Per-layer output row stride in bytes.
+   * @param chunk_start Global token offset where the chunk begins.
+   * @param chunk_valid Number of valid tokens in the chunk.
+   */
   void AppendPrefillChunk(const int8_t* const* k_outs, const int8_t* const* v_outs,
                           const int64_t* row_strides, int chunk_start,
                           int chunk_valid);
 
+  /**
+   * @brief Copy one decode step's K/V output into the cache.
+   *
+   * @param k_outs Per-layer key output pointers.
+   * @param v_outs Per-layer value output pointers.
+   * @param row_strides Per-layer output row stride in bytes.
+   * @param global_pos Global token position being decoded.
+   */
   void AppendDecodeStep(const int8_t* const* k_outs, const int8_t* const* v_outs,
                         const int64_t* row_strides, int global_pos);
 
+  /// Map a global token position to its physical cache index.
   int PhysicalIndex(int global_pos) const;
 
+  /// Set the number of occupied tokens directly.
   void SetOccupiedLen(int len) { occupied_len_ = len; }
 
-  // Compact KV cache: keep [0, n_keep) and [n_keep+discard, occupied_len_).
-  // Physically moves the tail portion to start at physical index n_keep.
-  // Updates occupied_len_ and phys_of_global_ accordingly.
+  /**
+   * @brief Compact the cache to drop a middle range of tokens.
+   *
+   * Keeps [0, n_keep) and [n_keep+discard, occupied_len_), moving the tail
+   * physically to start at index @p n_keep and updating the global→physical
+   * mapping.
+   *
+   * @param n_keep Number of leading tokens preserved.
+   * @param discard Number of tokens discarded after the preserved prefix.
+   */
   void CompactShift(int n_keep, int discard);
 
  private:

--- a/samples/llm/gemma4-e2b/runtime/cpp/inc/gemma4_native_tokenizer.hpp
+++ b/samples/llm/gemma4-e2b/runtime/cpp/inc/gemma4_native_tokenizer.hpp
@@ -3,6 +3,16 @@
  * All rights reserved
  */
 
+/**
+ * @file gemma4_native_tokenizer.hpp
+ * @brief Declare the native tokenizers-cpp wrapper used by Gemma4-E2B.
+ *
+ * The wrapper exposes encoding, decoding, vocabulary lookup, and incremental
+ * decoding helpers for the board-side C++ runtime.
+ *
+ * @note Tokenizer instances serialize incremental decoding state internally.
+ */
+
 #pragma once
 
 #include <memory>
@@ -15,6 +25,9 @@
 
 namespace gemma4 {
 
+/**
+ * @brief Describe a shared native tokenizer instance and its metadata.
+ */
 struct TokenizerInfo {
   std::string tokenizer_path;
   std::shared_ptr<tokenizers::Tokenizer> tokenizer;
@@ -23,6 +36,12 @@ struct TokenizerInfo {
   size_t ref_count;
 };
 
+/**
+ * @brief Encode and decode Gemma4-E2B tokens through tokenizers-cpp.
+ *
+ * Instances share loaded tokenizer resources while retaining independent
+ * incremental decoding buffers.
+ */
 class Tokenizer {
  public:
   Tokenizer() = default;

--- a/samples/llm/gemma4-e2b/runtime/cpp/inc/gemma4_native_tokenizer.hpp
+++ b/samples/llm/gemma4-e2b/runtime/cpp/inc/gemma4_native_tokenizer.hpp
@@ -1,6 +1,9 @@
 /*
  * Copyright (C) 2024 Shanghai Gua Technology Co., Ltd.
  * All rights reserved
+ *
+ * This header is adapted from the reference OpenExplorer_LLM-s600
+ * tokenizer stack and retains the original third-party copyright notice.
  */
 
 /**
@@ -106,9 +109,24 @@ class Tokenizer {
    */
   size_t GetVocabSize() const { return tokenizer_->GetVocabSize(); }
 
-  // TODO(cdliang): 这两个接口不对输出的token做后处理
-  //                第三方库(tokenizers)也分为Decode/ IdToToken 两种
+  /**
+   * @brief Map a single token ID to its raw token string.
+   *
+   * @note Unlike @ref Decode, this returns the raw token without any
+   *       post-processing (e.g. ignore-special-token handling). The
+   *       underlying tokenizers library exposes both Decode and IdToToken.
+   *
+   * @param token_id Input token ID.
+   * @return Raw token string for the given ID.
+   */
   std::string IdToToken(int32_t token_id) const;
+
+  /**
+   * @brief Map a raw token string to its token ID.
+   *
+   * @param token Input token string.
+   * @return Token ID for the given string.
+   */
   int32_t TokenToId(std::string const &token) const;
 
   int32_t inline eos_token_id() const { return stop_token_id_; }

--- a/samples/llm/gemma4-e2b/runtime/cpp/inc/gemma4_text_engine.hpp
+++ b/samples/llm/gemma4-e2b/runtime/cpp/inc/gemma4_text_engine.hpp
@@ -1,9 +1,9 @@
 /**
- * @file gemma4_text_engine.h
+ * @file gemma4_text_engine.hpp
  * @brief Text LLM engine for Gemma4-E2B (prefill + decode + KV cache).
  *
- * Wraps the Horizon BPU DNN APIs to run the Gemma4-E2B text decoder on the
- * S100P BPU. Manages prefill (chunked) and decode steps, zero-copy KV cache,
+ * Wraps the Horizon BPU DNN APIs to run the Gemma4-E2B text decoder on
+ * supported RDK S targets. Manages prefill (chunked) and decode steps, zero-copy KV cache,
  * and logits→token sampling.
  */
 #pragma once
@@ -31,6 +31,9 @@ struct BenchmarkResult {
   double tokens_per_sec = 0;   ///< Decode throughput (tokens/sec)
 };
 
+/**
+ * @brief Hold one exported prefill chunk for conversion/runtime verification.
+ */
 struct PrefillChunkTensors {
   std::vector<int64_t> input_ids;
   std::vector<int32_t> position_ids;
@@ -39,6 +42,9 @@ struct PrefillChunkTensors {
   std::vector<float> sliding_mask;
 };
 
+/**
+ * @brief Own the DNN handle and tensors for one compiled text subgraph.
+ */
 struct ModelIo {
   hbDNNHandle_t handle = nullptr;
   std::vector<hbDNNTensor> inputs;
@@ -49,6 +55,12 @@ struct ModelIo {
 // Called for each newly generated token id. Return false to stop early.
 using TokenCallback = std::function<bool(int64_t token_id)>;
 
+/**
+ * @brief Run Gemma4-E2B text generation with reusable KV-cache state.
+ *
+ * A TextEngine owns the prefill/decode models, embedding table, and one chat
+ * session. Callers must serialize access to an instance.
+ */
 class TextEngine {
  public:
   TextEngine(const std::string& text_hbm, const std::string& embed_path);

--- a/samples/llm/gemma4-e2b/runtime/cpp/inc/gemma4_text_engine.hpp
+++ b/samples/llm/gemma4-e2b/runtime/cpp/inc/gemma4_text_engine.hpp
@@ -69,61 +69,159 @@ class TextEngine {
   TextEngine(const TextEngine&) = delete;
   TextEngine& operator=(const TextEngine&) = delete;
 
+  /**
+   * @brief Run one-shot greedy text generation for a prompt.
+   *
+   * @param prompt_ids Token IDs of the prompt.
+   * @param max_new_tokens Maximum number of new tokens to generate.
+   *
+   * @return Generated token IDs (excluding the prompt).
+   */
   std::vector<int64_t> Generate(const std::vector<int64_t>& prompt_ids,
                                 int max_new_tokens);
 
-  // Streaming version: calls on_token for each generated token.
+  /**
+   * @brief Generate text with a per-token streaming callback.
+   *
+   * @param prompt_ids Token IDs of the prompt.
+   * @param max_new_tokens Maximum number of new tokens to generate.
+   * @param on_token Callback invoked with each newly generated token ID.
+   *        Returning false stops generation early.
+   *
+   * @return Generated token IDs (excluding the prompt).
+   */
   std::vector<int64_t> GenerateStream(const std::vector<int64_t>& prompt_ids,
                                        int max_new_tokens, TokenCallback on_token);
 
+  /**
+   * @brief Generate text starting from prebuilt prompt hidden states.
+   *
+   * @param prompt_ids Token IDs of the prompt.
+   * @param prompt_hidden Prebuilt inputs_embeds for the prompt.
+   * @param max_new_tokens Maximum number of new tokens to generate.
+   *
+   * @return Generated token IDs (excluding the prompt).
+   */
   std::vector<int64_t> GenerateWithPromptEmbeddings(
       const std::vector<int64_t>& prompt_ids,
       const std::vector<float>& prompt_hidden, int max_new_tokens);
 
-  // Incremental chat: prefill only new suffix, keep KV cache.
+  /**
+   * @brief Incremental chat generation reusing the existing KV cache.
+   *
+   * Prefills only the new suffix of @p full_ids and keeps the previous KV
+   * cache intact, enabling multi-turn chat without re-encoding history.
+   *
+   * @param full_ids Full token sequence including prior context.
+   * @param max_new_tokens Maximum number of new tokens to generate.
+   * @param full_hidden Optional prebuilt hidden states for the suffix.
+   *
+   * @return Generated token IDs.
+   */
   std::vector<int64_t> ContinueGenerate(
       const std::vector<int64_t>& full_ids, int max_new_tokens,
       const std::vector<float>* full_hidden = nullptr);
 
-  // Streaming incremental generation.
+  /**
+   * @brief Streaming variant of @ref ContinueGenerate.
+   *
+   * @param full_ids Full token sequence including prior context.
+   * @param max_new_tokens Maximum number of new tokens to generate.
+   * @param on_token Per-token streaming callback.
+   * @param full_hidden Optional prebuilt hidden states for the suffix.
+   *
+   * @return Generated token IDs.
+   */
   std::vector<int64_t> ContinueGenerateStream(
       const std::vector<int64_t>& full_ids, int max_new_tokens,
       TokenCallback on_token,
       const std::vector<float>* full_hidden = nullptr);
 
+  /// Clear all KV-cache and session state.
   void ResetSession();
 
+  /// Number of tokens currently processed and held in the KV cache.
   int ProcessedTokens() const { return processed_tokens_; }
 
   // Context management for multi-turn chat
+  /// Set the number of leading tokens preserved during a context shift.
   void SetKeepTokens(int n) { n_keep_ = n; }
+  /// Number of leading tokens preserved during a context shift.
   int KeepTokens() const { return n_keep_; }
 
-  // Perform context shift: keep first n_keep tokens, discard middle,
-  // and compact KV cache. Returns the number of tokens discarded.
+  /**
+   * @brief Compact the KV cache to make room for new context.
+   *
+   * Keeps the first @p n_keep tokens, discards the middle, and compacts the
+   * KV cache so generation can continue without exceeding capacity.
+   *
+   * @param n_keep Number of leading tokens to preserve.
+   *
+   * @return Number of tokens discarded.
+   */
   int ContextShift(int n_keep);
 
-  // Check if new tokens would exceed capacity and auto-truncate if needed.
-  // Returns true if truncation occurred.
+  /**
+   * @brief Check whether new tokens would exceed KV capacity.
+   *
+   * Auto-truncates the pending input if needed so generation stays within
+   * the fixed cache length.
+   *
+   * @param new_prompt_tokens Number of prompt tokens about to be added.
+   * @param max_new_tokens Requested output length.
+   *
+   * @return True if truncation occurred.
+   */
   bool AutoTruncate(int new_prompt_tokens, int max_new_tokens);
 
   // Chat history management
+  /// Append a full turn (e.g. user+assistant tokens) to chat history.
   void AddToHistory(const std::vector<int64_t>& tokens);
+  /// Clear the chat history used for truncation decisions.
   void ClearHistory();
+  /// Full chat history accumulated for truncation decisions.
   const std::vector<int64_t>& GetHistory() const { return chat_history_; }
 
+  /**
+   * @brief Build prompt hidden states by injecting vision features.
+   *
+   * @param prompt_ids Token IDs of the text prompt.
+   * @param vision_features Vision soft-token features to inject.
+   *
+   * @return inputs_embeds for the full prompt.
+   */
   std::vector<float> BuildPromptHidden(
       const std::vector<int64_t>& prompt_ids,
       const std::vector<float>& vision_features) const;
 
-  // Build prefill tensors without running BPU (for golden_mask_kv alignment).
+  /**
+   * @brief Export one prefill chunk's tensors without running the BPU.
+   *
+   * Used for golden mask/KV alignment verification against PC-side data.
+   *
+   * @param prompt_ids Full prompt token IDs.
+   * @param chunk_start Start offset of the chunk within the prompt.
+   * @param chunk_valid Number of valid tokens in the chunk.
+   *
+   * @return The exported chunk tensors.
+   */
   PrefillChunkTensors ExportPrefillChunk(const std::vector<int64_t>& prompt_ids,
                                          int chunk_start,
                                          int chunk_valid) const;
 
+  /**
+   * @brief Benchmark prefill and decode latency for a prompt.
+   *
+   * @param prompt_ids Token IDs of the prompt.
+   * @param max_new_tokens Number of decode steps to time.
+   * @param warmup_decode Decode warmup steps performed before timing.
+   *
+   * @return Benchmark timing result.
+   */
   BenchmarkResult Benchmark(const std::vector<int64_t>& prompt_ids,
                             int max_new_tokens, int warmup_decode = 0);
 
+  /// Model load time in milliseconds.
   double LoadMs() const { return load_ms_; }
 
  private:

--- a/samples/llm/gemma4-e2b/runtime/cpp/inc/gemma4_tokenizer.hpp
+++ b/samples/llm/gemma4-e2b/runtime/cpp/inc/gemma4_tokenizer.hpp
@@ -1,5 +1,5 @@
 /**
- * @file gemma4_tokenizer.h
+ * @file gemma4_tokenizer.hpp
  * @brief Tokenizer bridge backed by native C++ tokenizers-cpp.
  *
  * Keeps the original TokenizerBridge API (EncodeMessagesJson / DecodeIds)

--- a/samples/llm/gemma4-e2b/runtime/cpp/inc/gemma4_vision_engine.hpp
+++ b/samples/llm/gemma4-e2b/runtime/cpp/inc/gemma4_vision_engine.hpp
@@ -1,5 +1,5 @@
 /**
- * @file gemma4_vision_engine.h
+ * @file gemma4_vision_engine.hpp
  * @brief Vision ViT engine for Gemma4-E2B.
  *
  * Loads the Vision HBM and runs the ViT encoder to produce 280 soft image

--- a/samples/llm/gemma4-e2b/runtime/cpp/inc/gemma4_vision_preprocess.hpp
+++ b/samples/llm/gemma4-e2b/runtime/cpp/inc/gemma4_vision_preprocess.hpp
@@ -14,6 +14,12 @@
 
 namespace gemma4 {
 
+/**
+ * @brief Load and transform an image into the vision HBM input tensor.
+ * @param image_path Path to an image readable by OpenCV.
+ * @return Flattened normalized patch tensor expected by the vision model.
+ * @throws std::runtime_error If the image cannot be loaded or transformed.
+ */
 std::vector<float> PreprocessImage(const std::string& image_path);
 
 }  // namespace gemma4

--- a/samples/llm/gemma4-e2b/runtime/cpp/inc/hb_utils.hpp
+++ b/samples/llm/gemma4-e2b/runtime/cpp/inc/hb_utils.hpp
@@ -12,6 +12,9 @@
  */
 #pragma once
 
+#include <dlfcn.h>
+
+#include <cstdlib>
 #include <cstdint>
 #include <cstring>
 #include <functional>
@@ -155,8 +158,62 @@ inline void FreeTensors(std::vector<hbDNNTensor>& tensors) {
   tensors.clear();
 }
 
-// OE model_inference flow: hbDNNInferV2 -> hbUCPSubmitTask -> hbUCPWaitTaskDone
-// -> hbDNNGetTaskOutputTensorProperties -> hbUCPReleaseTask
+/**
+ * @brief Mirror the optional DNN V3 inference parameter ABI.
+ *
+ * The compatibility layout allows the sample to select V2 or V3 inference
+ * without requiring newer SDK headers on every supported board image.
+ */
+struct DNNInferV3ParamCompat {
+  bool enable_pre_submit{false};
+  bool enable_poll{false};
+};
+
+using DNNInferV3Fn = int32_t (*)(hbUCPTaskHandle_t*, hbDNNTensor*,
+                                const hbDNNTensor*, hbDNNHandle_t,
+                                const DNNInferV3ParamCompat*);
+
+inline int32_t DNNInfer(hbUCPTaskHandle_t* task, hbDNNTensor* outputs,
+                        const hbDNNTensor* inputs, hbDNNHandle_t handle) {
+#if defined(SOC_S600)
+  if (std::getenv("HB_DNN_USER_DEFINED_L2M_SIZES") == nullptr) {
+    setenv("HB_DNN_USER_DEFINED_L2M_SIZES", "6:6:6:6", 0);
+  }
+#endif
+  const char* use_v3 = std::getenv("GEMMA4_USE_DNN_V3");
+  if (use_v3 != nullptr && std::strcmp(use_v3, "1") == 0) {
+    static const auto infer_v3 = reinterpret_cast<DNNInferV3Fn>(
+        dlsym(RTLD_DEFAULT, "hbDNNInferV3"));
+    if (infer_v3 != nullptr) {
+      const DNNInferV3ParamCompat params{};
+      return infer_v3(task, outputs, inputs, handle, &params);
+    }
+  }
+  return hbDNNInferV2(task, outputs, inputs, handle);
+}
+
+inline uint64_t DNNBpuBackend(hbDNNHandle_t handle) {
+#if defined(SOC_S600)
+  int32_t core_count = 0;
+  HBDNN_CHECK(hbDNNGetCompileBpuCoreNum(&core_count, handle),
+              "get compile BPU core count");
+  if (core_count < 1 || core_count > 4) {
+    throw std::runtime_error("unsupported BPU core count " +
+                             std::to_string(core_count));
+  }
+  uint64_t backend = 0;
+  for (int32_t core = 0; core < core_count; ++core) {
+    backend |= HB_UCP_BPU_CORE_0 << core;
+  }
+  return backend;
+#else
+  static_cast<void>(handle);
+  return HB_UCP_BPU_CORE_ANY;
+#endif
+}
+
+// OE model_inference flow: hbDNNInferV2 (or opt-in V3) -> hbUCPSubmitTask
+// -> hbUCPWaitTaskDone -> hbDNNGetTaskOutputTensorProperties -> hbUCPReleaseTask
 // Flushes ALL input tensors before inference and ALL output tensors after.
 inline void RunInfer(hbDNNHandle_t handle, std::vector<hbDNNTensor>& inputs,
                      std::vector<hbDNNTensor>& outputs) {
@@ -165,11 +222,11 @@ inline void RunInfer(hbDNNHandle_t handle, std::vector<hbDNNTensor>& inputs,
   }
 
   hbUCPTaskHandle_t task = nullptr;
-  HBDNN_CHECK(hbDNNInferV2(&task, outputs.data(), inputs.data(), handle), "infer");
+  HBDNN_CHECK(DNNInfer(&task, outputs.data(), inputs.data(), handle), "infer");
 
   hbUCPSchedParam sched{};
   HB_UCP_INITIALIZE_SCHED_PARAM(&sched);
-  sched.backend = HB_UCP_BPU_CORE_ANY;
+  sched.backend = DNNBpuBackend(handle);
   HBUCP_CHECK(hbUCPSubmitTask(task, &sched), "submit");
   HBUCP_CHECK(hbUCPWaitTaskDone(task, 0), "wait");
 
@@ -198,11 +255,11 @@ inline void RunInferSelective(hbDNNHandle_t handle,
   }
 
   hbUCPTaskHandle_t task = nullptr;
-  HBDNN_CHECK(hbDNNInferV2(&task, outputs.data(), inputs.data(), handle), "infer");
+  HBDNN_CHECK(DNNInfer(&task, outputs.data(), inputs.data(), handle), "infer");
 
   hbUCPSchedParam sched{};
   HB_UCP_INITIALIZE_SCHED_PARAM(&sched);
-  sched.backend = HB_UCP_BPU_CORE_ANY;
+  sched.backend = DNNBpuBackend(handle);
   HBUCP_CHECK(hbUCPSubmitTask(task, &sched), "submit");
   HBUCP_CHECK(hbUCPWaitTaskDone(task, 0), "wait");
 

--- a/samples/llm/gemma4-e2b/runtime/cpp/inc/hb_utils.hpp
+++ b/samples/llm/gemma4-e2b/runtime/cpp/inc/hb_utils.hpp
@@ -46,6 +46,7 @@
     }                                                                              \
   } while (0)
 
+/// Return the byte size of one element for a Horizon tensor type.
 inline int32_t ElementSize(int32_t type) {
   switch (type) {
     case HB_DNN_TENSOR_TYPE_BOOL8:
@@ -69,6 +70,7 @@ inline int32_t ElementSize(int32_t type) {
   }
 }
 
+/// Compute the product of all dimensions (total element count).
 inline int64_t ProdSize(const int32_t* dim, int ndim) {
   int64_t p = 1;
   for (int i = 0; i < ndim; ++i) {
@@ -113,6 +115,7 @@ inline void CopyWithStridePadding(void* dst, const void* src,
   rec(dst, src, 0);
 }
 
+/// Zero the aligned memory of a tensor.
 inline void ZeroTensorMem(hbDNNTensor& tensor) {
   if (tensor.sysMem.virAddr && tensor.properties.alignedByteSize > 0) {
     std::memset(tensor.sysMem.virAddr, 0,
@@ -120,19 +123,23 @@ inline void ZeroTensorMem(hbDNNTensor& tensor) {
   }
 }
 
+/// Copy @p src into an input tensor's BPU buffer, applying stride padding.
 inline void WriteInputTensor(hbDNNTensor& tensor, const void* src) {
   ZeroTensorMem(tensor);
   CopyWithStridePadding(tensor.sysMem.virAddr, src, tensor.properties);
 }
 
+/// Flush CPU dirty cache lines before BPU reads a buffer.
 inline void FlushClean(hbUCPSysMem& mem) {
   HBUCP_CHECK(hbUCPMemFlush(&mem, HB_SYS_MEM_CACHE_CLEAN), "flush clean");
 }
 
+/// Invalidate CPU cache lines after BPU writes a buffer.
 inline void FlushInvalidate(hbUCPSysMem& mem) {
   HBUCP_CHECK(hbUCPMemFlush(&mem, HB_SYS_MEM_CACHE_INVALIDATE), "flush invalidate");
 }
 
+/// Allocate and zero a tensor buffer for a model input or output slot.
 inline hbDNNTensor MakeTensor(hbDNNHandle_t handle, bool is_input, int index) {
   hbDNNTensor tensor{};
   if (is_input) {
@@ -148,6 +155,7 @@ inline hbDNNTensor MakeTensor(hbDNNHandle_t handle, bool is_input, int index) {
   return tensor;
 }
 
+/// Release all BPU buffers owned by a tensor vector.
 inline void FreeTensors(std::vector<hbDNNTensor>& tensors) {
   for (auto& t : tensors) {
     if (t.sysMem.virAddr != nullptr) {

--- a/samples/llm/gemma4-e2b/runtime/cpp/run.sh
+++ b/samples/llm/gemma4-e2b/runtime/cpp/run.sh
@@ -4,9 +4,17 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SAMPLE_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 GEMMA4_HOME="${GEMMA4_HOME:-$HOME/gemma4_e2b}"
+BUILD_DIR="$SCRIPT_DIR/build"
+export PATH="$HOME/.cargo/bin:$PATH"
+
+# Usage:
+#   ./run.sh                              # interactive main
+#   ./run.sh --max_tokens=512             # main with gflags
+#   ./run.sh server --port=8000           # OpenAI-compatible HTTP API
+#   ./run.sh demo text --prompt "Hello"  # single-shot diagnostic
 
 # Optional proxy for git/cargo/cmake downloads (export before running):
-#   export HTTP_PROXY=http://192.168.66.115:1082 HTTPS_PROXY=$HTTP_PROXY
+#   export HTTP_PROXY=http://proxy.example.com:8080 HTTPS_PROXY=$HTTP_PROXY
 if [[ -n "${HTTP_PROXY:-}" ]]; then
   export http_proxy="${HTTP_PROXY}"
   export https_proxy="${HTTPS_PROXY:-${HTTP_PROXY}}"
@@ -18,7 +26,14 @@ if [[ -r /sys/class/boardinfo/soc_name ]]; then
   echo "SOC         : $SOC"
 fi
 
-PKGS=(cmake g++ libopencv-dev libgflags-dev nlohmann-json3-dev cargo wget)
+if [[ "$SOC" == "s600" ]]; then
+  unset LD_LIBRARY_PATH GEMMA4_USE_DNN_V3
+  export HB_DNN_USER_DEFINED_L2M_SIZES="${HB_DNN_USER_DEFINED_L2M_SIZES:-6:6:6:6}"
+  echo "DNN mode    : system runtime (V2)"
+  echo "L2M sizes   : $HB_DNN_USER_DEFINED_L2M_SIZES"
+fi
+
+PKGS=(cmake g++ libopencv-dev libgflags-dev nlohmann-json3-dev cargo wget git curl)
 need_update=false
 for pkg in "${PKGS[@]}"; do
   if ! dpkg -s "$pkg" >/dev/null 2>&1; then
@@ -28,8 +43,16 @@ for pkg in "${PKGS[@]}"; do
 done
 
 if $need_update; then
+  if command -v sudo >/dev/null 2>&1; then
+    APT=(sudo apt)
+  elif [[ ${EUID:-$(id -u)} -eq 0 ]]; then
+    APT=(apt)
+  else
+    echo "ERROR: missing packages require root privileges or sudo." >&2
+    exit 1
+  fi
   echo "Running apt update (packages missing)..."
-  sudo apt update
+  "${APT[@]}" update
 fi
 
 for pkg in "${PKGS[@]}"; do
@@ -37,7 +60,7 @@ for pkg in "${PKGS[@]}"; do
     echo "$pkg already installed"
   else
     echo "Installing $pkg..."
-    sudo apt install -y "$pkg"
+    "${APT[@]}" install -y "$pkg"
   fi
 done
 
@@ -45,29 +68,84 @@ echo "GEMMA4_HOME : $GEMMA4_HOME"
 GEMMA4_HOME="$GEMMA4_HOME" bash "$SAMPLE_ROOT/model/download_model.sh"
 bash "$SAMPLE_ROOT/third_party/install_tokenizers_cpp.sh"
 
+mkdir -p "$BUILD_DIR"
+RUST_TOOLCHAIN_ID="$(rustc --version); $(command -v cargo) $(cargo --version)"
+RUST_VERSION_FILE="$BUILD_DIR/.tokenizers-rust-version"
+PREVIOUS_RUST_TOOLCHAIN_ID="$(cat "$RUST_VERSION_FILE" 2>/dev/null || true)"
+if [[ -d "$BUILD_DIR/tokenizers-cpp/release" &&
+      ! -f "$BUILD_DIR/tokenizers-cpp/release/libtokenizers_c.a" &&
+      "$PREVIOUS_RUST_TOOLCHAIN_ID" != "$RUST_TOOLCHAIN_ID" ]]; then
+  echo "Rust toolchain changed; cleaning stale tokenizers build artifacts."
+  rm -rf "$BUILD_DIR/tokenizers-cpp/release"
+fi
+printf '%s\n' "$RUST_TOOLCHAIN_ID" > "$RUST_VERSION_FILE"
+
 # tokenizers-cpp sets CARGO_TARGET=aarch64-unknown-linux-gnu on aarch64 even
 # for native builds, so cc-rs looks for aarch64-unknown-linux-gnu-gcc. Stock
-# Ubuntu provides aarch64-linux-gnu-gcc (no "unknown"). Create symlinks so
-# the Rust build finds the compiler without patching upstream.
+# Ubuntu provides aarch64-linux-gnu-gcc (no "unknown"). Create aliases under
+# build/ so a non-root user can compile without modifying /usr/local/bin.
+mkdir -p "$BUILD_DIR"
 ARCH=$(uname -m)
 if [[ "$ARCH" == "aarch64" ]]; then
+  TOOL_ALIAS_DIR="$BUILD_DIR/toolchain_aliases"
+  mkdir -p "$TOOL_ALIAS_DIR"
   for tool in gcc g++ ar; do
     if ! command -v "aarch64-unknown-linux-gnu-$tool" >/dev/null 2>&1; then
       ln -sf "$(command -v "aarch64-linux-gnu-$tool" || command -v "$tool")" \
-             /usr/local/bin/"aarch64-unknown-linux-gnu-$tool" 2>/dev/null || true
+             "$TOOL_ALIAS_DIR/aarch64-unknown-linux-gnu-$tool"
     fi
   done
+  export PATH="$TOOL_ALIAS_DIR:$PATH"
 fi
 
-mkdir -p build
-cd build
-cmake ..
-make -j"$(nproc)"
+CMAKE_ARGS=("-DCARGO_EXECUTABLE=$(command -v cargo)")
+if [[ -n "${GEMMA4_ABSL_PREFIX:-}" ]]; then
+  ABSL_PREFIX="${GEMMA4_ABSL_PREFIX%/}"
+  CMAKE_ARGS+=(
+    -DSPM_ABSL_PROVIDER=package
+    "-DCMAKE_PREFIX_PATH=$ABSL_PREFIX"
+    "-Dabsl_DIR=$ABSL_PREFIX/lib/cmake/absl"
+  )
+fi
+cmake -S "$SCRIPT_DIR" -B "$BUILD_DIR" "${CMAKE_ARGS[@]}"
+cmake --build "$BUILD_DIR" --parallel "$(nproc)"
 
 export GEMMA4_HOME
+APP="${GEMMA4_APP:-main}"
+if [[ $# -gt 0 && "$1" != -* ]]; then
+  APP="$1"
+  shift
+fi
+case "$APP" in
+  main)
+    BINARY=main
+    ;;
+  server|gemma4_server)
+    BINARY=gemma4_server
+    ;;
+  demo|gemma4_demo)
+    BINARY=gemma4_demo
+    ;;
+  text_bench|gemma4_text_bench)
+    BINARY=gemma4_text_bench
+    ;;
+  golden_verify|gemma4_golden_verify)
+    BINARY=gemma4_golden_verify
+    ;;
+  *)
+    echo "ERROR: unknown app $APP" >&2
+    echo "Expected: main, server, demo, text_bench, or golden_verify" >&2
+    exit 2
+    ;;
+esac
+
 echo
-echo "Starting main (Ctrl+C to exit)..."
-echo "Try: /image $SAMPLE_ROOT/test_data/image1.jpg"
-echo "Then: Describe this image"
+echo "Starting $BINARY (Ctrl+C to exit)..."
+if [[ "$BINARY" == "main" ]]; then
+  echo "Try: /image $SAMPLE_ROOT/test_data/image1.jpg"
+  echo "Then: Describe this image"
+elif [[ "$BINARY" == "gemma4_server" ]]; then
+  echo "OpenAI base URL: http://<board-ip>:8000/v1"
+fi
 echo
-exec ./main
+exec "$BUILD_DIR/$BINARY" "$@"

--- a/samples/llm/gemma4-e2b/runtime/cpp/src/gemma4_demo.cpp
+++ b/samples/llm/gemma4-e2b/runtime/cpp/src/gemma4_demo.cpp
@@ -1,3 +1,11 @@
+/**
+ * @file gemma4_demo.cpp
+ * @brief Run single-shot text or vision-language Gemma4-E2B inference.
+ *
+ * This executable provides a compact diagnostic entry for text prompts and
+ * image-plus-text prompts using the shared runtime classes.
+ */
+
 #include <iostream>
 #include <cstdlib>
 #include <sstream>

--- a/samples/llm/gemma4-e2b/runtime/cpp/src/gemma4_embeddings.cpp
+++ b/samples/llm/gemma4-e2b/runtime/cpp/src/gemma4_embeddings.cpp
@@ -1,3 +1,11 @@
+/**
+ * @file gemma4_embeddings.cpp
+ * @brief Load token embeddings and construct Gemma4-E2B prompt tensors.
+ *
+ * The implementation reads the external embedding table and injects optional
+ * vision features into text prompt hidden states.
+ */
+
 #include "gemma4_embeddings.hpp"
 
 #include <algorithm>
@@ -101,16 +109,21 @@ std::vector<float> TokenEmbeddings::BuildPromptHidden(
                              " expected " + std::to_string(expected));
   }
 
-  // Debug: count image tokens in ids
-  int img_count = 0;
-  for (size_t i = 0; i < seq_len; ++i) {
-    if (ids[i] == static_cast<int64_t>(kImageTokenId)) ++img_count;
+  if (RuntimeDebugEnabled()) {
+    int image_token_count = 0;
+    for (size_t index = 0; index < seq_len; ++index) {
+      if (ids[index] == static_cast<int64_t>(kImageTokenId)) {
+        ++image_token_count;
+      }
+    }
+    fprintf(stderr,
+            "[DEBUG] BuildPromptHidden: seq_len=%zu, image_tokens=%d, "
+            "vision_features.size=%zu\n",
+            seq_len, image_token_count, vision_features.size());
   }
-  fprintf(stderr, "[DEBUG] BuildPromptHidden: seq_len=%zu, image_tokens=%d, vision_features.size=%zu\n",
-          seq_len, img_count, vision_features.size());
 
   // Debug: vision feature statistics
-  {
+  if (RuntimeDebugEnabled()) {
     double sum = 0, sq = 0;
     float vmin = vision_features[0], vmax = vision_features[0];
     for (size_t i = 0; i < vision_features.size(); ++i) {
@@ -141,8 +154,11 @@ std::vector<float> TokenEmbeddings::BuildPromptHidden(
       // PLE token-identity path uses pad embedding at image positions
       // (Gemma4Model.forward replaces image token ids with pad_token_id).
       // Vision HBM output [280,1536] is injected raw — no L2-norm / sqrt scaling.
-      fprintf(stderr, "[VLM-FIX] Injecting raw vision features at positions [%d, %d)\n",
-              run_start, run_start + kVisionSoftTokens);
+      if (RuntimeDebugEnabled()) {
+        fprintf(stderr,
+                "[DEBUG] Injecting raw vision features at positions [%d, %d)\n",
+                run_start, run_start + kVisionSoftTokens);
+      }
 
       for (int t = 0; t < kVisionSoftTokens; ++t) {
         const float* src = vision_features.data() +
@@ -152,8 +168,8 @@ std::vector<float> TokenEmbeddings::BuildPromptHidden(
         std::copy(src, src + kHiddenSize, dst);
       }
 
-      // Self-check: injected vision features std and L2/row (per fix doc §4 P0)
-      {
+      // Self-check: injected vision features std and L2/row.
+      if (RuntimeDebugEnabled()) {
         double inj_sq = 0, inj_l2_sum = 0;
         for (int t = 0; t < kVisionSoftTokens; ++t) {
           const float* row = hidden.data() +
@@ -180,7 +196,7 @@ std::vector<float> TokenEmbeddings::BuildPromptHidden(
   }
 
   // Debug: hidden buffer statistics after injection
-  {
+  if (RuntimeDebugEnabled()) {
     double sum = 0, sq = 0;
     float hmin = hidden[0], hmax = hidden[0];
     for (size_t i = 0; i < hidden.size(); ++i) {

--- a/samples/llm/gemma4-e2b/runtime/cpp/src/gemma4_golden_verify.cpp
+++ b/samples/llm/gemma4-e2b/runtime/cpp/src/gemma4_golden_verify.cpp
@@ -1,3 +1,11 @@
+/**
+ * @file gemma4_golden_verify.cpp
+ * @brief Verify Gemma4-E2B prefill tensors against reference golden data.
+ *
+ * The executable exports prefill inputs and reports numerical agreement for
+ * model-conversion and runtime-alignment diagnostics.
+ */
+
 #include <cmath>
 #include <cstdint>
 #include <cstdlib>

--- a/samples/llm/gemma4-e2b/runtime/cpp/src/gemma4_kv_cache.cpp
+++ b/samples/llm/gemma4-e2b/runtime/cpp/src/gemma4_kv_cache.cpp
@@ -1,3 +1,13 @@
+/**
+ * @file gemma4_kv_cache.cpp
+ * @brief Manage Gemma4-E2B BPU key-value cache storage and compaction.
+ *
+ * The implementation allocates cache tensors, appends prefill/decode results,
+ * and shifts retained tokens when conversation history is truncated.
+ *
+ * @note KvCache instances are not thread-safe.
+ */
+
 #include "gemma4_kv_cache.hpp"
 
 #include <algorithm>
@@ -150,29 +160,51 @@ int KvCache::PhysicalIndex(int global_pos) const {
 }
 
 void KvCache::CompactShift(int n_keep, int discard) {
-  if (discard <= 0) return;
+  if (discard <= 0) {
+    return;
+  }
 
-  // Truncate the KV cache to only keep the first n_keep tokens.
-  // The caller will re-prefill the recent history with correct positions.
-  // This is necessary because RoPE positions are baked into the int8 K cache.
-  
   if (n_keep <= 0) {
-    // Keep nothing
+    for (int layer = 0; layer < kNumKvLayers; ++layer) {
+      const size_t total_bytes = static_cast<size_t>(layer_bytes_[layer]);
+      std::memset(KLayer(layer), 0, total_bytes);
+      std::memset(VLayer(layer), 0, total_bytes);
+    }
     phys_of_global_.clear();
     occupied_len_ = 0;
     cache_start_ = 0;
     return;
   }
 
-  // Truncate phys_of_global_ to only keep [0, n_keep)
-  if (static_cast<int>(phys_of_global_.size()) > n_keep) {
-    phys_of_global_.resize(n_keep, -1);
+  const int cached_tokens = std::min(occupied_len_, kCacheLen);
+  if (n_keep > cached_tokens) {
+    throw std::runtime_error("KV compact keep exceeds cached tokens");
+  }
+
+  // KV rows are right-aligned. Move the retained prefix from the beginning of
+  // the occupied range to the end of the cache before replaying the suffix.
+  for (int layer = 0; layer < kNumKvLayers; ++layer) {
+    const size_t row_bytes = static_cast<size_t>(kHeadDims[layer]);
+    const size_t keep_bytes = static_cast<size_t>(n_keep) * row_bytes;
+    const size_t total_bytes = static_cast<size_t>(layer_bytes_[layer]);
+    const size_t source_offset =
+        total_bytes - static_cast<size_t>(cached_tokens) * row_bytes;
+    const size_t target_offset = total_bytes - keep_bytes;
+    std::memmove(KLayer(layer) + target_offset,
+                 KLayer(layer) + source_offset, keep_bytes);
+    std::memmove(VLayer(layer) + target_offset,
+                 VLayer(layer) + source_offset, keep_bytes);
+    std::memset(KLayer(layer), 0, target_offset);
+    std::memset(VLayer(layer), 0, target_offset);
+  }
+
+  phys_of_global_.assign(static_cast<size_t>(n_keep), -1);
+  const int physical_start = kCacheLen - n_keep;
+  for (int index = 0; index < n_keep; ++index) {
+    phys_of_global_[static_cast<size_t>(index)] = physical_start + index;
   }
   occupied_len_ = n_keep;
   cache_start_ = 0;
-  
-  // Note: We don't zero out the physical buffer beyond n_keep because
-  // it will be overwritten when the caller re-prefills the tail.
 }
 
 }  // namespace gemma4

--- a/samples/llm/gemma4-e2b/runtime/cpp/src/gemma4_native_tokenizer.cpp
+++ b/samples/llm/gemma4-e2b/runtime/cpp/src/gemma4_native_tokenizer.cpp
@@ -1,6 +1,9 @@
 /*
  * Copyright (C) 2024 Shanghai Gua Technology Co., Ltd.
  * All rights reserved
+ *
+ * This source is adapted from the reference OpenExplorer_LLM-s600
+ * tokenizer stack and retains the original third-party copyright notice.
  */
 
 /**

--- a/samples/llm/gemma4-e2b/runtime/cpp/src/gemma4_native_tokenizer.cpp
+++ b/samples/llm/gemma4-e2b/runtime/cpp/src/gemma4_native_tokenizer.cpp
@@ -3,6 +3,14 @@
  * All rights reserved
  */
 
+/**
+ * @file gemma4_native_tokenizer.cpp
+ * @brief Implement the native tokenizers-cpp wrapper for Gemma4-E2B.
+ *
+ * The implementation loads tokenizer metadata and provides encoding, decoding,
+ * token lookup, and incremental text reconstruction.
+ */
+
 #include "gemma4_native_tokenizer.hpp"
 
 #include <algorithm>
@@ -19,14 +27,17 @@
 
 #include <nlohmann/json.hpp>
 
+#include "gemma4_config.hpp"
+
 #define TAG "tokenizer"
 // Local logging shims (no hlog dependency).
 #define LOGE(tag, fmt, ...) fprintf(stderr, "[E][" tag "] " fmt "\n", ##__VA_ARGS__)
-#ifndef NDEBUG
-#define LOGD(tag, fmt, ...) fprintf(stderr, "[D][" tag "] " fmt "\n", ##__VA_ARGS__)
-#else
-#define LOGD(tag, fmt, ...) ((void)0)
-#endif
+#define LOGD(tag, fmt, ...)                                                   \
+  do {                                                                        \
+    if (::gemma4::RuntimeDebugEnabled()) {                                    \
+      fprintf(stderr, "[D][" tag "] " fmt "\n", ##__VA_ARGS__);             \
+    }                                                                         \
+  } while (0)
 
 namespace {
 /* @brief The method to post-process the tokens to their original strings.

--- a/samples/llm/gemma4-e2b/runtime/cpp/src/gemma4_server.cpp
+++ b/samples/llm/gemma4-e2b/runtime/cpp/src/gemma4_server.cpp
@@ -1,246 +1,935 @@
-#include <iostream>
+/**
+ * @file gemma4_server.cpp
+ * @brief OpenAI-compatible HTTP text chat server for Gemma4-E2B.
+ *
+ * Keeps the Text HBM loaded, reuses the KV cache when consecutive requests
+ * share a token prefix, and exposes /v1/chat/completions for ChatBox and other
+ * OpenAI-compatible clients. Image chat remains in the interactive main
+ * executable because this server currently implements the text-only request
+ * schema and runtime path.
+ */
+#include <algorithm>
+#include <cerrno>
+#include <cctype>
+#include <chrono>
+#include <csignal>
+#include <cstddef>
+#include <cstdint>
 #include <cstdlib>
+#include <cstring>
+#include <ctime>
+#include <functional>
+#include <iostream>
+#include <limits>
+#include <map>
 #include <memory>
-#include <optional>
 #include <sstream>
+#include <stdexcept>
 #include <string>
+#include <utility>
 #include <vector>
 
-#include "gflags/gflags.h"
+#include <netdb.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
 
+#include "gflags/gflags.h"
+#include <nlohmann/json.hpp>
+
+#include "gemma4_config.hpp"
 #include "gemma4_text_engine.hpp"
 #include "gemma4_tokenizer.hpp"
-#include "gemma4_vision_engine.hpp"
+
+// Empty path defaults are resolved from $GEMMA4_HOME.
+DEFINE_string(text_hbm, "",
+              "Path to text LLM *.hbm. Default: $GEMMA4_HOME/model/"
+              "gemma4-e2b_lm_chunk_256_cache_4096_ptq.hbm");
+DEFINE_string(tok_embeddings, "",
+              "Path to tok_embeddings.bin. Default: "
+              "$GEMMA4_HOME/model/tok_embeddings.bin");
+DEFINE_string(tokenizer_path, "",
+              "Path to tokenizer.json. Default: "
+              "$GEMMA4_HOME/tokenizer/tokenizer.json");
+DEFINE_string(host, "0.0.0.0", "HTTP listen address.");
+DEFINE_int32(port, 8000, "HTTP listen port.");
+DEFINE_string(model, "gemma4-e2b", "Model id returned by the OpenAI API.");
+DEFINE_int32(max_tokens, 0,
+             "Default maximum new tokens per request. 0 uses all KV capacity "
+             "remaining after the prompt.");
+DEFINE_int32(min_response_tokens, 256,
+             "Minimum response capacity preserved when old turns are trimmed.");
+DEFINE_int32(request_limit_mb, 4, "Maximum HTTP request body size in MiB.");
 
 namespace {
 
-void PrintHelp() {
-  std::cerr
-      << "Gemma4 chat server (models loaded once, KV cache reused)\n\n"
-      << "Commands:\n"
-      << "  /help              Show help\n"
-      << "  /reset             Clear conversation + KV cache\n"
-      << "  /status            Show session stats\n"
-      << "  /image PATH        Attach image for next VLM turn\n"
-      << "  /quit              Exit\n\n"
-      << "Type a message and press Enter to chat.\n"
-      << std::endl;
+using json = nlohmann::json;
+
+constexpr size_t kMaxHeaderBytes = 64 * 1024;
+
+class HttpError : public std::runtime_error {
+ public:
+  HttpError(int status, const std::string& message)
+      : std::runtime_error(message), status_(status) {}
+
+  int status() const { return status_; }
+
+ private:
+  int status_;
+};
+
+struct HttpRequest {
+  std::string method;
+  std::string path;
+  std::map<std::string, std::string> headers;
+  std::string body;
+};
+
+struct ChatMessage {
+  std::string role;
+  std::string content;
+};
+
+struct ChatRequest {
+  std::vector<ChatMessage> messages;
+  int max_tokens = 0;
+  bool stream = false;
+  bool include_usage = false;
+};
+
+struct PreparedChat {
+  std::vector<int64_t> prompt_ids;
+  int max_new_tokens = 0;
+  size_t trimmed_messages = 0;
+};
+
+struct ChatResult {
+  std::string text;
+  std::string finish_reason;
+  int prompt_tokens = 0;
+  int completion_tokens = 0;
+  int output_budget = 0;
+  size_t trimmed_messages = 0;
+  bool cache_reused = false;
+};
+
+std::string ToLower(std::string value) {
+  std::transform(value.begin(), value.end(), value.begin(),
+                 [](unsigned char ch) {
+                   return static_cast<char>(std::tolower(ch));
+                 });
+  return value;
 }
 
-std::string JsonEscape(const std::string& s) {
-  std::string out;
-  for (char c : s) {
-    switch (c) {
-      case '\\':
-        out += "\\\\";
-        break;
-      case '"':
-        out += "\\\"";
-        break;
-      case '\n':
-        out += "\\n";
-        break;
-      case '\r':
-        out += "\\r";
-        break;
-      case '\t':
-        out += "\\t";
-        break;
-      default:
-        out += c;
-        break;
-    }
+std::string Trim(const std::string& value) {
+  const size_t first = value.find_first_not_of(" \t\r\n");
+  if (first == std::string::npos) {
+    return "";
   }
-  return out;
+  const size_t last = value.find_last_not_of(" \t\r\n");
+  return value.substr(first, last - first + 1);
 }
 
-std::string BuildMessagesJson(
-    const std::vector<std::pair<std::string, std::string>>& turns) {
-  std::ostringstream oss;
-  oss << '[';
-  for (size_t i = 0; i < turns.size(); ++i) {
-    if (i) {
-      oss << ',';
-    }
-    oss << "{\"role\":\"" << turns[i].first << "\",\"content\":\""
-        << JsonEscape(turns[i].second) << "\"}";
+const char* StatusText(int status) {
+  switch (status) {
+    case 200:
+      return "OK";
+    case 204:
+      return "No Content";
+    case 400:
+      return "Bad Request";
+    case 404:
+      return "Not Found";
+    case 405:
+      return "Method Not Allowed";
+    case 413:
+      return "Payload Too Large";
+    case 431:
+      return "Request Header Fields Too Large";
+    case 500:
+      return "Internal Server Error";
+    case 501:
+      return "Not Implemented";
+    default:
+      return "Error";
   }
-  oss << ']';
-  return oss.str();
+}
+
+bool SendAll(int file_descriptor, const std::string& data) {
+  size_t offset = 0;
+  while (offset < data.size()) {
+    const ssize_t written =
+        send(file_descriptor, data.data() + offset, data.size() - offset,
+             MSG_NOSIGNAL);
+    if (written < 0 && errno == EINTR) {
+      continue;
+    }
+    if (written <= 0) {
+      return false;
+    }
+    offset += static_cast<size_t>(written);
+  }
+  return true;
+}
+
+bool SendResponse(int file_descriptor, int status, const std::string& body,
+                  const std::string& content_type =
+                      "application/json; charset=utf-8") {
+  std::ostringstream headers;
+  headers << "HTTP/1.1 " << status << ' ' << StatusText(status) << "\r\n"
+          << "Content-Type: " << content_type << "\r\n"
+          << "Content-Length: " << body.size() << "\r\n"
+          << "Connection: close\r\n"
+          << "Access-Control-Allow-Origin: *\r\n"
+          << "Access-Control-Allow-Headers: Authorization, Content-Type\r\n"
+          << "Access-Control-Allow-Methods: GET, POST, OPTIONS\r\n"
+          << "\r\n";
+  return SendAll(file_descriptor, headers.str()) &&
+         (body.empty() || SendAll(file_descriptor, body));
+}
+
+bool SendSseHeaders(int file_descriptor) {
+  const std::string headers =
+      "HTTP/1.1 200 OK\r\n"
+      "Content-Type: text/event-stream; charset=utf-8\r\n"
+      "Cache-Control: no-cache\r\n"
+      "Connection: close\r\n"
+      "X-Accel-Buffering: no\r\n"
+      "Access-Control-Allow-Origin: *\r\n"
+      "Access-Control-Allow-Headers: Authorization, Content-Type\r\n"
+      "Access-Control-Allow-Methods: GET, POST, OPTIONS\r\n"
+      "\r\n";
+  return SendAll(file_descriptor, headers);
+}
+
+bool SendSseData(int file_descriptor, const json& payload) {
+  return SendAll(file_descriptor, "data: " + payload.dump() + "\n\n");
+}
+
+json ErrorBody(const std::string& message, const std::string& type,
+               const std::string& code) {
+  return json{{"error",
+               {{"message", message},
+                {"type", type},
+                {"param", nullptr},
+                {"code", code}}}};
+}
+
+void SendError(int file_descriptor, int status, const std::string& message) {
+  const bool client_error = status >= 400 && status < 500;
+  const json body = ErrorBody(
+      message, client_error ? "invalid_request_error" : "server_error",
+      client_error ? "invalid_request" : "internal_error");
+  SendResponse(file_descriptor, status, body.dump());
+}
+
+HttpRequest ReadHttpRequest(int file_descriptor, size_t max_body_bytes) {
+  std::string received;
+  received.reserve(8192);
+  char buffer[8192];
+  size_t header_end = std::string::npos;
+
+  while (header_end == std::string::npos) {
+    const ssize_t count = recv(file_descriptor, buffer, sizeof(buffer), 0);
+    if (count < 0 && errno == EINTR) {
+      continue;
+    }
+    if (count <= 0) {
+      throw HttpError(400, "connection closed before HTTP headers completed");
+    }
+    received.append(buffer, static_cast<size_t>(count));
+    if (received.size() > kMaxHeaderBytes) {
+      throw HttpError(431, "HTTP headers exceed 64 KiB");
+    }
+    header_end = received.find("\r\n\r\n");
+  }
+
+  HttpRequest request;
+  std::istringstream header_stream(received.substr(0, header_end));
+  std::string request_line;
+  if (!std::getline(header_stream, request_line)) {
+    throw HttpError(400, "missing HTTP request line");
+  }
+  if (!request_line.empty() && request_line.back() == '\r') {
+    request_line.pop_back();
+  }
+
+  std::string target;
+  std::string version;
+  std::istringstream request_line_stream(request_line);
+  if (!(request_line_stream >> request.method >> target >> version)) {
+    throw HttpError(400, "invalid HTTP request line");
+  }
+  if (version != "HTTP/1.1" && version != "HTTP/1.0") {
+    throw HttpError(400, "unsupported HTTP version");
+  }
+  const size_t query = target.find('?');
+  request.path = target.substr(0, query);
+
+  std::string line;
+  while (std::getline(header_stream, line)) {
+    if (!line.empty() && line.back() == '\r') {
+      line.pop_back();
+    }
+    const size_t colon = line.find(':');
+    if (colon == std::string::npos) {
+      throw HttpError(400, "invalid HTTP header");
+    }
+    request.headers[ToLower(Trim(line.substr(0, colon)))] =
+        Trim(line.substr(colon + 1));
+  }
+
+  const auto transfer_encoding = request.headers.find("transfer-encoding");
+  if (transfer_encoding != request.headers.end() &&
+      ToLower(transfer_encoding->second) != "identity") {
+    throw HttpError(501, "chunked request bodies are not supported");
+  }
+
+  size_t content_length = 0;
+  const auto length_header = request.headers.find("content-length");
+  if (length_header != request.headers.end()) {
+    try {
+      size_t parsed = 0;
+      const unsigned long long length =
+          std::stoull(length_header->second, &parsed, 10);
+      if (parsed != length_header->second.size()) {
+        throw std::invalid_argument("trailing data");
+      }
+      if (length > max_body_bytes) {
+        throw HttpError(413, "HTTP request body exceeds configured limit");
+      }
+      content_length = static_cast<size_t>(length);
+    } catch (const HttpError&) {
+      throw;
+    } catch (const std::exception&) {
+      throw HttpError(400, "invalid Content-Length header");
+    }
+  }
+
+  const size_t body_start = header_end + 4;
+  if (received.size() > body_start) {
+    request.body.assign(received.data() + body_start,
+                        received.size() - body_start);
+  }
+
+  const auto expect_header = request.headers.find("expect");
+  if (expect_header != request.headers.end() &&
+      ToLower(expect_header->second) == "100-continue" &&
+      request.body.size() < content_length) {
+    if (!SendAll(file_descriptor, "HTTP/1.1 100 Continue\r\n\r\n")) {
+      throw HttpError(400, "client disconnected before request body");
+    }
+  }
+
+  while (request.body.size() < content_length) {
+    const size_t remaining = content_length - request.body.size();
+    const ssize_t count =
+        recv(file_descriptor, buffer, std::min(remaining, sizeof(buffer)), 0);
+    if (count < 0 && errno == EINTR) {
+      continue;
+    }
+    if (count <= 0) {
+      throw HttpError(400, "connection closed before request body completed");
+    }
+    request.body.append(buffer, static_cast<size_t>(count));
+  }
+  if (request.body.size() > content_length) {
+    request.body.resize(content_length);
+  }
+  return request;
+}
+
+std::string ReadMessageContent(const json& content) {
+  if (content.is_string()) {
+    return content.get<std::string>();
+  }
+  if (!content.is_array()) {
+    throw HttpError(400, "each message content must be a string or array");
+  }
+
+  std::string text;
+  for (const auto& part : content) {
+    if (part.is_string()) {
+      text += part.get<std::string>();
+      continue;
+    }
+    if (!part.is_object()) {
+      throw HttpError(400, "invalid message content part");
+    }
+    const std::string type = part.value("type", "");
+    if (type == "text" || type == "input_text" ||
+        (type.empty() && part.contains("text"))) {
+      if (!part.contains("text") || !part["text"].is_string()) {
+        throw HttpError(400, "text content part requires a string text field");
+      }
+      text += part["text"].get<std::string>();
+    } else if (type == "image" || type == "image_url" ||
+               type == "input_image") {
+      throw HttpError(
+          400,
+          "gemma4_server is text-only; use the interactive main executable "
+          "for image chat");
+    } else {
+      throw HttpError(400, "unsupported message content part type: " + type);
+    }
+  }
+  return text;
+}
+
+int ReadRequestMaxTokens(const json& request, int default_max_tokens) {
+  const json* value = nullptr;
+  if (request.contains("max_tokens") && !request["max_tokens"].is_null()) {
+    value = &request["max_tokens"];
+  } else if (request.contains("max_completion_tokens") &&
+             !request["max_completion_tokens"].is_null()) {
+    value = &request["max_completion_tokens"];
+  }
+  if (value == nullptr) {
+    return default_max_tokens;
+  }
+  if (!value->is_number_integer()) {
+    throw HttpError(400, "max_tokens must be a non-negative integer");
+  }
+  const int64_t requested = value->get<int64_t>();
+  if (requested < 0) {
+    throw HttpError(400, "max_tokens must be a non-negative integer");
+  }
+  return static_cast<int>(std::min<int64_t>(
+      requested, std::numeric_limits<int>::max()));
+}
+
+ChatRequest ParseChatRequest(const std::string& body,
+                             int default_max_tokens) {
+  json request;
+  try {
+    request = json::parse(body);
+  } catch (const std::exception& error) {
+    throw HttpError(400, std::string("invalid JSON body: ") + error.what());
+  }
+  if (!request.is_object()) {
+    throw HttpError(400, "request body must be a JSON object");
+  }
+  if (!request.contains("messages") || !request["messages"].is_array() ||
+      request["messages"].empty()) {
+    throw HttpError(400, "messages must be a non-empty array");
+  }
+  if (request.contains("n") && request["n"].is_number_integer() &&
+      request["n"].get<int>() != 1) {
+    throw HttpError(400, "only n=1 is supported");
+  }
+
+  ChatRequest parsed;
+  parsed.max_tokens = ReadRequestMaxTokens(request, default_max_tokens);
+  if (request.contains("stream")) {
+    if (!request["stream"].is_boolean()) {
+      throw HttpError(400, "stream must be a boolean");
+    }
+    parsed.stream = request["stream"].get<bool>();
+  }
+  if (request.contains("stream_options") &&
+      request["stream_options"].is_object()) {
+    const auto& options = request["stream_options"];
+    if (options.contains("include_usage") &&
+        options["include_usage"].is_boolean()) {
+      parsed.include_usage = options["include_usage"].get<bool>();
+    }
+  }
+
+  for (const auto& item : request["messages"]) {
+    if (!item.is_object() || !item.contains("role") ||
+        !item["role"].is_string() || !item.contains("content")) {
+      throw HttpError(400, "each message requires string role and content");
+    }
+    std::string role = item["role"].get<std::string>();
+    if (role == "developer") {
+      role = "system";
+    } else if (role == "model") {
+      role = "assistant";
+    }
+    if (role != "system" && role != "user" && role != "assistant") {
+      throw HttpError(400, "unsupported message role: " + role);
+    }
+    parsed.messages.push_back({role, ReadMessageContent(item["content"])});
+  }
+  if (parsed.messages.back().role != "user") {
+    throw HttpError(400, "the last message must have role=user");
+  }
+  return parsed;
+}
+
+std::string BuildMessagesJson(const std::vector<ChatMessage>& messages) {
+  json output = json::array();
+  for (const auto& message : messages) {
+    output.push_back({{"role", message.role}, {"content", message.content}});
+  }
+  return output.dump();
+}
+
+size_t DropOldestTurn(std::vector<ChatMessage>* messages) {
+  if (messages == nullptr || messages->size() <= 1) {
+    return 0;
+  }
+
+  size_t first = 0;
+  while (first + 1 < messages->size() &&
+         (*messages)[first].role == "system") {
+    ++first;
+  }
+  if (first >= messages->size() - 1) {
+    return 0;
+  }
+
+  size_t erase_count = 1;
+  if ((*messages)[first].role == "user" &&
+      first + 1 < messages->size() - 1 &&
+      (*messages)[first + 1].role == "assistant") {
+    erase_count = 2;
+  }
+  messages->erase(messages->begin() + static_cast<std::ptrdiff_t>(first),
+                  messages->begin() +
+                      static_cast<std::ptrdiff_t>(first + erase_count));
+  return erase_count;
+}
+
+bool PrefixMatches(const std::vector<int64_t>& prompt,
+                   const std::vector<int64_t>& cached, int length) {
+  if (length <= 0) {
+    return true;
+  }
+  if (static_cast<int>(prompt.size()) < length ||
+      static_cast<int>(cached.size()) < length) {
+    return false;
+  }
+  for (int index = 0; index < length; ++index) {
+    if (prompt[static_cast<size_t>(index)] !=
+        cached[static_cast<size_t>(index)]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+class ChatService {
+ public:
+  ChatService(const std::string& text_hbm, const std::string& embeddings,
+              const std::string& tokenizer_path) {
+    std::cout << "Loading Text HBM (one-time)..." << std::endl;
+    engine_ = std::make_unique<gemma4::TextEngine>(text_hbm, embeddings);
+    tokenizer_ =
+        std::make_unique<gemma4::TokenizerBridge>(tokenizer_path);
+    std::cout << "Text ready (" << engine_->LoadMs() << " ms)" << std::endl;
+  }
+
+  PreparedChat Prepare(const ChatRequest& request,
+                       int min_response_tokens) const {
+    std::vector<ChatMessage> messages = request.messages;
+    const int desired_reserve = request.max_tokens == 0
+        ? min_response_tokens
+        : std::min(request.max_tokens, gemma4::kCacheLen - 1);
+
+    PreparedChat prepared;
+    while (true) {
+      prepared.prompt_ids =
+          tokenizer_->EncodeMessagesJson(BuildMessagesJson(messages), true);
+      const bool prompt_fits =
+          prepared.prompt_ids.size() < static_cast<size_t>(gemma4::kCacheLen);
+      const bool reserve_fits =
+          prepared.prompt_ids.size() + static_cast<size_t>(desired_reserve) <=
+          static_cast<size_t>(gemma4::kCacheLen);
+      if (prompt_fits && reserve_fits) {
+        break;
+      }
+      const size_t removed = DropOldestTurn(&messages);
+      if (removed == 0) {
+        break;
+      }
+      prepared.trimmed_messages += removed;
+    }
+
+    if (prepared.prompt_ids.size() >=
+        static_cast<size_t>(gemma4::kCacheLen)) {
+      std::ostringstream error;
+      error << "prompt uses " << prepared.prompt_ids.size()
+            << " tokens, but the HBM KV cache is limited to "
+            << gemma4::kCacheLen;
+      throw HttpError(400, error.str());
+    }
+
+    const int available =
+        gemma4::kCacheLen - static_cast<int>(prepared.prompt_ids.size());
+    prepared.max_new_tokens = request.max_tokens == 0
+        ? available
+        : std::min(request.max_tokens, available);
+    return prepared;
+  }
+
+  ChatResult Generate(
+      const PreparedChat& prepared,
+      const std::function<bool(const std::string&)>& on_text = nullptr) {
+    const int previous_processed = engine_->ProcessedTokens();
+    const bool prefix_matches = PrefixMatches(
+        prepared.prompt_ids, cached_ids_, previous_processed);
+    const bool cache_reused =
+        prepared.trimmed_messages == 0 && previous_processed > 0 &&
+        prefix_matches;
+    if (previous_processed > 0 &&
+        (prepared.trimmed_messages > 0 || !prefix_matches)) {
+      engine_->ResetSession();
+      cached_ids_.clear();
+    }
+
+    std::cout << "[request] prompt=" << prepared.prompt_ids.size()
+              << ", output_budget=" << prepared.max_new_tokens
+              << ", capacity=" << gemma4::kCacheLen
+              << ", cache_reused=" << (cache_reused ? "yes" : "no")
+              << ", trimmed_messages=" << prepared.trimmed_messages
+              << std::endl;
+
+    gemma4::TokenCallback token_callback;
+    if (on_text) {
+      token_callback = [&](int64_t token_id) {
+        if (token_id == gemma4::kEosTokenId ||
+            token_id == gemma4::kTurnEndTokenId) {
+          return true;
+        }
+        return on_text(tokenizer_->DecodeIds({token_id}));
+      };
+    }
+
+    std::vector<int64_t> output;
+    try {
+      output = engine_->ContinueGenerateStream(
+          prepared.prompt_ids, prepared.max_new_tokens, token_callback);
+    } catch (...) {
+      engine_->ResetSession();
+      cached_ids_.clear();
+      throw;
+    }
+
+    size_t generation_end = output.size();
+    bool stopped = false;
+    while (generation_end > prepared.prompt_ids.size() &&
+           (output[generation_end - 1] == gemma4::kEosTokenId ||
+            output[generation_end - 1] == gemma4::kTurnEndTokenId)) {
+      stopped = true;
+      --generation_end;
+    }
+    const std::vector<int64_t> generated(
+        output.begin() + static_cast<std::ptrdiff_t>(prepared.prompt_ids.size()),
+        output.begin() + static_cast<std::ptrdiff_t>(generation_end));
+
+    cached_ids_ = output;
+
+    ChatResult result;
+    result.text = tokenizer_->DecodeIds(generated);
+    result.finish_reason = stopped ? "stop" : "length";
+    result.prompt_tokens = static_cast<int>(prepared.prompt_ids.size());
+    result.completion_tokens = static_cast<int>(generated.size());
+    result.output_budget = prepared.max_new_tokens;
+    result.trimmed_messages = prepared.trimmed_messages;
+    result.cache_reused = cache_reused;
+    return result;
+  }
+
+  double LoadMs() const { return engine_->LoadMs(); }
+  int CachedTokens() const { return engine_->ProcessedTokens(); }
+
+ private:
+  std::unique_ptr<gemma4::TextEngine> engine_;
+  std::unique_ptr<gemma4::TokenizerBridge> tokenizer_;
+  std::vector<int64_t> cached_ids_;
+};
+
+int64_t UnixTime() {
+  return static_cast<int64_t>(std::time(nullptr));
+}
+
+std::string MakeCompletionId() {
+  static uint64_t sequence = 0;
+  const uint64_t milliseconds = static_cast<uint64_t>(
+      std::chrono::duration_cast<std::chrono::milliseconds>(
+          std::chrono::system_clock::now().time_since_epoch())
+          .count());
+  std::ostringstream id;
+  id << "chatcmpl-gemma4-" << milliseconds << '-' << ++sequence;
+  return id.str();
+}
+
+json CompletionChunk(const std::string& id, int64_t created,
+                     const std::string& model, const json& delta,
+                     const json& finish_reason) {
+  json chunk;
+  chunk["id"] = id;
+  chunk["object"] = "chat.completion.chunk";
+  chunk["created"] = created;
+  chunk["model"] = model;
+  chunk["choices"] = json::array(
+      {{{"index", 0}, {"delta", delta}, {"finish_reason", finish_reason}}});
+  return chunk;
+}
+
+void HandleChatCompletion(int file_descriptor, const HttpRequest& request,
+                          ChatService* service, const std::string& model,
+                          int default_max_tokens,
+                          int min_response_tokens) {
+  const ChatRequest chat_request =
+      ParseChatRequest(request.body, default_max_tokens);
+  const PreparedChat prepared =
+      service->Prepare(chat_request, min_response_tokens);
+  const std::string completion_id = MakeCompletionId();
+  const int64_t created = UnixTime();
+
+  if (!chat_request.stream) {
+    const ChatResult result = service->Generate(prepared);
+    json response;
+    response["id"] = completion_id;
+    response["object"] = "chat.completion";
+    response["created"] = created;
+    response["model"] = model;
+    response["choices"] = json::array(
+        {{{"index", 0},
+          {"message", {{"role", "assistant"}, {"content", result.text}}},
+          {"finish_reason", result.finish_reason}}});
+    response["usage"] = {
+        {"prompt_tokens", result.prompt_tokens},
+        {"completion_tokens", result.completion_tokens},
+        {"total_tokens", result.prompt_tokens + result.completion_tokens}};
+    SendResponse(file_descriptor, 200, response.dump());
+    return;
+  }
+
+  if (!SendSseHeaders(file_descriptor)) {
+    return;
+  }
+  bool connected = SendSseData(
+      file_descriptor,
+      CompletionChunk(completion_id, created, model,
+                      json{{"role", "assistant"}}, nullptr));
+  if (!connected) {
+    return;
+  }
+
+  try {
+    const ChatResult result = service->Generate(
+        prepared, [&](const std::string& text) {
+          if (text.empty()) {
+            return true;
+          }
+          connected = SendSseData(
+              file_descriptor,
+              CompletionChunk(completion_id, created, model,
+                              json{{"content", text}}, nullptr));
+          return connected;
+        });
+    if (!connected) {
+      return;
+    }
+
+    connected = SendSseData(
+        file_descriptor,
+        CompletionChunk(completion_id, created, model, json::object(),
+                        result.finish_reason));
+    if (connected && chat_request.include_usage) {
+      json usage_chunk;
+      usage_chunk["id"] = completion_id;
+      usage_chunk["object"] = "chat.completion.chunk";
+      usage_chunk["created"] = created;
+      usage_chunk["model"] = model;
+      usage_chunk["choices"] = json::array();
+      usage_chunk["usage"] = {
+          {"prompt_tokens", result.prompt_tokens},
+          {"completion_tokens", result.completion_tokens},
+          {"total_tokens", result.prompt_tokens + result.completion_tokens}};
+      connected = SendSseData(file_descriptor, usage_chunk);
+    }
+    if (connected) {
+      SendAll(file_descriptor, "data: [DONE]\n\n");
+    }
+  } catch (const std::exception& error) {
+    if (connected) {
+      SendSseData(file_descriptor,
+                  ErrorBody(error.what(), "server_error", "internal_error"));
+      SendAll(file_descriptor, "data: [DONE]\n\n");
+    }
+  }
+}
+
+void HandleClient(int file_descriptor, size_t max_body_bytes,
+                  ChatService* service, const std::string& model,
+                  int default_max_tokens, int min_response_tokens) {
+  try {
+    const HttpRequest request =
+        ReadHttpRequest(file_descriptor, max_body_bytes);
+
+    if (request.method == "OPTIONS") {
+      SendResponse(file_descriptor, 204, "");
+      return;
+    }
+    if (request.method == "GET" &&
+        (request.path == "/health" || request.path == "/v1/health")) {
+      const json body = {{"status", "ok"},
+                         {"model", model},
+                         {"context_length", gemma4::kCacheLen},
+                         {"cached_tokens", service->CachedTokens()},
+                         {"load_ms", service->LoadMs()}};
+      SendResponse(file_descriptor, 200, body.dump());
+      return;
+    }
+    if (request.method == "GET" && request.path == "/v1/models") {
+      const json body = {
+          {"object", "list"},
+          {"data",
+           json::array({{{"id", model},
+                         {"object", "model"},
+                         {"created", 0},
+                         {"owned_by", "d-robotics"}}})}};
+      SendResponse(file_descriptor, 200, body.dump());
+      return;
+    }
+    if (request.method == "GET" && request.path == "/") {
+      const json body = {
+          {"name", "Gemma4-E2B OpenAI-compatible server"},
+          {"model", model},
+          {"context_length", gemma4::kCacheLen},
+          {"endpoints",
+           json::array({"GET /health", "GET /v1/models",
+                        "POST /v1/chat/completions"})}};
+      SendResponse(file_descriptor, 200, body.dump());
+      return;
+    }
+    if (request.method == "POST" &&
+        request.path == "/v1/chat/completions") {
+      HandleChatCompletion(file_descriptor, request, service, model,
+                           default_max_tokens, min_response_tokens);
+      return;
+    }
+    if (request.path == "/v1/chat/completions") {
+      throw HttpError(405, "use POST for /v1/chat/completions");
+    }
+    throw HttpError(404, "endpoint not found");
+  } catch (const HttpError& error) {
+    SendError(file_descriptor, error.status(), error.what());
+  } catch (const std::exception& error) {
+    std::cerr << "Request error: " << error.what() << std::endl;
+    SendError(file_descriptor, 500, error.what());
+  }
+}
+
+int CreateListenSocket(const std::string& host, int port) {
+  struct addrinfo hints {};
+  hints.ai_family = AF_UNSPEC;
+  hints.ai_socktype = SOCK_STREAM;
+  hints.ai_flags = AI_PASSIVE;
+
+  struct addrinfo* addresses = nullptr;
+  const std::string port_text = std::to_string(port);
+  const char* node = (host.empty() || host == "*") ? nullptr : host.c_str();
+  const int resolve_result =
+      getaddrinfo(node, port_text.c_str(), &hints, &addresses);
+  if (resolve_result != 0) {
+    throw std::runtime_error(std::string("getaddrinfo failed: ") +
+                             gai_strerror(resolve_result));
+  }
+
+  int listen_socket = -1;
+  for (struct addrinfo* address = addresses; address != nullptr;
+       address = address->ai_next) {
+    listen_socket =
+        socket(address->ai_family, address->ai_socktype, address->ai_protocol);
+    if (listen_socket < 0) {
+      continue;
+    }
+    const int reuse = 1;
+    setsockopt(listen_socket, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse));
+    if (::bind(listen_socket, address->ai_addr, address->ai_addrlen) == 0 &&
+        listen(listen_socket, 16) == 0) {
+      break;
+    }
+    close(listen_socket);
+    listen_socket = -1;
+  }
+  freeaddrinfo(addresses);
+
+  if (listen_socket < 0) {
+    throw std::runtime_error(std::string("failed to bind HTTP socket: ") +
+                             std::strerror(errno));
+  }
+  return listen_socket;
 }
 
 }  // namespace
 
-// -------------------- Command-line flags --------------------
-// Empty default => resolved at runtime from $GEMMA4_HOME.
-DEFINE_string(text_hbm, "",
-              "Path to text LLM *.hbm. Default: $GEMMA4_HOME/model/"
-              "gemma4-e2b_lm_chunk_256_cache_4096_ptq.hbm");
-DEFINE_string(vision_hbm, "",
-              "Path to vision ViT *.hbm. Default: $GEMMA4_HOME/model/"
-              "gemma4-e2b_vit_ptq.hbm");
-DEFINE_string(tok_embeddings, "",
-              "Path to tok_embeddings.bin. Default: $GEMMA4_HOME/model/tok_embeddings.bin");
-DEFINE_int32(max_tokens, 128,
-             "Maximum new tokens to generate per turn.");
-
 int main(int argc, char** argv) {
   gflags::SetUsageMessage(
-      "Gemma4-E2B chat server (models loaded once, KV cache reused).\n"
-      "Usage: ./gemma4_server [--text_hbm PATH] [--vision_hbm PATH] "
-      "[--tok_embeddings PATH] [--max_tokens N]");
+      "OpenAI-compatible text chat server for Gemma4-E2B.\n"
+      "Usage: ./gemma4_server [--host 0.0.0.0] [--port 8000] "
+      "[--max_tokens 0]");
   gflags::ParseCommandLineFlags(&argc, &argv, true);
+
+  if (FLAGS_port <= 0 || FLAGS_port > 65535) {
+    std::cerr << "--port must be in [1, 65535]" << std::endl;
+    return 2;
+  }
+  if (FLAGS_max_tokens < 0) {
+    std::cerr << "--max_tokens must be zero or positive" << std::endl;
+    return 2;
+  }
+  if (FLAGS_min_response_tokens <= 0) {
+    std::cerr << "--min_response_tokens must be positive" << std::endl;
+    return 2;
+  }
+  if (FLAGS_request_limit_mb <= 0 || FLAGS_request_limit_mb > 64) {
+    std::cerr << "--request_limit_mb must be in [1, 64]" << std::endl;
+    return 2;
+  }
 
   const char* env_home = std::getenv("GEMMA4_HOME");
   const std::string home = (env_home && *env_home) ? env_home : ".";
   const std::string text_hbm = FLAGS_text_hbm.empty()
       ? home + "/model/gemma4-e2b_lm_chunk_256_cache_4096_ptq.hbm"
       : FLAGS_text_hbm;
-  const std::string vision_hbm = FLAGS_vision_hbm.empty()
-      ? home + "/model/gemma4-e2b_vit_ptq.hbm"
-      : FLAGS_vision_hbm;
-  const std::string embed = FLAGS_tok_embeddings.empty()
+  const std::string embeddings = FLAGS_tok_embeddings.empty()
       ? home + "/model/tok_embeddings.bin"
       : FLAGS_tok_embeddings;
-  const int max_tokens = FLAGS_max_tokens;
+  const std::string tokenizer_path = FLAGS_tokenizer_path.empty()
+      ? home + "/tokenizer/tokenizer.json"
+      : FLAGS_tokenizer_path;
+  const int min_response_tokens =
+      std::min(FLAGS_min_response_tokens, gemma4::kCacheLen - 1);
+  const size_t max_body_bytes =
+      static_cast<size_t>(FLAGS_request_limit_mb) * 1024 * 1024;
+
+  std::signal(SIGPIPE, SIG_IGN);
 
   try {
-    std::cout << "Loading Text HBM (one-time, ~60s) ..." << std::endl;
-    gemma4::TextEngine text(text_hbm, embed);
-    std::cout << "Text ready (" << text.LoadMs() << " ms)\n";
+    ChatService service(text_hbm, embeddings, tokenizer_path);
+    const int listen_socket = CreateListenSocket(FLAGS_host, FLAGS_port);
+    std::cout << "Listening on http://" << FLAGS_host << ':' << FLAGS_port
+              << std::endl;
+    std::cout << "OpenAI base URL: http://<board-ip>:" << FLAGS_port << "/v1"
+              << std::endl;
+    std::cout << "KV cache: " << gemma4::kCacheLen
+              << " tokens; default max output: "
+              << (FLAGS_max_tokens == 0
+                      ? std::string("all capacity remaining after the prompt")
+                      : std::to_string(FLAGS_max_tokens))
+              << std::endl;
 
-    std::unique_ptr<gemma4::VisionEngine> vision;
-    gemma4::TokenizerBridge tokenizer;
-
-    std::vector<std::pair<std::string, std::string>> turns;
-    std::optional<std::string> pending_image;
-    std::vector<int64_t> session_ids;
-    std::vector<float> session_hidden;
-
-    auto build_messages_json = [&]() -> std::string {
-      std::ostringstream oss;
-      oss << '[';
-      for (size_t i = 0; i < turns.size(); ++i) {
-        if (i) {
-          oss << ',';
+    while (true) {
+      const int client_socket = accept(listen_socket, nullptr, nullptr);
+      if (client_socket < 0) {
+        if (errno == EINTR) {
+          continue;
         }
-        oss << "{\"role\":\"" << turns[i].first << "\",\"content\":\""
-            << JsonEscape(turns[i].second) << "\"}";
+        throw std::runtime_error(std::string("accept failed: ") +
+                                 std::strerror(errno));
       }
-      oss << ']';
-      return oss.str();
-    };
-
-    auto prefix_match = [](const std::vector<int64_t>& a,
-                           const std::vector<int64_t>& b, int len) {
-      if (static_cast<int>(a.size()) < len || static_cast<int>(b.size()) < len) {
-        return false;
-      }
-      for (int i = 0; i < len; ++i) {
-        if (a[static_cast<size_t>(i)] != b[static_cast<size_t>(i)]) {
-          return false;
-        }
-      }
-      return true;
-    };
-
-    PrintHelp();
-    std::cout << "gemma4> " << std::flush;
-
-    std::string line;
-    while (std::getline(std::cin, line)) {
-      if (line == "/quit" || line == "/exit") {
-        break;
-      }
-      if (line == "/help") {
-        PrintHelp();
-        std::cout << "gemma4> " << std::flush;
-        continue;
-      }
-      if (line == "/reset") {
-        text.ResetSession();
-        turns.clear();
-        session_ids.clear();
-        session_hidden.clear();
-        pending_image.reset();
-        std::cout << "Session reset.\n";
-        std::cout << "gemma4> " << std::flush;
-        continue;
-      }
-      if (line == "/status") {
-        std::cout << "turns=" << turns.size()
-                  << " cached_tokens=" << text.ProcessedTokens()
-                  << " session_ids=" << session_ids.size() << "\n";
-        std::cout << "gemma4> " << std::flush;
-        continue;
-      }
-      if (line.rfind("/image ", 0) == 0) {
-        pending_image = line.substr(7);
-        std::cout << "Image queued: " << *pending_image << "\n";
-        std::cout << "gemma4> " << std::flush;
-        continue;
-      }
-      if (line.empty()) {
-        std::cout << "gemma4> " << std::flush;
-        continue;
-      }
-
-      turns.emplace_back("user", line);
-
-      const std::vector<int64_t> prev_ids = session_ids;
-      const int prev_processed = text.ProcessedTokens();
-
-      if (pending_image.has_value()) {
-        std::ostringstream oss;
-        oss << '[';
-        for (size_t i = 0; i + 1 < turns.size(); ++i) {
-          if (i) {
-            oss << ',';
-          }
-          oss << "{\"role\":\"" << turns[i].first << "\",\"content\":\""
-              << JsonEscape(turns[i].second) << "\"}";
-        }
-        if (turns.size() > 1) {
-          oss << ',';
-        }
-        oss << "{\"role\":\"user\",\"content\":[{\"type\":\"image\"},{\"type\":\"text\",\"text\":\""
-            << JsonEscape(line) << "\"}]}]";
-        session_ids = tokenizer.EncodeMessagesJson(oss.str());
-
-        if (!vision) {
-          std::cout << "Loading Vision HBM ..." << std::endl;
-          vision = std::make_unique<gemma4::VisionEngine>(vision_hbm);
-          std::cout << "Vision ready (" << vision->LoadMs() << " ms)\n";
-        }
-        const auto vision_features = vision->Infer(*pending_image);
-        session_hidden = text.BuildPromptHidden(session_ids, vision_features);
-        pending_image.reset();
-      } else {
-        session_ids = tokenizer.EncodeMessagesJson(build_messages_json());
-        session_hidden.clear();
-      }
-
-      if (prev_processed > 0 &&
-          !prefix_match(session_ids, prev_ids, prev_processed)) {
-        text.ResetSession();
-      }
-
-      const std::vector<float>* hidden_ptr =
-          session_hidden.empty() ? nullptr : &session_hidden;
-      const auto out = text.ContinueGenerate(session_ids, max_tokens, hidden_ptr);
-
-      const std::vector<int64_t> gen(out.begin() + session_ids.size(), out.end());
-      const std::string reply = tokenizer.DecodeIds(gen);
-      turns.emplace_back("assistant", reply);
-      session_ids = out;
-
-      std::cout << "\nassistant> " << reply << "\n\n";
-      std::cout << "gemma4> " << std::flush;
+      HandleClient(client_socket, max_body_bytes, &service, FLAGS_model,
+                   FLAGS_max_tokens, min_response_tokens);
+      close(client_socket);
     }
-
-    return 0;
-  } catch (const std::exception& ex) {
-    std::cerr << "ERROR: " << ex.what() << std::endl;
+  } catch (const std::exception& error) {
+    std::cerr << "ERROR: " << error.what() << std::endl;
     return 1;
   }
 }

--- a/samples/llm/gemma4-e2b/runtime/cpp/src/gemma4_server.cpp
+++ b/samples/llm/gemma4-e2b/runtime/cpp/src/gemma4_server.cpp
@@ -78,6 +78,9 @@ class HttpError : public std::runtime_error {
   int status_;
 };
 
+/**
+ * @brief Represent a parsed HTTP request.
+ */
 struct HttpRequest {
   std::string method;
   std::string path;
@@ -85,11 +88,17 @@ struct HttpRequest {
   std::string body;
 };
 
+/**
+ * @brief Represent a single chat message (role + content).
+ */
 struct ChatMessage {
   std::string role;
   std::string content;
 };
 
+/**
+ * @brief Represent a parsed OpenAI-style chat completion request.
+ */
 struct ChatRequest {
   std::vector<ChatMessage> messages;
   int max_tokens = 0;
@@ -97,12 +106,18 @@ struct ChatRequest {
   bool include_usage = false;
 };
 
+/**
+ * @brief Represent a prepared prompt ready for one inference call.
+ */
 struct PreparedChat {
   std::vector<int64_t> prompt_ids;
   int max_new_tokens = 0;
   size_t trimmed_messages = 0;
 };
 
+/**
+ * @brief Represent the decoded result of one chat completion.
+ */
 struct ChatResult {
   std::string text;
   std::string finish_reason;
@@ -223,6 +238,17 @@ void SendError(int file_descriptor, int status, const std::string& message) {
   SendResponse(file_descriptor, status, body.dump());
 }
 
+/**
+ * @brief Read one HTTP request from a client socket.
+ *
+ * @param file_descriptor Open client socket file descriptor.
+ * @param max_body_bytes Maximum accepted request body size in bytes.
+ *
+ * @return Parsed HTTP request (method, path, headers, body).
+ *
+ * @throws HttpError On malformed headers, unsupported HTTP version, or a
+ *         request body larger than @p max_body_bytes.
+ */
 HttpRequest ReadHttpRequest(int file_descriptor, size_t max_body_bytes) {
   std::string received;
   received.reserve(8192);
@@ -398,6 +424,18 @@ int ReadRequestMaxTokens(const json& request, int default_max_tokens) {
       requested, std::numeric_limits<int>::max()));
 }
 
+/**
+ * @brief Parse a JSON chat-completion request body.
+ *
+ * @param body Raw JSON request body.
+ * @param default_max_tokens Fallback output limit when the request omits
+ *        `max_tokens`.
+ *
+ * @return Parsed chat request.
+ *
+ * @throws HttpError On invalid JSON, a missing `messages` array, or a
+ *         negative `max_tokens`.
+ */
 ChatRequest ParseChatRequest(const std::string& body,
                              int default_max_tokens) {
   json request;
@@ -509,6 +547,12 @@ bool PrefixMatches(const std::vector<int64_t>& prompt,
   return true;
 }
 
+/**
+ * @brief Own the text engine and tokenizer, and serve chat completions.
+ *
+ * Loads the Text HBM once at construction and keeps it resident. Consecutive
+ * requests that share a token prefix reuse the KV cache.
+ */
 class ChatService {
  public:
   ChatService(const std::string& text_hbm, const std::string& embeddings,
@@ -520,6 +564,19 @@ class ChatService {
     std::cout << "Text ready (" << engine_->LoadMs() << " ms)" << std::endl;
   }
 
+  /**
+   * @brief Encode messages into a prompt that fits the KV cache.
+   *
+   * Trims the oldest complete turns until the prompt plus the requested
+   * output reserve fit into the fixed 4096-token KV cache.
+   *
+   * @param request Parsed chat request.
+   * @param min_response_tokens Minimum output capacity to preserve.
+   *
+   * @return Prepared prompt with the final output budget.
+   *
+   * @throws HttpError If the prompt itself still exceeds the KV cache.
+   */
   PreparedChat Prepare(const ChatRequest& request,
                        int min_response_tokens) const {
     std::vector<ChatMessage> messages = request.messages;
@@ -563,6 +620,17 @@ class ChatService {
     return prepared;
   }
 
+  /**
+   * @brief Run inference for a prepared chat and return the decoded result.
+   *
+   * Reuses the KV cache when the new prompt shares a token prefix with the
+   * previously processed context; otherwise resets the cache first.
+   *
+   * @param prepared Prepared prompt and output budget.
+   * @param on_text Optional streaming callback invoked per generated chunk.
+   *
+   * @return Decoded completion text, finish reason, and token accounting.
+   */
   ChatResult Generate(
       const PreparedChat& prepared,
       const std::function<bool(const std::string&)>& on_text = nullptr) {
@@ -668,6 +736,21 @@ json CompletionChunk(const std::string& id, int64_t created,
   return chunk;
 }
 
+/**
+ * @brief Handle one POST /v1/chat/completions request.
+ *
+ * Parses the request, prepares the prompt, runs inference, and writes either
+ * a single JSON response or an SSE stream depending on the request's
+ * `stream` flag.
+ *
+ * @param file_descriptor Client socket to write the response to.
+ * @param request Parsed HTTP request.
+ * @param service Shared chat service holding the resident text engine.
+ * @param model Model ID to report in the response.
+ * @param default_max_tokens Fallback output token limit.
+ * @param min_response_tokens Minimum output capacity preserved while
+ *        trimming history.
+ */
 void HandleChatCompletion(int file_descriptor, const HttpRequest& request,
                           ChatService* service, const std::string& model,
                           int default_max_tokens,
@@ -754,6 +837,21 @@ void HandleChatCompletion(int file_descriptor, const HttpRequest& request,
   }
 }
 
+/**
+ * @brief Serve one client connection until the request is answered.
+ *
+ * Reads a single HTTP request, dispatches it to the matching endpoint
+ * (`/health`, `/v1/models`, `/v1/chat/completions`), and writes the response.
+ * Any HttpError is converted into the corresponding HTTP error body.
+ *
+ * @param file_descriptor Client socket.
+ * @param max_body_bytes Maximum accepted request body size.
+ * @param service Shared chat service.
+ * @param model Model ID to report.
+ * @param default_max_tokens Fallback output token limit.
+ * @param min_response_tokens Minimum output capacity preserved while
+ *        trimming history.
+ */
 void HandleClient(int file_descriptor, size_t max_body_bytes,
                   ChatService* service, const std::string& model,
                   int default_max_tokens, int min_response_tokens) {
@@ -815,6 +913,17 @@ void HandleClient(int file_descriptor, size_t max_body_bytes,
   }
 }
 
+/**
+ * @brief Create and bind a listening TCP socket.
+ *
+ * @param host Bind address (e.g. "0.0.0.0").
+ * @param port Listen port.
+ *
+ * @return The listening socket file descriptor.
+ *
+ * @throws std::runtime_error On socket creation, bind, listen, or
+ *         SO_REUSEADDR failure.
+ */
 int CreateListenSocket(const std::string& host, int port) {
   struct addrinfo hints {};
   hints.ai_family = AF_UNSPEC;

--- a/samples/llm/gemma4-e2b/runtime/cpp/src/gemma4_text_bench.cpp
+++ b/samples/llm/gemma4-e2b/runtime/cpp/src/gemma4_text_bench.cpp
@@ -1,3 +1,11 @@
+/**
+ * @file gemma4_text_bench.cpp
+ * @brief Benchmark Gemma4-E2B text prefill and decode performance.
+ *
+ * The executable loads the text HBM, runs a configurable prompt, and reports
+ * model load time, prefill latency, decode latency, and throughput.
+ */
+
 #include <chrono>
 #include <cstdlib>
 #include <iostream>

--- a/samples/llm/gemma4-e2b/runtime/cpp/src/gemma4_text_engine.cpp
+++ b/samples/llm/gemma4-e2b/runtime/cpp/src/gemma4_text_engine.cpp
@@ -1,3 +1,13 @@
+/**
+ * @file gemma4_text_engine.cpp
+ * @brief Execute Gemma4-E2B text prefill, decode, and KV-cache reuse.
+ *
+ * The implementation prepares model tensors, manages prompt suffix prefill,
+ * performs greedy decoding, and preserves reusable conversation prefixes.
+ *
+ * @note TextEngine instances are not thread-safe.
+ */
+
 #include "gemma4_text_engine.hpp"
 
 #include <algorithm>
@@ -72,7 +82,7 @@ TextEngine::~TextEngine() {
     decode_.inputs[5 + i].sysMem.virAddr = nullptr;
     decode_.inputs[20 + i].sysMem.virAddr = nullptr;
   }
-  
+
   FreeTensors(prefill_.inputs);
   FreeTensors(prefill_.outputs);
   FreeTensors(decode_.inputs);
@@ -93,7 +103,7 @@ TextEngine::~TextEngine() {
 //   col = cache_col_start + (abs_pos - cache_start_abs)
 //
 void TextEngine::BuildFullMask(const KvCache& /*kv*/, float* mask,
-                               int cache_start, int chunk_start,
+                               int /*cache_start*/, int chunk_start,
                                int chunk_valid, int seq_len) {
   const int total = seq_len * kCacheLen;
   std::fill(mask, mask + total, kMaskValue);
@@ -122,7 +132,7 @@ void TextEngine::BuildFullMask(const KvCache& /*kv*/, float* mask,
 }
 
 void TextEngine::BuildSlidingMask(const KvCache& /*kv*/, float* mask,
-                                  int cache_start, int chunk_start,
+                                  int /*cache_start*/, int chunk_start,
                                   int chunk_valid, int seq_len) {
   const int total = seq_len * kCacheLen;
   std::fill(mask, mask + total, kMaskValue);
@@ -214,8 +224,10 @@ void TextEngine::FillCommonInputs(ModelIo& io,
       float* dst = hidden.data() + static_cast<size_t>(i) * kHiddenSize;
       std::copy(src, src + kHiddenSize, dst);
     }
-    std::cerr << "[DEBUG] FillCommonInputs: using prebuilt_hidden, chunk_start=" << chunk_start
-              << " chunk_valid=" << chunk_valid << std::endl;
+    if (RuntimeDebugEnabled()) {
+      std::cerr << "[DEBUG] FillCommonInputs: using prebuilt_hidden, chunk_start="
+                << chunk_start << " chunk_valid=" << chunk_valid << std::endl;
+    }
   } else {
     embeddings_.Lookup(ple_padded, hidden.data());
   }
@@ -290,8 +302,8 @@ void TextEngine::RunPrefillChunk(const std::vector<int64_t>& chunk,
   const int chunk_valid = static_cast<int>(chunk.size());
   FillCommonInputs(prefill_, chunk, chunk_start, chunk_valid, false,
                    prebuilt_hidden);
-  // Selective flush: only flush non-KV input tensors (embedding/token/pos/masks).
-  // KV cache inputs are BPU-owned, no CPU write happened.
+  // KV rows are rolled into the cache on CPU after every inference, so all
+  // inputs must be cleaned before the BPU reads the cache again.
   static const std::vector<int> flush_in = PrefillFlushIndices();
   // Flush ALL outputs — we need logits (0) + KV outputs (1..30) for CPU read.
   RunInferSelective(prefill_.handle, prefill_.inputs, prefill_.outputs, flush_in);
@@ -382,7 +394,7 @@ bool TextEngine::AutoTruncate(int new_prompt_tokens, int max_new_tokens) {
 
   // Perform context shift to make room for new tokens
   ContextShift(n_keep_);
-  
+
   // The caller should now re-prefill the recent history using PrefillSuffix
   return true;
 }
@@ -404,8 +416,24 @@ std::vector<int64_t> TextEngine::ContinueGenerate(
 std::vector<int64_t> TextEngine::ContinueGenerateStream(
     const std::vector<int64_t>& full_ids, int max_new_tokens,
     TokenCallback on_token, const std::vector<float>* full_hidden) {
+  if (max_new_tokens <= 0) {
+    return full_ids;
+  }
+
   if (static_cast<int>(full_ids.size()) < processed_tokens_) {
     throw std::runtime_error("full_ids shorter than processed prefix");
+  }
+
+  if (static_cast<int>(full_ids.size()) > processed_tokens_ &&
+      processed_tokens_ % kChunkSize != 0) {
+    const int aligned_prefix =
+        (processed_tokens_ / kChunkSize) * kChunkSize;
+    const int replay_tokens = processed_tokens_ - aligned_prefix;
+    ContextShift(aligned_prefix);
+    if (RuntimeDebugEnabled()) {
+      std::cerr << "[DEBUG] KV reuse aligned to prefill boundary: keep="
+                << aligned_prefix << " replay=" << replay_tokens << std::endl;
+    }
   }
 
   if (static_cast<int>(full_ids.size()) > processed_tokens_) {
@@ -427,8 +455,7 @@ std::vector<int64_t> TextEngine::ContinueGenerateStream(
   std::vector<int64_t> out = full_ids;
   int64_t next = ArgmaxLogits(prefill_.outputs[0], last_idx);
   out.push_back(next);
-  processed_tokens_ += 1;
-  
+
   if (on_token && !on_token(next)) {
     return out;
   }
@@ -440,13 +467,13 @@ std::vector<int64_t> TextEngine::ContinueGenerateStream(
   int64_t last = next;
   for (int i = 1; i < max_new_tokens; ++i) {
     next = RunDecodeStep(last);
-    out.push_back(next);
     processed_tokens_ += 1;
-    
+    out.push_back(next);
+
     if (on_token && !on_token(next)) {
       break;
     }
-    
+
     if (IsEos(next)) {
       break;
     }
@@ -530,13 +557,12 @@ PrefillChunkTensors TextEngine::ExportPrefillChunk(
 int64_t TextEngine::RunDecodeStep(int64_t token_id) {
   const int pos = token_offset_;
   FillDecodeInputs(token_id, pos);
-  // Selective flush: only flush non-KV input tensors.
-  // KV cache inputs are shared with BPU — no CPU write happened.
+  // KV rows are rolled into the cache on CPU after every inference, so all
+  // inputs must be cleaned before the BPU reads the cache again.
   static const std::vector<int> flush_in = DecodeFlushIndices();
-  // Decode only needs logits output (0) — KV outputs write to shared memory.
-  static const std::vector<int> flush_out = {static_cast<int>(kLogitsOutputIndex)};
-  RunInferSelective(decode_.handle, decode_.inputs, decode_.outputs,
-                    flush_in, flush_out);
+  // CPU copies decode KV outputs into the rolling cache, so invalidate every
+  // output before reading it rather than only invalidating logits.
+  RunInferSelective(decode_.handle, decode_.inputs, decode_.outputs, flush_in);
 
   const int8_t* k_outs[kNumKvLayers];
   const int8_t* v_outs[kNumKvLayers];

--- a/samples/llm/gemma4-e2b/runtime/cpp/src/gemma4_tokenizer.cpp
+++ b/samples/llm/gemma4-e2b/runtime/cpp/src/gemma4_tokenizer.cpp
@@ -1,11 +1,22 @@
+/**
+ * @file gemma4_tokenizer.cpp
+ * @brief Convert structured chat messages to and from Gemma4-E2B tokens.
+ *
+ * The bridge applies the tokenizer chat template and delegates native token
+ * encoding and decoding to the tokenizers-cpp wrapper.
+ */
+
 #include "gemma4_tokenizer.hpp"
 
 #include <cstdlib>
 #include <filesystem>
+#include <iostream>
 #include <sstream>
 #include <stdexcept>
 
 #include <nlohmann/json.hpp>
+
+#include "gemma4_config.hpp"
 
 namespace gemma4 {
 
@@ -28,8 +39,15 @@ constexpr int kSoftImageTokens = 280;
 // well-known relative locations. The directory must contain tokenizer.json
 // and tokenizer_config.json.
 std::string ResolveTokenizerDir(const std::string& hint) {
-  if (!hint.empty() && fs::exists(fs::path(hint) / "tokenizer.json")) {
-    return hint;
+  if (!hint.empty()) {
+    const fs::path hint_path(hint);
+    if (fs::is_regular_file(hint_path) &&
+        fs::exists(hint_path.parent_path() / "tokenizer.json")) {
+      return hint_path.parent_path().string();
+    }
+    if (fs::exists(hint_path / "tokenizer.json")) {
+      return hint;
+    }
   }
   const char* env = std::getenv("GEMMA4_HOME");
   if (env && *env) {
@@ -42,28 +60,6 @@ std::string ResolveTokenizerDir(const std::string& hint) {
   throw std::runtime_error(
       "TokenizerBridge: cannot locate tokenizer.json. Set GEMMA4_HOME or pass "
       "the tokenizer directory explicitly.");
-}
-
-// JSON string unescape (inverse of JsonEscape in chat.cpp).
-std::string JsonUnescape(const std::string& s) {
-  std::string out;
-  out.reserve(s.size());
-  for (size_t i = 0; i < s.size(); ++i) {
-    if (s[i] == '\\' && i + 1 < s.size()) {
-      switch (s[++i]) {
-        case '\\': out += '\\'; break;
-        case '"':  out += '"'; break;
-        case 'n':  out += '\n'; break;
-        case 'r':  out += '\r'; break;
-        case 't':  out += '\t'; break;
-        case '/':  out += '/'; break;
-        default:   out += s[i]; break;
-      }
-    } else {
-      out += s[i];
-    }
-  }
-  return out;
 }
 
 // Render messages_json to the Gemma prompt text. Supports:
@@ -80,12 +76,12 @@ std::string RenderChat(const std::string& messages_json) {
 
     const auto& content = m["content"];
     if (content.is_string()) {
-      out += JsonUnescape(content.get<std::string>());
+      out += content.get<std::string>();
     } else if (content.is_array()) {
       for (const auto& part : content) {
         const std::string type = part.value("type", "");
         if (type == "text") {
-          out += JsonUnescape(part.value("text", std::string{}));
+          out += part.value("text", std::string{});
         } else if (type == "image") {
           out += kImageMark;
         }
@@ -139,9 +135,16 @@ std::vector<int64_t> TokenizerBridge::EncodeMessagesJson(
   if (expand_images) {
     rendered = ExpandImageTokens(rendered);
   }
+  if (RuntimeDebugEnabled()) {
+    std::cerr << "[DEBUG] Rendered chat begin\n"
+              << rendered << "\n[DEBUG] Rendered chat end" << std::endl;
+  }
   // The tokenizer's added_tokens table makes special tokens (<bos>, <|turn>,
   // <|image>, <image|>) match as single tokens even with add_special_tokens off.
   const auto ids = tokenizer_->Encode(rendered);
+  if (RuntimeDebugEnabled()) {
+    std::cerr << "[DEBUG] Encoded prompt tokens=" << ids.size() << std::endl;
+  }
   return std::vector<int64_t>(ids.begin(), ids.end());
 }
 

--- a/samples/llm/gemma4-e2b/runtime/cpp/src/gemma4_vision_engine.cpp
+++ b/samples/llm/gemma4-e2b/runtime/cpp/src/gemma4_vision_engine.cpp
@@ -1,3 +1,13 @@
+/**
+ * @file gemma4_vision_engine.cpp
+ * @brief Execute the Gemma4-E2B vision HBM and return image features.
+ *
+ * The implementation preprocesses an image, submits BPU inference, and
+ * converts the encoder output into features consumed by the text runtime.
+ *
+ * @note VisionEngine instances are not thread-safe.
+ */
+
 #include "gemma4_vision_engine.hpp"
 
 #include <chrono>
@@ -77,7 +87,7 @@ std::vector<float> VisionEngine::Infer(const std::string& image_path) {
   const std::vector<float> patches = PreprocessImage(image_path);
 
   // Debug: patch statistics
-  {
+  if (RuntimeDebugEnabled()) {
     double sum = 0, sq = 0;
     float pmin = patches[0], pmax = patches[0];
     for (size_t i = 0; i < patches.size(); ++i) {
@@ -99,7 +109,7 @@ std::vector<float> VisionEngine::Infer(const std::string& image_path) {
   }
 
   // Debug: print input tensor properties
-  {
+  if (RuntimeDebugEnabled()) {
     const auto& props = inputs_[0].properties;
     std::cerr << "[DEBUG] input tensor: type=" << props.tensorType
               << " ndim=" << props.validShape.numDimensions
@@ -119,15 +129,21 @@ std::vector<float> VisionEngine::Infer(const std::string& image_path) {
       ProdSize(props.validShape.dimensionSize, props.validShape.numDimensions);
 
   // Debug: output tensor properties
-  std::cerr << "[DEBUG] output tensor: type=" << props.tensorType
-            << " ndim=" << props.validShape.numDimensions
-            << " shape=[";
-  for (int d = 0; d < props.validShape.numDimensions; ++d) {
-    if (d) std::cerr << ",";
-    std::cerr << props.validShape.dimensionSize[d];
+  if (RuntimeDebugEnabled()) {
+    std::cerr << "[DEBUG] output tensor: type=" << props.tensorType
+              << " ndim=" << props.validShape.numDimensions
+              << " shape=[";
+    for (int dimension = 0; dimension < props.validShape.numDimensions;
+         ++dimension) {
+      if (dimension != 0) {
+        std::cerr << ",";
+      }
+      std::cerr << props.validShape.dimensionSize[dimension];
+    }
+    std::cerr << "] elems=" << elems
+              << " elem_size=" << ElementSize(props.tensorType)
+              << " aligned_bytes=" << props.alignedByteSize << std::endl;
   }
-  std::cerr << "] elems=" << elems << " elem_size=" << ElementSize(props.tensorType)
-            << " aligned_bytes=" << props.alignedByteSize << std::endl;
 
   std::vector<float> out(static_cast<size_t>(elems));
   const void* raw_out = outputs_[0].sysMem.virAddr;
@@ -156,14 +172,14 @@ std::vector<float> VisionEngine::Infer(const std::string& image_path) {
     }
   } else {
     // Fallback: try float
-    std::cerr << "[DEBUG] WARNING: unexpected tensor type " << props.tensorType
-              << ", trying float cast" << std::endl;
+    std::cerr << "[WARN] Unexpected Vision output tensor type "
+              << props.tensorType << "; trying float cast." << std::endl;
     const auto* src = static_cast<const float*>(raw_out);
     std::copy(src, src + elems, out.data());
   }
 
   // Debug: output statistics
-  {
+  if (RuntimeDebugEnabled()) {
     double sum = 0, sq = 0;
     float omin = out[0], omax = out[0];
     for (size_t i = 0; i < out.size(); ++i) {

--- a/samples/llm/gemma4-e2b/runtime/cpp/src/gemma4_vision_preprocess.cpp
+++ b/samples/llm/gemma4-e2b/runtime/cpp/src/gemma4_vision_preprocess.cpp
@@ -1,3 +1,11 @@
+/**
+ * @file gemma4_vision_preprocess.cpp
+ * @brief Prepare input images for Gemma4-E2B vision inference.
+ *
+ * The implementation loads, resizes, normalizes, and arranges image tensors in
+ * the layout expected by the compiled vision HBM.
+ */
+
 #include "gemma4_vision_preprocess.hpp"
 
 #include <algorithm>

--- a/samples/llm/gemma4-e2b/runtime/cpp/src/main.cpp
+++ b/samples/llm/gemma4-e2b/runtime/cpp/src/main.cpp
@@ -1,6 +1,6 @@
 /**
  * @file main.cpp
- * @brief Interactive VLM chat entry point for Gemma4-E2B on RDK S100P.
+ * @brief Interactive VLM chat entry point for Gemma4-E2B on RDK S series.
  *
  * Provides a streaming, multi-turn chat loop that supports both pure-text
  * prompts and image+text (VLM) queries. Loads pre-compiled HBM models via
@@ -9,17 +9,23 @@
  *
  * @note Primary executable of this Model Zoo sample; built as `main`.
  */
+#include <algorithm>
+#include <cerrno>
 #include <chrono>
+#include <cstdint>
 #include <cstdlib>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
-#include <memory>
 #include <sstream>
 #include <string>
+#include <utility>
 #include <vector>
 
+#include <iconv.h>
+
 #include "gflags/gflags.h"
+#include "nlohmann/json.hpp"
 
 #include "gemma4_tokenizer.hpp"
 #include "gemma4_config.hpp"
@@ -39,8 +45,13 @@ DEFINE_string(tok_embeddings, "",
               "Default: $GEMMA4_HOME/model/tok_embeddings.bin");
 DEFINE_string(tokenizer_path, "",
               "Path to tokenizer.json. Default: $GEMMA4_HOME/tokenizer/tokenizer.json");
-DEFINE_int32(max_tokens, gemma4::kCacheLen,
-             "Maximum new tokens to generate per turn (bounded by KV cache length).");
+DEFINE_int32(max_tokens, 0,
+             "Maximum new tokens per turn. 0 uses all KV capacity remaining "
+             "after the prompt.");
+DEFINE_int32(min_response_tokens, 256,
+             "Minimum response capacity preserved when old chat turns are trimmed.");
+DEFINE_bool(rebuild_context_each_turn, false,
+            "Rebuild the full prompt and KV cache before every response.");
 
 namespace {
 
@@ -56,6 +67,7 @@ void PrintHelp() {
       << "Commands:\n"
       << "  /help              Show this help\n"
       << "  /reset             Clear conversation history + KV cache\n"
+      << "  /context           Show KV-cache usage\n"
       << "  /image <path>      Load image for next message\n"
       << "  /quit              Exit\n\n"
       << "Type a message and press Enter to chat.\n"
@@ -63,39 +75,151 @@ void PrintHelp() {
       << std::endl;
 }
 
-std::string JsonEscape(const std::string& s) {
-  std::string out;
-  out.reserve(s.size() + 8);
-  for (char c : s) {
-    switch (c) {
-      case '\\': out += "\\\\"; break;
-      case '"':  out += "\\\""; break;
-      case '\n': out += "\\n"; break;
-      case '\r': out += "\\r"; break;
-      case '\t': out += "\\t"; break;
-      default:   out += c; break;
+bool IsValidUtf8(const std::string& value) {
+  const auto* bytes = reinterpret_cast<const uint8_t*>(value.data());
+  size_t offset = 0;
+  while (offset < value.size()) {
+    const uint8_t first = bytes[offset];
+    if (first <= 0x7f) {
+      ++offset;
+      continue;
     }
+
+    size_t length = 0;
+    uint32_t code_point = 0;
+    uint32_t minimum = 0;
+    if ((first & 0xe0) == 0xc0) {
+      length = 2;
+      code_point = first & 0x1f;
+      minimum = 0x80;
+    } else if ((first & 0xf0) == 0xe0) {
+      length = 3;
+      code_point = first & 0x0f;
+      minimum = 0x800;
+    } else if ((first & 0xf8) == 0xf0) {
+      length = 4;
+      code_point = first & 0x07;
+      minimum = 0x10000;
+    } else {
+      return false;
+    }
+    if (offset + length > value.size()) {
+      return false;
+    }
+    for (size_t index = 1; index < length; ++index) {
+      const uint8_t continuation = bytes[offset + index];
+      if ((continuation & 0xc0) != 0x80) {
+        return false;
+      }
+      code_point = (code_point << 6) | (continuation & 0x3f);
+    }
+    if (code_point < minimum || code_point > 0x10ffff ||
+        (code_point >= 0xd800 && code_point <= 0xdfff)) {
+      return false;
+    }
+    offset += length;
   }
-  return out;
+  return true;
+}
+
+bool ConvertGb18030ToUtf8(const std::string& input, std::string* output) {
+  if (output == nullptr) {
+    return false;
+  }
+  iconv_t converter = iconv_open("UTF-8", "GB18030");
+  if (converter == reinterpret_cast<iconv_t>(-1)) {
+    return false;
+  }
+
+  char* input_data = const_cast<char*>(input.data());
+  size_t input_remaining = input.size();
+  std::string converted(std::max<size_t>(64, input.size() * 2 + 16), '\0');
+  size_t output_used = 0;
+  while (true) {
+    char* output_data = converted.data() + output_used;
+    size_t output_remaining = converted.size() - output_used;
+    const size_t result = iconv(converter, &input_data, &input_remaining,
+                                &output_data, &output_remaining);
+    output_used = converted.size() - output_remaining;
+    if (result != static_cast<size_t>(-1)) {
+      break;
+    }
+    if (errno != E2BIG) {
+      iconv_close(converter);
+      return false;
+    }
+    converted.resize(converted.size() * 2);
+  }
+  iconv_close(converter);
+  converted.resize(output_used);
+  if (input_remaining != 0 || !IsValidUtf8(converted)) {
+    return false;
+  }
+  *output = std::move(converted);
+  return true;
+}
+
+bool NormalizeTerminalInput(std::string* input, bool* converted_from_gb18030) {
+  if (input == nullptr) {
+    return false;
+  }
+  if (!input->empty() && input->back() == '\r') {
+    input->pop_back();
+  }
+  if (converted_from_gb18030 != nullptr) {
+    *converted_from_gb18030 = false;
+  }
+  if (IsValidUtf8(*input)) {
+    return true;
+  }
+
+  std::string converted;
+  if (!ConvertGb18030ToUtf8(*input, &converted)) {
+    return false;
+  }
+  *input = std::move(converted);
+  if (converted_from_gb18030 != nullptr) {
+    *converted_from_gb18030 = true;
+  }
+  return true;
 }
 
 std::string BuildMessagesJson(const std::vector<Message>& history) {
-  std::ostringstream oss;
-  oss << '[';
-  for (size_t i = 0; i < history.size(); ++i) {
-    if (i) oss << ',';
-    if (history[i].has_image) {
-      // VLM format: content is array with image + text
-      oss << "{\"role\":\"" << history[i].role
-          << "\",\"content\":[{\"type\":\"image\"},{\"type\":\"text\",\"text\":\""
-          << JsonEscape(history[i].content) << "\"}]}";
+  nlohmann::json messages = nlohmann::json::array();
+  for (const auto& history_item : history) {
+    nlohmann::json message;
+    message["role"] = history_item.role;
+    if (history_item.has_image) {
+      message["content"] = nlohmann::json::array(
+          {{{"type", "image"}},
+           {{"type", "text"}, {"text", history_item.content}}});
     } else {
-      oss << "{\"role\":\"" << history[i].role
-          << "\",\"content\":\"" << JsonEscape(history[i].content) << "\"}";
+      message["content"] = history_item.content;
+    }
+    messages.push_back(std::move(message));
+  }
+  return messages.dump();
+}
+
+bool DropOldestTurn(std::vector<Message>* history, bool* removed_image) {
+  if (history == nullptr || history->size() <= 1) {
+    return false;
+  }
+
+  size_t erase_count = 1;
+  if (history->size() >= 2 && (*history)[0].role == "user" &&
+      (*history)[1].role == "assistant") {
+    erase_count = 2;
+  }
+
+  if (removed_image != nullptr) {
+    *removed_image = false;
+    for (size_t index = 0; index < erase_count; ++index) {
+      *removed_image = *removed_image || (*history)[index].has_image;
     }
   }
-  oss << ']';
-  return oss.str();
+  history->erase(history->begin(), history->begin() + erase_count);
+  return true;
 }
 
 void PrintBanner() {
@@ -109,7 +233,15 @@ void PrintBanner() {
     "\033[38;5;33m",  "\033[38;5;99m",  "\033[38;5;201m",
   };
 
+#if defined(SOC_S600)
+  const char* title = "        Gemma on RDK S600";
+#elif defined(SOC_S100P)
   const char* title = "        Gemma on RDK S100P";
+#elif defined(SOC_S100)
+  const char* title = "        Gemma on RDK S100";
+#else
+  const char* title = "        Gemma on RDK S Series";
+#endif
 
   std::cout << "\n" << DIM
             << "================================================================\n" << RST
@@ -134,9 +266,10 @@ void PrintBanner() {
 int main(int argc, char** argv) {
   // Parse gflags first (consumes recognized --flag args, leaves the rest).
   gflags::SetUsageMessage(
-      "Interactive VLM chat for Gemma4-E2B on RDK S100P.\n"
+      "Interactive VLM chat for Gemma4-E2B on RDK S series.\n"
       "Usage: ./main [--text_hbm PATH] [--vision_hbm PATH] "
-      "[--tok_embeddings PATH] [--tokenizer_path PATH] [--max_tokens N]");
+      "[--tok_embeddings PATH] [--tokenizer_path PATH] [--max_tokens N] "
+      "[--min_response_tokens N]");
   gflags::ParseCommandLineFlags(&argc, &argv, true);
 
   // Resolve default paths from $GEMMA4_HOME when the corresponding flag is empty.
@@ -154,29 +287,46 @@ int main(int argc, char** argv) {
   const std::string tokenizer_json = FLAGS_tokenizer_path.empty()
       ? home + "/tokenizer/tokenizer.json"
       : FLAGS_tokenizer_path;
-  const int max_tokens = FLAGS_max_tokens;
+
+  if (FLAGS_max_tokens < 0) {
+    std::cerr << "--max_tokens must be zero or positive" << std::endl;
+    return 2;
+  }
+  if (FLAGS_min_response_tokens <= 0) {
+    std::cerr << "--min_response_tokens must be positive" << std::endl;
+    return 2;
+  }
+  const int requested_max_tokens = FLAGS_max_tokens;
+  const int response_reserve = std::min(
+      FLAGS_min_response_tokens, gemma4::kCacheLen - 1);
 
   try {
     PrintBanner();
+
+    std::cout << "Loading vision model..." << std::endl;
+    gemma4::VisionEngine vision(vision_hbm);
+    std::cout << "Vision model loaded in " << std::fixed << std::setprecision(0)
+              << vision.LoadMs() << " ms\n";
 
     std::cout << "Loading text model..." << std::endl;
     gemma4::TextEngine engine(text_hbm, embed);
     std::cout << "Text model loaded in " << std::fixed << std::setprecision(0)
               << engine.LoadMs() << " ms\n";
+    std::cout << "KV cache: " << gemma4::kCacheLen
+              << " tokens; max output: "
+              << (requested_max_tokens == 0
+                      ? std::string("auto (all remaining tokens)")
+                      : std::to_string(requested_max_tokens))
+              << std::endl;
 
-    std::unique_ptr<gemma4::VisionEngine> vision;
-    std::cout << "Loading vision model..." << std::endl;
-    vision = std::make_unique<gemma4::VisionEngine>(vision_hbm);
-    std::cout << "Vision model loaded in " << std::fixed << std::setprecision(0)
-              << vision->LoadMs() << " ms\n";
-
-    gemma4::TokenizerBridge tokenizer;
+    gemma4::TokenizerBridge tokenizer(tokenizer_json);
 
     std::vector<Message> history;
     std::vector<int64_t> session_ids;
     int turn_count = 0;
 
-    // Pending image path for next message
+    // One active image is supported per conversation. Its compact vision
+    // features are retained so follow-up turns can still reference the image.
     std::string pending_image;
     std::vector<float> pending_vision_features;
     bool has_pending_image = false;
@@ -186,6 +336,16 @@ int main(int argc, char** argv) {
 
     std::string line;
     while (std::getline(std::cin, line)) {
+      bool converted_from_gb18030 = false;
+      if (!NormalizeTerminalInput(&line, &converted_from_gb18030)) {
+        std::cerr << "Input error: terminal text is neither valid UTF-8 nor "
+                     "GB18030. Configure the terminal for UTF-8 and retry.\n";
+        std::cout << "gemma4> " << std::flush;
+        continue;
+      }
+      if (converted_from_gb18030) {
+        std::cerr << "[input] Converted GB18030 terminal bytes to UTF-8.\n";
+      }
       if (line == "/quit" || line == "/exit") break;
 
       if (line == "/help") {
@@ -203,6 +363,18 @@ int main(int argc, char** argv) {
         pending_image.clear();
         pending_vision_features.clear();
         std::cout << "Session reset.\n";
+        std::cout << "gemma4> " << std::flush;
+        continue;
+      }
+
+      if (line == "/context") {
+        const size_t used_tokens = session_ids.size();
+        const size_t remaining_tokens = used_tokens < gemma4::kCacheLen
+            ? static_cast<size_t>(gemma4::kCacheLen) - used_tokens
+            : 0;
+        std::cout << "Context: " << used_tokens << "/" << gemma4::kCacheLen
+                  << " tokens, remaining=" << remaining_tokens
+                  << ", turns=" << turn_count << std::endl;
         std::cout << "gemma4> " << std::flush;
         continue;
       }
@@ -228,8 +400,18 @@ int main(int argc, char** argv) {
           continue;
         }
 
+        if (!history.empty() || !pending_vision_features.empty()) {
+          engine.ResetSession();
+          history.clear();
+          session_ids.clear();
+          turn_count = 0;
+          pending_vision_features.clear();
+          std::cout << "Starting a new conversation for the image."
+                    << std::endl;
+        }
+
         std::cout << "Processing image: " << img_path << "..." << std::endl;
-        pending_vision_features = vision->Infer(img_path);
+        pending_vision_features = vision.Infer(img_path);
         pending_image = img_path;
         has_pending_image = true;
         std::cout << "Image loaded (" << pending_vision_features.size() << " features).\n";
@@ -243,19 +425,98 @@ int main(int argc, char** argv) {
         continue;
       }
 
-      // Add message to history
-      Message msg{"user", line, has_pending_image};
-      history.push_back(msg);
+      // Preserve the original image turn and explicitly condition the latest
+      // follow-up on the same image. Older repeated placeholders are removed,
+      // so a multimodal prompt contains at most two 280-token image runs.
+      const bool starts_image_conversation = has_pending_image;
+      if (starts_image_conversation) {
+        history.clear();
+        session_ids.clear();
+        engine.ResetSession();
+        turn_count = 0;
+      }
+      const bool uses_active_image =
+          starts_image_conversation || !pending_vision_features.empty();
+      if (uses_active_image) {
+        bool kept_original_image = false;
+        for (auto& history_item : history) {
+          if (!history_item.has_image) {
+            continue;
+          }
+          if (!kept_original_image) {
+            kept_original_image = true;
+          } else {
+            history_item.has_image = false;
+          }
+        }
+      }
+      history.push_back({"user", line, uses_active_image});
 
       const std::vector<int64_t> prev_ids = session_ids;
       const int prev_processed = engine.ProcessedTokens();
 
-      const std::string messages_json = BuildMessagesJson(history);
-      session_ids = tokenizer.EncodeMessagesJson(messages_json, true);
+      const int desired_reserve = requested_max_tokens == 0
+          ? response_reserve
+          : std::min(requested_max_tokens, gemma4::kCacheLen - 1);
+      bool history_trimmed = false;
+      while (true) {
+        session_ids = tokenizer.EncodeMessagesJson(BuildMessagesJson(history), true);
+        if (session_ids.size() < static_cast<size_t>(gemma4::kCacheLen) &&
+            (session_ids.size() + static_cast<size_t>(desired_reserve) <=
+                 static_cast<size_t>(gemma4::kCacheLen) ||
+             history.size() <= 1)) {
+          break;
+        }
 
-      // Check if we need to reset due to prefix mismatch
+        bool removed_image = false;
+        if (!DropOldestTurn(&history, &removed_image)) {
+          break;
+        }
+        if (turn_count > 0) {
+          --turn_count;
+        }
+        history_trimmed = true;
+        const bool history_still_uses_image = std::any_of(
+            history.begin(), history.end(),
+            [](const Message& history_item) { return history_item.has_image; });
+        if (removed_image && !history_still_uses_image) {
+          pending_vision_features.clear();
+          pending_image.clear();
+          has_pending_image = false;
+        }
+      }
+
+      if (session_ids.size() >= static_cast<size_t>(gemma4::kCacheLen)) {
+        std::cout << "Error: the current prompt uses " << session_ids.size()
+                  << " tokens, exceeding the " << gemma4::kCacheLen
+                  << "-token KV cache." << std::endl;
+        history.pop_back();
+        session_ids = prev_ids;
+        std::cout << "gemma4> " << std::flush;
+        continue;
+      }
+
+      if (history_trimmed) {
+        engine.ResetSession();
+        std::cout << "[context] Oldest chat turns were removed to stay within "
+                  << gemma4::kCacheLen << " tokens." << std::endl;
+      }
+
+      const int available_tokens =
+          gemma4::kCacheLen - static_cast<int>(session_ids.size());
+      const int turn_max_tokens = requested_max_tokens == 0
+          ? available_tokens
+          : std::min(requested_max_tokens, available_tokens);
+      std::cout << "[context] prompt=" << session_ids.size()
+                << ", output_budget=" << turn_max_tokens
+                << ", capacity=" << gemma4::kCacheLen << std::endl;
+
+      // Check if we need to reset due to prefix mismatch.
       bool prefix_ok = true;
-      if (prev_processed > 0) {
+      if (FLAGS_rebuild_context_each_turn) {
+        engine.ResetSession();
+        prefix_ok = false;
+      } else if (!history_trimmed && prev_processed > 0) {
         if (static_cast<int>(session_ids.size()) < prev_processed ||
             static_cast<int>(prev_ids.size()) < prev_processed) {
           prefix_ok = false;
@@ -272,11 +533,25 @@ int main(int argc, char** argv) {
           engine.ResetSession();
         }
       }
+      if (gemma4::RuntimeDebugEnabled()) {
+        std::cerr << "[DEBUG] context reuse: prev_processed=" << prev_processed
+                  << " prev_ids=" << prev_ids.size()
+                  << " prompt_ids=" << session_ids.size()
+                  << " prefix_ok=" << (prefix_ok ? "true" : "false")
+                  << " rebuild="
+                  << (FLAGS_rebuild_context_each_turn ? "true" : "false")
+                  << std::endl;
+      }
 
+      gemma4::TextEngine& text_engine = engine;
       auto t_start = std::chrono::steady_clock::now();
       int token_count = 0;
 
       auto stream_callback = [&](int64_t token_id) {
+        if (token_id == gemma4::kEosTokenId ||
+            token_id == gemma4::kTurnEndTokenId) {
+          return true;
+        }
         const std::string token_text = tokenizer.DecodeIds({token_id});
         std::cout << token_text << std::flush;
         ++token_count;
@@ -284,37 +559,35 @@ int main(int argc, char** argv) {
       };
 
       std::vector<int64_t> out;
-      if (has_pending_image && !pending_vision_features.empty()) {
-        // Build prompt hidden with vision features.
-        // IMPORTANT: Reset history and session first. The current architecture
-        // only supports a single image per conversation (pending_vision_features
-        // holds features for one image). If old history contains image tokens
-        // from previous turns, BuildPromptHidden would find more image token
-        // placeholders than features available, causing incorrect injection.
-        history.clear();
-        session_ids.clear();
-        turn_count = 0;
-        // Re-add only the current user message with image
-        history.push_back(msg);
-        const std::string fresh_json = BuildMessagesJson(history);
-        session_ids = tokenizer.EncodeMessagesJson(fresh_json, true);
-
-        auto prompt_hidden = engine.BuildPromptHidden(session_ids, pending_vision_features);
-        engine.ResetSession();
-        out = engine.ContinueGenerateStream(session_ids, max_tokens, stream_callback, &prompt_hidden);
-        // Clear pending image after use
+      if (!pending_vision_features.empty()) {
+        // Retain one image placeholder and inject the same active features when
+        // rebuilding the multimodal prompt for follow-up turns.
+        auto prompt_hidden = text_engine.BuildPromptHidden(
+            session_ids, pending_vision_features);
+        text_engine.ResetSession();
+        out = text_engine.ContinueGenerateStream(
+            session_ids, turn_max_tokens, stream_callback, &prompt_hidden);
+        // The image is no longer pending, but retain its features so follow-up
+        // turns can rebuild the multimodal prompt correctly.
         has_pending_image = false;
         pending_image.clear();
-        pending_vision_features.clear();
       } else {
-        out = engine.ContinueGenerateStream(session_ids, max_tokens, stream_callback);
+        out = text_engine.ContinueGenerateStream(
+            session_ids, turn_max_tokens, stream_callback);
       }
 
       auto t_end = std::chrono::steady_clock::now();
       double elapsed_ms =
           std::chrono::duration<double, std::milli>(t_end - t_start).count();
 
-      const std::vector<int64_t> gen(out.begin() + session_ids.size(), out.end());
+      size_t generation_end = out.size();
+      while (generation_end > session_ids.size() &&
+             (out[generation_end - 1] == gemma4::kEosTokenId ||
+              out[generation_end - 1] == gemma4::kTurnEndTokenId)) {
+        --generation_end;
+      }
+      const std::vector<int64_t> gen(
+          out.begin() + session_ids.size(), out.begin() + generation_end);
       const std::string reply = tokenizer.DecodeIds(gen);
       history.push_back({"assistant", reply, false});
       session_ids = out;

--- a/samples/llm/gemma4-e2b/third_party/README.md
+++ b/samples/llm/gemma4-e2b/third_party/README.md
@@ -21,6 +21,6 @@ bash third_party/install_tokenizers_cpp.sh
 ```
 
 This requires `curl` and network access. The build itself additionally
-needs `cargo` (Rust toolchain) to compile the tokenizers Rust binding. Rust 1.79 or newer is required;
+needs `cargo` (Rust toolchain) to compile the tokenizers Rust binding. Rust 1.80 or newer is required;
 when the system version is older, the installer bootstraps the current stable
 rustup toolchain under `$HOME/.cargo`.

--- a/samples/llm/gemma4-e2b/third_party/README.md
+++ b/samples/llm/gemma4-e2b/third_party/README.md
@@ -21,4 +21,6 @@ bash third_party/install_tokenizers_cpp.sh
 ```
 
 This requires `curl` and network access. The build itself additionally
-needs `cargo` (Rust toolchain) to compile the tokenizers Rust binding.
+needs `cargo` (Rust toolchain) to compile the tokenizers Rust binding. Rust 1.79 or newer is required;
+when the system version is older, the installer bootstraps the current stable
+rustup toolchain under `$HOME/.cargo`.

--- a/samples/llm/gemma4-e2b/third_party/README_cn.md
+++ b/samples/llm/gemma4-e2b/third_party/README_cn.md
@@ -20,4 +20,4 @@ bash third_party/install_tokenizers_cpp.sh
 ```
 
 依赖 `curl` 及外网访问；编译过程还需要 `cargo`（Rust 工具链）来构建
-tokenizers 的 Rust binding。 Rust 版本需不低于 1.79；若系统版本过旧，安装脚本会在 `$HOME/.cargo` 下引导安装当前稳定版 rustup 工具链。
+tokenizers 的 Rust binding。 Rust 版本需不低于 1.80；若系统版本过旧，安装脚本会在 `$HOME/.cargo` 下引导安装当前稳定版 rustup 工具链。

--- a/samples/llm/gemma4-e2b/third_party/README_cn.md
+++ b/samples/llm/gemma4-e2b/third_party/README_cn.md
@@ -20,4 +20,4 @@ bash third_party/install_tokenizers_cpp.sh
 ```
 
 依赖 `curl` 及外网访问；编译过程还需要 `cargo`（Rust 工具链）来构建
-tokenizers 的 Rust binding。
+tokenizers 的 Rust binding。 Rust 版本需不低于 1.79；若系统版本过旧，安装脚本会在 `$HOME/.cargo` 下引导安装当前稳定版 rustup 工具链。

--- a/samples/llm/gemma4-e2b/third_party/install_tokenizers_cpp.sh
+++ b/samples/llm/gemma4-e2b/third_party/install_tokenizers_cpp.sh
@@ -14,8 +14,57 @@ DEST="$SCRIPT_DIR/tokenizers-cpp"
 # The Rust binding uses tokenizers 0.21.2 + onig, matching the reference
 # OpenExplorer_LLM-s600 tokenizer stack.
 COMMIT="c586c52f93f7b060753bd2388eb96a105cb7374d"
+MIN_RUST_VERSION="1.80.0"
+
+version_at_least() {
+  local current="$1"
+  local required="$2"
+  [[ "$(printf '%s\n' "$required" "$current" | sort -V | head -n 1)" == "$required" ]]
+}
+
+ensure_compatible_rust() {
+  export PATH="$HOME/.cargo/bin:$PATH"
+
+  local current=""
+  if command -v rustc >/dev/null 2>&1; then
+    current="$(rustc --version 2>/dev/null | awk '{print $2}' || true)"
+  fi
+  if [[ -n "$current" ]] && version_at_least "$current" "$MIN_RUST_VERSION"; then
+    echo "Rust $current already satisfies >= $MIN_RUST_VERSION."
+    return
+  fi
+
+  if ! command -v curl >/dev/null 2>&1; then
+    echo "ERROR: Rust >= $MIN_RUST_VERSION is required and curl is unavailable." >&2
+    echo "Install curl, then rerun this script." >&2
+    exit 1
+  fi
+
+  echo "Installing a current Rust toolchain (found: ${current:-none}) ..."
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+    | sh -s -- -y --profile minimal --default-toolchain stable
+  export PATH="$HOME/.cargo/bin:$PATH"
+
+  current="$(rustc --version | awk '{print $2}')"
+  if ! version_at_least "$current" "$MIN_RUST_VERSION"; then
+    echo "ERROR: Rust upgrade failed; found $current, need >= $MIN_RUST_VERSION." >&2
+    exit 1
+  fi
+  echo "Rust $current is ready."
+}
+
+normalize_cargo_lock() {
+  local lock_file="$DEST/rust/Cargo.lock"
+  if [[ -f "$lock_file" ]] && grep -q '^version = 4' "$lock_file"; then
+    sed -i '1,5s/^version = 4/version = 3/' "$lock_file"
+    echo "Normalized Cargo.lock to stable lockfile version 3."
+  fi
+}
+
+ensure_compatible_rust
 
 if [[ -d "$DEST" && -f "$DEST/CMakeLists.txt" && -f "$DEST/msgpack/CMakeLists.txt" ]]; then
+  normalize_cargo_lock
   echo "tokenizers-cpp already present at $DEST, skip download."
   exit 0
 fi
@@ -38,5 +87,6 @@ cd "$DEST"
 git fetch --depth 1 origin "$COMMIT"
 git checkout "$COMMIT"
 git submodule update --init --depth 1
+normalize_cargo_lock
 
 echo "tokenizers-cpp ready at $DEST"


### PR DESCRIPTION
﻿## Summary

- add SoC-aware Gemma4-E2B conversion and compile flows for S100, S100P, and S600 (`nash-e`, `nash-m`, and `nash-p`)
- use COCO images for vision calibration and keep text calibration inputs explicit and reproducible
- add the public S600 Vision/Text HBM download location while reusing the shared tokenizer and embedding assets
- update the C++ runtime so interactive chat loads Vision and Text once, keeps a 4096-token KV cache, supports multi-turn text/image follow-ups, and handles UTF-8/GB18030 terminal input
- provide an OpenAI-compatible text chat endpoint for ChatBox-style clients
- document S600 quantization, deployment, runtime commands, limitations, and verification in English and Chinese

## Compatibility

- S100P keeps its existing public `nash-m` download path and runtime defaults.
- S100 keeps a separate `nash-e` path and requires matching local HBMs or `GEMMA4_MODEL_BASE_URL`.
- S600-only DNN scheduling and L2M defaults are guarded by `SOC_S600`; the shared runtime remains the same source tree.
- The tokenizer installer now enforces Rust 1.80+, matching the pinned dependency lockfile.

## Validation

Static checks:

- `git diff --check`
- `bash -n` on all 8 modified shell scripts
- `python -m py_compile` on all 7 modified Python files
- no credentials, internal hosts, or generated artifacts in the diff

RDK S600 board validation (`SoC=S600`):

- native build completed for `main`, `gemma4_server`, `gemma4_demo`, `gemma4_text_bench`, and `gemma4_golden_verify` (using the cached pinned `tokenizers-cpp` dependency)
- `./run.sh text_bench generate --token_ids=9259 --max_tokens=4 --warmup=0` completed successfully
- interactive text chat loaded Vision/Text once and retained multi-turn context (`731` recall test passed)
- interactive VLM chat loaded an actual COCO image, described the cabinet/refrigerator scene, and retained image context for a follow-up turn
- default runtime output contained no `GEMMA4_DEBUG`, `VLM-FIX`, or tokenizer debug traces
- HTTP `/health` and `/v1/models` returned successfully
- two-turn `/v1/chat/completions` returned `731` and reported `cache_reused=yes` on the second request
- `download_model.sh` auto-detected S600 and selected the public `rdk_s600/gemma4_e2b/model` HBM directory
