### PR TITLE
fix(minicpm5): use RDK S600 model download directory

### DIFF
--- a/samples/llm/minicpm5-2b/model/README.md
+++ b/samples/llm/minicpm5-2b/model/README.md
@@ -16,6 +16,6 @@ SHA256: `8f2bef6fc7d2290f05055570e7dcfb1cf4e8c07c9a6bb0d0acc24dd202a83841`
 
 Size: 2457817532 bytes.
 
-[Download model](https://archive.d-robotics.cc/downloads/rdk_model_zoo/rdk_s100/minicpm5-2b_s600_oellm2_w8_ctx4096_20260908.tar.gz)
+[Download model](https://archive.d-robotics.cc/downloads/rdk_model_zoo/rdk_s600/minicpm5-2b_s600_oellm2_w8_ctx4096_20260908.tar.gz)
 
-The default destination is `model/s600`. It contains the HBM, FP16 embedding, tokenizer files, model metadata, LICENSE, NOTICE and MODEL_INFO.json. SDK libraries are not included. The historical `rdk_s100` server directory in this URL does not change the artifact target: this HBM is S600/Nash-p only.
+The default destination is `model/s600`. It contains the HBM, FP16 embedding, tokenizer files, model metadata, LICENSE, NOTICE and MODEL_INFO.json. SDK libraries are not included. This HBM is S600/Nash-p only.

--- a/samples/llm/minicpm5-2b/model/README_cn.md
+++ b/samples/llm/minicpm5-2b/model/README_cn.md
@@ -16,6 +16,6 @@ SHA256: `8f2bef6fc7d2290f05055570e7dcfb1cf4e8c07c9a6bb0d0acc24dd202a83841`
 
 Size: 2457817532 bytes.
 
-[Download model](https://archive.d-robotics.cc/downloads/rdk_model_zoo/rdk_s100/minicpm5-2b_s600_oellm2_w8_ctx4096_20260908.tar.gz)
+[Download model](https://archive.d-robotics.cc/downloads/rdk_model_zoo/rdk_s600/minicpm5-2b_s600_oellm2_w8_ctx4096_20260908.tar.gz)
 
-默认输出到 `model/s600`，包含 HBM、FP16 embedding、tokenizer、模型元数据、LICENSE、NOTICE 和 MODEL_INFO.json，不包含 SDK 运行库。下载地址沿用文件服务器的 `rdk_s100` 目录，本产物实际只适用于 S600/Nash-p。
+默认输出到 `model/s600`，包含 HBM、FP16 embedding、tokenizer、模型元数据、LICENSE、NOTICE 和 MODEL_INFO.json，不包含 SDK 运行库。本产物只适用于 S600/Nash-p。

--- a/samples/llm/minicpm5-2b/model/download_model.sh
+++ b/samples/llm/minicpm5-2b/model/download_model.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 HERE=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 MODEL_DIR=${MODEL_DIR:-"$HERE/s600"}
-URL=${MINICPM5_MODEL_URL:-https://archive.d-robotics.cc/downloads/rdk_model_zoo/rdk_s100/minicpm5-2b_s600_oellm2_w8_ctx4096_20260908.tar.gz}
+URL=${MINICPM5_MODEL_URL:-https://archive.d-robotics.cc/downloads/rdk_model_zoo/rdk_s600/minicpm5-2b_s600_oellm2_w8_ctx4096_20260908.tar.gz}
 ARCHIVE_SHA256=8f2bef6fc7d2290f05055570e7dcfb1cf4e8c07c9a6bb0d0acc24dd202a83841
 MANIFEST_SHA256=a938fb43fd7e2c161e188a12e2925f386809adcdd3ab0f0531faaa43d5affcb5
 


### PR DESCRIPTION
The S600 MiniCPM5-2B download used the rdk_s100 archive directory. Update the download script and both model READMEs to use rdk_s600, and remove the obsolete directory explanation.

Validation: the new public URL returns HTTP 200 with Content-Length 2457817532. The server-side archive SHA256 is unchanged: 8f2bef6fc7d2290f05055570e7dcfb1cf4e8c07c9a6bb0d0acc24dd202a83841. git diff --check passed. The existing URL remains available for already-published clients.
